### PR TITLE
fix: cs endpoint protobuf update

### DIFF
--- a/src/verana-proto/cs/v1/tx.ts
+++ b/src/verana-proto/cs/v1/tx.ts
@@ -34,11 +34,11 @@ export interface MsgCreateCredentialSchema {
   creator: string;
   trId: Long;
   jsonSchema: string;
-  issuerGrantorValidationValidityPeriod: number;
-  verifierGrantorValidationValidityPeriod: number;
-  issuerValidationValidityPeriod: number;
-  verifierValidationValidityPeriod: number;
-  holderValidationValidityPeriod: number;
+  issuerGrantorValidationValidityPeriod: OptionalUInt32 | undefined;
+  verifierGrantorValidationValidityPeriod: OptionalUInt32 | undefined;
+  issuerValidationValidityPeriod: OptionalUInt32 | undefined;
+  verifierValidationValidityPeriod: OptionalUInt32 | undefined;
+  holderValidationValidityPeriod: OptionalUInt32 | undefined;
   issuerPermManagementMode: number;
   verifierPermManagementMode: number;
 }
@@ -51,11 +51,11 @@ export interface MsgCreateCredentialSchemaResponse {
 export interface MsgUpdateCredentialSchema {
   creator: string;
   id: Long;
-  issuerGrantorValidationValidityPeriod: number;
-  verifierGrantorValidationValidityPeriod: number;
-  issuerValidationValidityPeriod: number;
-  verifierValidationValidityPeriod: number;
-  holderValidationValidityPeriod: number;
+  issuerGrantorValidationValidityPeriod: OptionalUInt32 | undefined;
+  verifierGrantorValidationValidityPeriod: OptionalUInt32 | undefined;
+  issuerValidationValidityPeriod: OptionalUInt32 | undefined;
+  verifierValidationValidityPeriod: OptionalUInt32 | undefined;
+  holderValidationValidityPeriod: OptionalUInt32 | undefined;
 }
 
 export interface MsgUpdateCredentialSchemaResponse {
@@ -194,11 +194,11 @@ function createBaseMsgCreateCredentialSchema(): MsgCreateCredentialSchema {
     creator: "",
     trId: Long.UZERO,
     jsonSchema: "",
-    issuerGrantorValidationValidityPeriod: 0,
-    verifierGrantorValidationValidityPeriod: 0,
-    issuerValidationValidityPeriod: 0,
-    verifierValidationValidityPeriod: 0,
-    holderValidationValidityPeriod: 0,
+    issuerGrantorValidationValidityPeriod: undefined,
+    verifierGrantorValidationValidityPeriod: undefined,
+    issuerValidationValidityPeriod: undefined,
+    verifierValidationValidityPeriod: undefined,
+    holderValidationValidityPeriod: undefined,
     issuerPermManagementMode: 0,
     verifierPermManagementMode: 0,
   };
@@ -215,20 +215,20 @@ export const MsgCreateCredentialSchema = {
     if (message.jsonSchema !== "") {
       writer.uint32(26).string(message.jsonSchema);
     }
-    if (message.issuerGrantorValidationValidityPeriod !== 0) {
-      writer.uint32(32).uint32(message.issuerGrantorValidationValidityPeriod);
+    if (message.issuerGrantorValidationValidityPeriod !== undefined) {
+      OptionalUInt32.encode(message.issuerGrantorValidationValidityPeriod, writer.uint32(34).fork()).ldelim();
     }
-    if (message.verifierGrantorValidationValidityPeriod !== 0) {
-      writer.uint32(40).uint32(message.verifierGrantorValidationValidityPeriod);
+    if (message.verifierGrantorValidationValidityPeriod !== undefined) {
+      OptionalUInt32.encode(message.verifierGrantorValidationValidityPeriod, writer.uint32(42).fork()).ldelim();
     }
-    if (message.issuerValidationValidityPeriod !== 0) {
-      writer.uint32(48).uint32(message.issuerValidationValidityPeriod);
+    if (message.issuerValidationValidityPeriod !== undefined) {
+      OptionalUInt32.encode(message.issuerValidationValidityPeriod, writer.uint32(50).fork()).ldelim();
     }
-    if (message.verifierValidationValidityPeriod !== 0) {
-      writer.uint32(56).uint32(message.verifierValidationValidityPeriod);
+    if (message.verifierValidationValidityPeriod !== undefined) {
+      OptionalUInt32.encode(message.verifierValidationValidityPeriod, writer.uint32(58).fork()).ldelim();
     }
-    if (message.holderValidationValidityPeriod !== 0) {
-      writer.uint32(64).uint32(message.holderValidationValidityPeriod);
+    if (message.holderValidationValidityPeriod !== undefined) {
+      OptionalUInt32.encode(message.holderValidationValidityPeriod, writer.uint32(66).fork()).ldelim();
     }
     if (message.issuerPermManagementMode !== 0) {
       writer.uint32(72).uint32(message.issuerPermManagementMode);
@@ -268,39 +268,39 @@ export const MsgCreateCredentialSchema = {
           message.jsonSchema = reader.string();
           continue;
         case 4:
-          if (tag !== 32) {
+          if (tag !== 34) {
             break;
           }
 
-          message.issuerGrantorValidationValidityPeriod = reader.uint32();
+          message.issuerGrantorValidationValidityPeriod = OptionalUInt32.decode(reader, reader.uint32());
           continue;
         case 5:
-          if (tag !== 40) {
+          if (tag !== 42) {
             break;
           }
 
-          message.verifierGrantorValidationValidityPeriod = reader.uint32();
+          message.verifierGrantorValidationValidityPeriod = OptionalUInt32.decode(reader, reader.uint32());
           continue;
         case 6:
-          if (tag !== 48) {
+          if (tag !== 50) {
             break;
           }
 
-          message.issuerValidationValidityPeriod = reader.uint32();
+          message.issuerValidationValidityPeriod = OptionalUInt32.decode(reader, reader.uint32());
           continue;
         case 7:
-          if (tag !== 56) {
+          if (tag !== 58) {
             break;
           }
 
-          message.verifierValidationValidityPeriod = reader.uint32();
+          message.verifierValidationValidityPeriod = OptionalUInt32.decode(reader, reader.uint32());
           continue;
         case 8:
-          if (tag !== 64) {
+          if (tag !== 66) {
             break;
           }
 
-          message.holderValidationValidityPeriod = reader.uint32();
+          message.holderValidationValidityPeriod = OptionalUInt32.decode(reader, reader.uint32());
           continue;
         case 9:
           if (tag !== 72) {
@@ -331,20 +331,20 @@ export const MsgCreateCredentialSchema = {
       trId: isSet(object.trId) ? Long.fromValue(object.trId) : Long.UZERO,
       jsonSchema: isSet(object.jsonSchema) ? globalThis.String(object.jsonSchema) : "",
       issuerGrantorValidationValidityPeriod: isSet(object.issuerGrantorValidationValidityPeriod)
-        ? globalThis.Number(object.issuerGrantorValidationValidityPeriod)
-        : 0,
+        ? OptionalUInt32.fromJSON(object.issuerGrantorValidationValidityPeriod)
+        : undefined,
       verifierGrantorValidationValidityPeriod: isSet(object.verifierGrantorValidationValidityPeriod)
-        ? globalThis.Number(object.verifierGrantorValidationValidityPeriod)
-        : 0,
+        ? OptionalUInt32.fromJSON(object.verifierGrantorValidationValidityPeriod)
+        : undefined,
       issuerValidationValidityPeriod: isSet(object.issuerValidationValidityPeriod)
-        ? globalThis.Number(object.issuerValidationValidityPeriod)
-        : 0,
+        ? OptionalUInt32.fromJSON(object.issuerValidationValidityPeriod)
+        : undefined,
       verifierValidationValidityPeriod: isSet(object.verifierValidationValidityPeriod)
-        ? globalThis.Number(object.verifierValidationValidityPeriod)
-        : 0,
+        ? OptionalUInt32.fromJSON(object.verifierValidationValidityPeriod)
+        : undefined,
       holderValidationValidityPeriod: isSet(object.holderValidationValidityPeriod)
-        ? globalThis.Number(object.holderValidationValidityPeriod)
-        : 0,
+        ? OptionalUInt32.fromJSON(object.holderValidationValidityPeriod)
+        : undefined,
       issuerPermManagementMode: isSet(object.issuerPermManagementMode)
         ? globalThis.Number(object.issuerPermManagementMode)
         : 0,
@@ -365,20 +365,20 @@ export const MsgCreateCredentialSchema = {
     if (message.jsonSchema !== "") {
       obj.jsonSchema = message.jsonSchema;
     }
-    if (message.issuerGrantorValidationValidityPeriod !== 0) {
-      obj.issuerGrantorValidationValidityPeriod = Math.round(message.issuerGrantorValidationValidityPeriod);
+    if (message.issuerGrantorValidationValidityPeriod !== undefined) {
+      obj.issuerGrantorValidationValidityPeriod = message.issuerGrantorValidationValidityPeriod.value;
     }
-    if (message.verifierGrantorValidationValidityPeriod !== 0) {
-      obj.verifierGrantorValidationValidityPeriod = Math.round(message.verifierGrantorValidationValidityPeriod);
+    if (message.verifierGrantorValidationValidityPeriod !== undefined) {
+      obj.verifierGrantorValidationValidityPeriod = message.verifierGrantorValidationValidityPeriod.value;
     }
-    if (message.issuerValidationValidityPeriod !== 0) {
-      obj.issuerValidationValidityPeriod = Math.round(message.issuerValidationValidityPeriod);
+    if (message.issuerValidationValidityPeriod !== undefined) {
+      obj.issuerValidationValidityPeriod = message.issuerValidationValidityPeriod.value;
     }
-    if (message.verifierValidationValidityPeriod !== 0) {
-      obj.verifierValidationValidityPeriod = Math.round(message.verifierValidationValidityPeriod);
+    if (message.verifierValidationValidityPeriod !== undefined) {
+      obj.verifierValidationValidityPeriod = message.verifierValidationValidityPeriod.value;
     }
-    if (message.holderValidationValidityPeriod !== 0) {
-      obj.holderValidationValidityPeriod = Math.round(message.holderValidationValidityPeriod);
+    if (message.holderValidationValidityPeriod !== undefined) {
+      obj.holderValidationValidityPeriod = message.holderValidationValidityPeriod.value;
     }
     if (message.issuerPermManagementMode !== 0) {
       obj.issuerPermManagementMode = Math.round(message.issuerPermManagementMode);
@@ -397,13 +397,98 @@ export const MsgCreateCredentialSchema = {
     message.creator = object.creator ?? "";
     message.trId = (object.trId !== undefined && object.trId !== null) ? Long.fromValue(object.trId) : Long.UZERO;
     message.jsonSchema = object.jsonSchema ?? "";
-    message.issuerGrantorValidationValidityPeriod = object.issuerGrantorValidationValidityPeriod ?? 0;
-    message.verifierGrantorValidationValidityPeriod = object.verifierGrantorValidationValidityPeriod ?? 0;
-    message.issuerValidationValidityPeriod = object.issuerValidationValidityPeriod ?? 0;
-    message.verifierValidationValidityPeriod = object.verifierValidationValidityPeriod ?? 0;
-    message.holderValidationValidityPeriod = object.holderValidationValidityPeriod ?? 0;
+    message.issuerGrantorValidationValidityPeriod =
+      (object.issuerGrantorValidationValidityPeriod !== undefined &&
+        object.issuerGrantorValidationValidityPeriod !== null)
+        ? OptionalUInt32.fromPartial(object.issuerGrantorValidationValidityPeriod)
+        : undefined;
+    message.verifierGrantorValidationValidityPeriod =
+      (object.verifierGrantorValidationValidityPeriod !== undefined &&
+        object.verifierGrantorValidationValidityPeriod !== null)
+        ? OptionalUInt32.fromPartial(object.verifierGrantorValidationValidityPeriod)
+        : undefined;
+    message.issuerValidationValidityPeriod =
+      (object.issuerValidationValidityPeriod !== undefined && object.issuerValidationValidityPeriod !== null)
+        ? OptionalUInt32.fromPartial(object.issuerValidationValidityPeriod)
+        : undefined;
+    message.verifierValidationValidityPeriod =
+      (object.verifierValidationValidityPeriod !== undefined && object.verifierValidationValidityPeriod !== null)
+        ? OptionalUInt32.fromPartial(object.verifierValidationValidityPeriod)
+        : undefined;
+    message.holderValidationValidityPeriod =
+      (object.holderValidationValidityPeriod !== undefined && object.holderValidationValidityPeriod !== null)
+        ? OptionalUInt32.fromPartial(object.holderValidationValidityPeriod)
+        : undefined;
     message.issuerPermManagementMode = object.issuerPermManagementMode ?? 0;
     message.verifierPermManagementMode = object.verifierPermManagementMode ?? 0;
+    return message;
+  },
+};
+
+function createBaseOptionalUInt32(): OptionalUInt32 {
+  return { value: 0 };
+}
+
+export interface OptionalUInt32 {
+  value: number;
+}
+
+export const OptionalUInt32 = {
+  encode(message: OptionalUInt32, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.value !== 0) {
+      writer.uint32(8).uint32(message.value);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): OptionalUInt32 {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseOptionalUInt32();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag !== 8) {
+            break;
+          }
+
+          message.value = reader.uint32();
+          continue;
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): OptionalUInt32 {
+    // Handle both direct number and {value: X} format
+    if (typeof object === "number") {
+      return { value: object };
+    }
+    if (typeof object === "object" && object !== null) {
+      return { value: isSet(object.value) ? globalThis.Number(object.value) : 0 };
+    }
+    return { value: 0 };
+  },
+
+  toJSON(message: OptionalUInt32): unknown {
+    const obj: any = {};
+    if (message.value !== 0) {
+      obj.value = Math.round(message.value);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<OptionalUInt32>, I>>(base?: I): OptionalUInt32 {
+    return OptionalUInt32.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<OptionalUInt32>, I>>(object: I): OptionalUInt32 {
+    const message = createBaseOptionalUInt32();
+    message.value = object.value ?? 0;
     return message;
   },
 };
@@ -473,11 +558,11 @@ function createBaseMsgUpdateCredentialSchema(): MsgUpdateCredentialSchema {
   return {
     creator: "",
     id: Long.UZERO,
-    issuerGrantorValidationValidityPeriod: 0,
-    verifierGrantorValidationValidityPeriod: 0,
-    issuerValidationValidityPeriod: 0,
-    verifierValidationValidityPeriod: 0,
-    holderValidationValidityPeriod: 0,
+    issuerGrantorValidationValidityPeriod: undefined,
+    verifierGrantorValidationValidityPeriod: undefined,
+    issuerValidationValidityPeriod: undefined,
+    verifierValidationValidityPeriod: undefined,
+    holderValidationValidityPeriod: undefined,
   };
 }
 
@@ -489,20 +574,20 @@ export const MsgUpdateCredentialSchema = {
     if (!message.id.equals(Long.UZERO)) {
       writer.uint32(16).uint64(message.id);
     }
-    if (message.issuerGrantorValidationValidityPeriod !== 0) {
-      writer.uint32(24).uint32(message.issuerGrantorValidationValidityPeriod);
+    if (message.issuerGrantorValidationValidityPeriod !== undefined) {
+      OptionalUInt32.encode(message.issuerGrantorValidationValidityPeriod, writer.uint32(26).fork()).ldelim();
     }
-    if (message.verifierGrantorValidationValidityPeriod !== 0) {
-      writer.uint32(32).uint32(message.verifierGrantorValidationValidityPeriod);
+    if (message.verifierGrantorValidationValidityPeriod !== undefined) {
+      OptionalUInt32.encode(message.verifierGrantorValidationValidityPeriod, writer.uint32(34).fork()).ldelim();
     }
-    if (message.issuerValidationValidityPeriod !== 0) {
-      writer.uint32(40).uint32(message.issuerValidationValidityPeriod);
+    if (message.issuerValidationValidityPeriod !== undefined) {
+      OptionalUInt32.encode(message.issuerValidationValidityPeriod, writer.uint32(42).fork()).ldelim();
     }
-    if (message.verifierValidationValidityPeriod !== 0) {
-      writer.uint32(48).uint32(message.verifierValidationValidityPeriod);
+    if (message.verifierValidationValidityPeriod !== undefined) {
+      OptionalUInt32.encode(message.verifierValidationValidityPeriod, writer.uint32(50).fork()).ldelim();
     }
-    if (message.holderValidationValidityPeriod !== 0) {
-      writer.uint32(56).uint32(message.holderValidationValidityPeriod);
+    if (message.holderValidationValidityPeriod !== undefined) {
+      OptionalUInt32.encode(message.holderValidationValidityPeriod, writer.uint32(58).fork()).ldelim();
     }
     return writer;
   },
@@ -529,39 +614,39 @@ export const MsgUpdateCredentialSchema = {
           message.id = reader.uint64() as Long;
           continue;
         case 3:
-          if (tag !== 24) {
+          if (tag !== 26) {
             break;
           }
 
-          message.issuerGrantorValidationValidityPeriod = reader.uint32();
+          message.issuerGrantorValidationValidityPeriod = OptionalUInt32.decode(reader, reader.uint32());
           continue;
         case 4:
-          if (tag !== 32) {
+          if (tag !== 34) {
             break;
           }
 
-          message.verifierGrantorValidationValidityPeriod = reader.uint32();
+          message.verifierGrantorValidationValidityPeriod = OptionalUInt32.decode(reader, reader.uint32());
           continue;
         case 5:
-          if (tag !== 40) {
+          if (tag !== 42) {
             break;
           }
 
-          message.issuerValidationValidityPeriod = reader.uint32();
+          message.issuerValidationValidityPeriod = OptionalUInt32.decode(reader, reader.uint32());
           continue;
         case 6:
-          if (tag !== 48) {
+          if (tag !== 50) {
             break;
           }
 
-          message.verifierValidationValidityPeriod = reader.uint32();
+          message.verifierValidationValidityPeriod = OptionalUInt32.decode(reader, reader.uint32());
           continue;
         case 7:
-          if (tag !== 56) {
+          if (tag !== 58) {
             break;
           }
 
-          message.holderValidationValidityPeriod = reader.uint32();
+          message.holderValidationValidityPeriod = OptionalUInt32.decode(reader, reader.uint32());
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -577,20 +662,20 @@ export const MsgUpdateCredentialSchema = {
       creator: isSet(object.creator) ? globalThis.String(object.creator) : "",
       id: isSet(object.id) ? Long.fromValue(object.id) : Long.UZERO,
       issuerGrantorValidationValidityPeriod: isSet(object.issuerGrantorValidationValidityPeriod)
-        ? globalThis.Number(object.issuerGrantorValidationValidityPeriod)
-        : 0,
+        ? OptionalUInt32.fromJSON(object.issuerGrantorValidationValidityPeriod)
+        : undefined,
       verifierGrantorValidationValidityPeriod: isSet(object.verifierGrantorValidationValidityPeriod)
-        ? globalThis.Number(object.verifierGrantorValidationValidityPeriod)
-        : 0,
+        ? OptionalUInt32.fromJSON(object.verifierGrantorValidationValidityPeriod)
+        : undefined,
       issuerValidationValidityPeriod: isSet(object.issuerValidationValidityPeriod)
-        ? globalThis.Number(object.issuerValidationValidityPeriod)
-        : 0,
+        ? OptionalUInt32.fromJSON(object.issuerValidationValidityPeriod)
+        : undefined,
       verifierValidationValidityPeriod: isSet(object.verifierValidationValidityPeriod)
-        ? globalThis.Number(object.verifierValidationValidityPeriod)
-        : 0,
+        ? OptionalUInt32.fromJSON(object.verifierValidationValidityPeriod)
+        : undefined,
       holderValidationValidityPeriod: isSet(object.holderValidationValidityPeriod)
-        ? globalThis.Number(object.holderValidationValidityPeriod)
-        : 0,
+        ? OptionalUInt32.fromJSON(object.holderValidationValidityPeriod)
+        : undefined,
     };
   },
 
@@ -602,20 +687,20 @@ export const MsgUpdateCredentialSchema = {
     if (!message.id.equals(Long.UZERO)) {
       obj.id = (message.id || Long.UZERO).toString();
     }
-    if (message.issuerGrantorValidationValidityPeriod !== 0) {
-      obj.issuerGrantorValidationValidityPeriod = Math.round(message.issuerGrantorValidationValidityPeriod);
+    if (message.issuerGrantorValidationValidityPeriod !== undefined) {
+      obj.issuerGrantorValidationValidityPeriod = message.issuerGrantorValidationValidityPeriod.value;
     }
-    if (message.verifierGrantorValidationValidityPeriod !== 0) {
-      obj.verifierGrantorValidationValidityPeriod = Math.round(message.verifierGrantorValidationValidityPeriod);
+    if (message.verifierGrantorValidationValidityPeriod !== undefined) {
+      obj.verifierGrantorValidationValidityPeriod = message.verifierGrantorValidationValidityPeriod.value;
     }
-    if (message.issuerValidationValidityPeriod !== 0) {
-      obj.issuerValidationValidityPeriod = Math.round(message.issuerValidationValidityPeriod);
+    if (message.issuerValidationValidityPeriod !== undefined) {
+      obj.issuerValidationValidityPeriod = message.issuerValidationValidityPeriod.value;
     }
-    if (message.verifierValidationValidityPeriod !== 0) {
-      obj.verifierValidationValidityPeriod = Math.round(message.verifierValidationValidityPeriod);
+    if (message.verifierValidationValidityPeriod !== undefined) {
+      obj.verifierValidationValidityPeriod = message.verifierValidationValidityPeriod.value;
     }
-    if (message.holderValidationValidityPeriod !== 0) {
-      obj.holderValidationValidityPeriod = Math.round(message.holderValidationValidityPeriod);
+    if (message.holderValidationValidityPeriod !== undefined) {
+      obj.holderValidationValidityPeriod = message.holderValidationValidityPeriod.value;
     }
     return obj;
   },
@@ -627,11 +712,28 @@ export const MsgUpdateCredentialSchema = {
     const message = createBaseMsgUpdateCredentialSchema();
     message.creator = object.creator ?? "";
     message.id = (object.id !== undefined && object.id !== null) ? Long.fromValue(object.id) : Long.UZERO;
-    message.issuerGrantorValidationValidityPeriod = object.issuerGrantorValidationValidityPeriod ?? 0;
-    message.verifierGrantorValidationValidityPeriod = object.verifierGrantorValidationValidityPeriod ?? 0;
-    message.issuerValidationValidityPeriod = object.issuerValidationValidityPeriod ?? 0;
-    message.verifierValidationValidityPeriod = object.verifierValidationValidityPeriod ?? 0;
-    message.holderValidationValidityPeriod = object.holderValidationValidityPeriod ?? 0;
+    message.issuerGrantorValidationValidityPeriod =
+      (object.issuerGrantorValidationValidityPeriod !== undefined &&
+        object.issuerGrantorValidationValidityPeriod !== null)
+        ? OptionalUInt32.fromPartial(object.issuerGrantorValidationValidityPeriod)
+        : undefined;
+    message.verifierGrantorValidationValidityPeriod =
+      (object.verifierGrantorValidationValidityPeriod !== undefined &&
+        object.verifierGrantorValidationValidityPeriod !== null)
+        ? OptionalUInt32.fromPartial(object.verifierGrantorValidationValidityPeriod)
+        : undefined;
+    message.issuerValidationValidityPeriod =
+      (object.issuerValidationValidityPeriod !== undefined && object.issuerValidationValidityPeriod !== null)
+        ? OptionalUInt32.fromPartial(object.issuerValidationValidityPeriod)
+        : undefined;
+    message.verifierValidationValidityPeriod =
+      (object.verifierValidationValidityPeriod !== undefined && object.verifierValidationValidityPeriod !== null)
+        ? OptionalUInt32.fromPartial(object.verifierValidationValidityPeriod)
+        : undefined;
+    message.holderValidationValidityPeriod =
+      (object.holderValidationValidityPeriod !== undefined && object.holderValidationValidityPeriod !== null)
+        ? OptionalUInt32.fromPartial(object.holderValidationValidityPeriod)
+        : undefined;
     return message;
   },
 };


### PR DESCRIPTION
The issue happened because the indexer was using an old Protobuf format, so it couldn’t read the newly created CS data correctly. I’ve updated the Protobuf code to match the current chain structure, and this should fix the problem where new CSs were showing zero values.