### PR TITLE
feat: return results with pagination and ordered by timestamp

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -305,47 +305,29 @@
                       "type": "integer",
                       "minimum": 0
                     },
-                    "changes": {
+                    "activity": {
                       "type": "array",
+                      "description": "List of activity items at this block height (same format as history endpoints)",
                       "items": {
-                        "type": "object",
-                        "properties": {
-                          "entity_type": {
-                            "type": "string"
-                          },
-                          "entity_id": {
-                            "type": "string"
-                          },
-                          "operation": {
-                            "type": "string",
-                            "enum": [
-                              "create",
-                              "update",
-                              "delete"
-                            ]
-                          },
-                          "payload": {
-                            "type": "object"
-                          }
-                        }
+                        "$ref": "#/components/schemas/ActivityItem"
                       }
                     }
                   }
                 },
                 "example": {
                   "block_height": 123450,
-                  "changes": [
+                  "activity": [
                     {
-                      "entity_type": "DidDirectory",
+                      "timestamp": "2025-11-24T07:00:00.000Z",
+                      "block_height": "123450",
+                      "entity_type": "DID",
                       "entity_id": "did:verana:abc123",
-                      "operation": "create",
-                      "payload": {
-                        "controller": "verana1abcd...",
-                        "changes": {
-                          "created": {
-                            "old": null,
-                            "new": "2025-11-24T07:00:00.000Z"
-                          }
+                      "account": "verana1abcd...",
+                      "msg": "AddDID",
+                      "changes": {
+                        "created": {
+                          "old": null,
+                          "new": "2025-11-24T07:00:00.000Z"
                         }
                       }
                     }
@@ -543,8 +525,8 @@
         "tags": [
           "DID"
         ],
-        "summary": "Get DID history",
-        "description": "Retrieve the complete history and changes for a specific DID",
+        "summary": "Get DID activity timeline",
+        "description": "Retrieve the activity timeline for a DID, showing all changes ordered by transaction timestamp descending. Returns only changed values in the changes field.",
         "operationId": "getDIDHistory",
         "parameters": [
           {
@@ -557,16 +539,38 @@
             "description": "The Decentralized Identifier to retrieve history for"
           },
           {
+            "name": "response_max_size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 64
+            },
+            "description": "Maximum number of activity items to return (default: 64)"
+          },
+          {
+            "name": "transaction_timestamp_older_than",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "description": "ISO 8601 timestamp to paginate results. Returns only activities with timestamps older than this value."
+          },
+          {
             "$ref": "#/components/parameters/At-Block-Height"
           }
         ],
         "responses": {
           "200": {
-            "description": "Successful response with DID history",
+            "description": "Successful response with DID activity timeline",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DIDHistoryResponse"
+                  "$ref": "#/components/schemas/ActivityTimelineResponse"
                 }
               }
             }
@@ -779,8 +783,8 @@
         "tags": [
           "Trust Registry"
         ],
-        "summary": "Get Trust Registry history",
-        "description": "Retrieve the complete history and changes for a specific Trust Registry",
+        "summary": "Get Trust Registry activity timeline",
+        "description": "Retrieve the activity timeline for a Trust Registry, showing all changes ordered by transaction timestamp descending. Returns only changed values in the changes field.",
         "operationId": "getTrustRegistryHistory",
         "parameters": [
           {
@@ -793,16 +797,38 @@
             "description": "The Trust Registry ID to retrieve history for"
           },
           {
+            "name": "response_max_size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 64
+            },
+            "description": "Maximum number of activity items to return (default: 64)"
+          },
+          {
+            "name": "transaction_timestamp_older_than",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "description": "ISO 8601 timestamp to paginate results. Returns only activities with timestamps older than this value."
+          },
+          {
             "$ref": "#/components/parameters/At-Block-Height"
           }
         ],
         "responses": {
           "200": {
-            "description": "Successful response with Trust Registry history",
+            "description": "Successful response with Trust Registry activity timeline",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TrustRegistryHistoryResponse"
+                  "$ref": "#/components/schemas/ActivityTimelineResponse"
                 }
               }
             }
@@ -1069,8 +1095,8 @@
         "tags": [
           "Credential Schema"
         ],
-        "summary": "Get Credential Schema history",
-        "description": "Retrieve the complete history and changes for a specific Credential Schema",
+        "summary": "Get Credential Schema activity timeline",
+        "description": "Retrieve the activity timeline for a Credential Schema, showing all changes ordered by transaction timestamp descending. Returns only changed values in the changes field.",
         "operationId": "getCredentialSchemaHistory",
         "parameters": [
           {
@@ -1081,6 +1107,28 @@
               "type": "string"
             },
             "description": "The Credential Schema ID to retrieve history for"
+          },
+          {
+            "name": "response_max_size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 64
+            },
+            "description": "Maximum number of activity items to return (default: 64)"
+          },
+          {
+            "name": "transaction_timestamp_older_than",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "description": "ISO 8601 timestamp to paginate results. Returns only activities with timestamps older than this value."
           },
           {
             "$ref": "#/components/parameters/At-Block-Height"
@@ -1545,8 +1593,8 @@
         "tags": [
           "Permissions"
         ],
-        "summary": "Get Permission History",
-        "description": "Retrieve the recorded history for a specific Permission ID.",
+        "summary": "Get Permission activity timeline",
+        "description": "Retrieve the activity timeline for a Permission, showing all changes ordered by transaction timestamp descending. Returns only changed values in the changes field.",
         "operationId": "getPermissionHistory",
         "parameters": [
           {
@@ -1559,22 +1607,44 @@
             "description": "Permission ID whose history will be returned"
           },
           {
+            "name": "response_max_size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 64
+            },
+            "description": "Maximum number of activity items to return (default: 64)"
+          },
+          {
+            "name": "transaction_timestamp_older_than",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "description": "ISO 8601 timestamp to paginate results. Returns only activities with timestamps older than this value."
+          },
+          {
             "$ref": "#/components/parameters/At-Block-Height"
           }
         ],
         "responses": {
           "200": {
-            "description": "History entries for the given Permission",
+            "description": "Successful response with Permission activity timeline",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PermissionHistoryResponse"
+                  "$ref": "#/components/schemas/ActivityTimelineResponse"
                 }
               }
             }
           },
           "404": {
-            "description": "No history entries found",
+            "description": "Permission history not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -1750,8 +1820,8 @@
         "tags": [
           "TrustDeposit"
         ],
-        "summary": "Get Trust Deposit History",
-        "description": "Retrieve the complete history of changes for a specific account's trust deposit",
+        "summary": "Get Trust Deposit activity timeline",
+        "description": "Retrieve the activity timeline for a Trust Deposit, showing all changes ordered by transaction timestamp descending. Returns only changed values in the changes field.",
         "operationId": "getTrustDepositHistory",
         "parameters": [
           {
@@ -1764,37 +1834,38 @@
             "description": "The account address to retrieve trust deposit history for"
           },
           {
+            "name": "response_max_size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 64
+            },
+            "description": "Maximum number of activity items to return (default: 64)"
+          },
+          {
+            "name": "transaction_timestamp_older_than",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "description": "ISO 8601 timestamp to paginate results. Returns only activities with timestamps older than this value."
+          },
+          {
             "$ref": "#/components/parameters/At-Block-Height"
           }
         ],
         "responses": {
           "200": {
-            "description": "Successful response with trust deposit history",
+            "description": "Successful response with Trust Deposit activity timeline",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TrustDepositHistoryResponse"
-                },
-                "example": {
-                  "history": [
-                    {
-                      "id": 1,
-                      "account": "verana1sxau0xyttphpck7vhlvt8s82ez70nlzw2mhya0",
-                      "share": "20000000",
-                      "amount": "20000000",
-                      "claimable": "0",
-                      "slashed_deposit": "0",
-                      "repaid_deposit": "0",
-                      "last_slashed": null,
-                      "last_repaid": null,
-                      "slash_count": 0,
-                      "last_repaid_by": "",
-                      "event_type": "CREATE_TRUST_DEPOSIT",
-                      "height": 12345,
-                      "changes": null,
-                      "created_at": "2025-11-26T08:35:35.199Z"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/ActivityTimelineResponse"
                 }
               }
             }
@@ -2654,6 +2725,92 @@
               "description": "Account that last performed repayment"
             }
           }
+        },
+        "ActivityTimelineResponse": {
+          "type": "object",
+          "properties": {
+            "entity_type": {
+              "type": "string",
+              "description": "The entity type (VPR spec name)",
+              "enum": [
+                "TrustRegistry",
+                "CredentialSchema",
+                "GovernanceFrameworkDocument",
+                "GovernanceFrameworkVersion",
+                "DID",
+                "Permission",
+                "TrustDeposit"
+              ]
+            },
+            "entity_id": {
+              "type": "string",
+              "description": "The entity ID"
+            },
+            "activity": {
+              "type": "array",
+              "description": "List of activity items ordered by timestamp descending",
+              "items": {
+                "$ref": "#/components/schemas/ActivityItem"
+              }
+            }
+          },
+          "required": [
+            "entity_type",
+            "entity_id",
+            "activity"
+          ]
+        },
+        "ActivityItem": {
+          "type": "object",
+          "properties": {
+            "timestamp": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Transaction timestamp (ISO 8601)",
+              "nullable": true
+            },
+            "block_height": {
+              "type": "string",
+              "description": "Block height when the change occurred"
+            },
+            "entity_type": {
+              "type": "string",
+              "description": "Entity type (VPR spec name). Only included when different from the top-level entity_type (e.g., for related entities in TrustRegistry history)."
+            },
+            "entity_id": {
+              "type": "string",
+              "description": "Entity ID. Only included when different from the top-level entity_id (e.g., for related entities in TrustRegistry history)."
+            },
+            "account": {
+              "type": "string",
+              "description": "Account address that made the change. Only included when available (omitted for system-generated events)."
+            },
+            "msg": {
+              "type": "string",
+              "description": "Message/action type (e.g., CreateTrustRegistry, AddGovernanceFrameworkDocument)"
+            },
+            "changes": {
+              "type": "object",
+              "description": "Only changed values (fields that actually changed). Null if no changes or for create actions.",
+              "nullable": true,
+              "additionalProperties": {
+                "type": "object",
+                "properties": {
+                  "old": {
+                    "description": "Previous value"
+                  },
+                  "new": {
+                    "description": "New value"
+                  }
+                }
+              }
+            }
+          },
+          "required": [
+            "timestamp",
+            "block_height",
+            "msg"
+          ]
         },
         "TrustDepositResponse": {
           "type": "object",
@@ -4217,6 +4374,10 @@
     {
       "name": "Indexer",
       "description": "Indexer state and changes tracking operations"
+    },
+    {
+      "name": "Activity",
+      "description": "Activity timeline operations for tracking entity changes"
     },
     {
       "description": "## Real-Time Event (WebSocket)\n\n**Endpoint URLs:**\n- Local: `ws://localhost:3001/verana/indexer/v1/events`\n- Testnet: `wss://idx.testnet.verana.network/verana/indexer/v1/events`\n\n**Message Format:**\n```json\n{\n  \"type\": \"block-processed\",\n  \"height\": 123456,\n  \"timestamp\": \"2025-01-15T10:30:00Z\"\n}\n```\n\n**Event Type:** `block-processed` - Sent whenever a new block is successfully processed by the indexer. The `height` field contains the latest processed block height (ISO 8601 format with 'Z' designator).\n\n**Example:**\n```javascript\nconst ws = new WebSocket('ws://localhost:3001/verana/indexer/v1/events');\nws.onmessage = (event) => {\n  const data = JSON.parse(event.data);\n  if (data.type === 'block-processed') {\n    console.log(`Block ${data.height} processed`);\n    // Now safe to query indexer API for updated data\n  }\n};\n```"

--- a/src/common/utils/activity_timeline_helper.ts
+++ b/src/common/utils/activity_timeline_helper.ts
@@ -1,0 +1,352 @@
+import knex from "./db_connection";
+import {
+  VeranaTrustRegistryMessageTypes,
+  VeranaCredentialSchemaMessageTypes,
+  VeranaDidMessageTypes,
+  VeranaPermissionMessageTypes,
+} from "../verana-message-types";
+
+const MSG_TYPE_TO_ACTION: Record<string, string> = {
+  [VeranaTrustRegistryMessageTypes.CreateTrustRegistry]: "CreateTrustRegistry",
+  [VeranaTrustRegistryMessageTypes.CreateTrustRegistryLegacy]: "CreateTrustRegistry",
+  [VeranaTrustRegistryMessageTypes.UpdateTrustRegistry]: "UpdateTrustRegistry",
+  [VeranaTrustRegistryMessageTypes.ArchiveTrustRegistry]: "ArchiveTrustRegistry",
+  [VeranaTrustRegistryMessageTypes.AddGovernanceFrameworkDoc]: "AddGovernanceFrameworkDocument",
+  [VeranaTrustRegistryMessageTypes.IncreaseGovernanceFrameworkVersion]: "IncreaseGovernanceFrameworkVersion",
+  [VeranaCredentialSchemaMessageTypes.CreateCredentialSchema]: "CreateCredentialSchema",
+  [VeranaCredentialSchemaMessageTypes.CreateCredentialSchemaLegacy]: "CreateCredentialSchema",
+  [VeranaCredentialSchemaMessageTypes.UpdateCredentialSchema]: "UpdateCredentialSchema",
+  [VeranaCredentialSchemaMessageTypes.ArchiveCredentialSchema]: "ArchiveCredentialSchema",
+  [VeranaDidMessageTypes.AddDid]: "AddDID",
+  [VeranaDidMessageTypes.RenewDid]: "RenewDID",
+  [VeranaDidMessageTypes.TouchDid]: "TouchDID",
+  [VeranaDidMessageTypes.RemoveDid]: "RemoveDID",
+  [VeranaPermissionMessageTypes.CreateRootPermission]: "CreateRootPermission",
+  [VeranaPermissionMessageTypes.CreatePermission]: "CreatePermission",
+  [VeranaPermissionMessageTypes.StartPermissionVP]: "StartPermissionVP",
+  [VeranaPermissionMessageTypes.RenewPermissionVP]: "RenewPermissionVP",
+  [VeranaPermissionMessageTypes.RevokePermission]: "RevokePermission",
+  [VeranaPermissionMessageTypes.ExtendPermission]: "ExtendPermission",
+  [VeranaPermissionMessageTypes.SetPermissionVPToValidated]: "SetPermissionVPToValidated",
+  [VeranaPermissionMessageTypes.CreateOrUpdatePermissionSession]: "CreateOrUpdatePermissionSession",
+  [VeranaPermissionMessageTypes.SlashPermissionTrustDeposit]: "SlashPermissionTrustDeposit",
+  [VeranaPermissionMessageTypes.RepayPermissionSlashedTrustDeposit]: "RepayPermissionSlashedTrustDeposit",
+  [VeranaPermissionMessageTypes.CancelPermissionVPLastRequest]: "CancelPermissionVPLastRequest",
+};
+
+function normalizeEventType(eventType: string): string {
+  let normalized = eventType.replace(/^.*\./, "");
+  
+  if (normalized.includes("_")) {
+    normalized = normalized
+      .split("_")
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+      .join("");
+  } else if (normalized === normalized.toUpperCase()) {
+    normalized = normalized
+      .split(/(?=[A-Z])/)
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+      .join("");
+  }
+  
+  return normalized;
+}
+
+function getActionFromMessageType(msgType: string, eventType?: string, action?: string): string {
+  if (msgType && MSG_TYPE_TO_ACTION[msgType]) {
+    return MSG_TYPE_TO_ACTION[msgType];
+  }
+  if (eventType) {
+    return normalizeEventType(eventType);
+  }
+  if (action) {
+    return normalizeEventType(action);
+  }
+  return "Unknown";
+}
+
+function filterChangedValues(changes: any): any {
+  if (!changes || typeof changes !== "object") {
+    return changes;
+  }
+  
+  const filtered: any = {};
+  for (const [key, value] of Object.entries(changes)) {
+    if (value && typeof value === "object" && ("old" in value || "new" in value)) {
+      const val = value as { old?: any; new?: any };
+      if (JSON.stringify(val.old) !== JSON.stringify(val.new)) {
+        filtered[key] = value;
+      }
+    } else if (value !== null && value !== undefined) {
+      filtered[key] = value;
+    }
+  }
+  return Object.keys(filtered).length > 0 ? filtered : null;
+}
+
+export interface RelatedEntityConfig {
+  entityType: string;
+  historyTable: string;
+  idField: string;
+  entityIdField: string;
+  msgTypePrefixes: string[];
+}
+
+export interface ActivityTimelineConfig {
+  entityType: string;
+  historyTable: string;
+  idField: string;
+  entityId: string | number;
+  msgTypePrefixes: string[];
+  relatedEntities?: RelatedEntityConfig[];
+}
+
+async function buildHistoryQuery(
+  config: {
+    entityType: string;
+    historyTable: string;
+    idField: string;
+    entityId: string | number;
+    msgTypePrefixes: string[];
+    entityIdField?: string;
+  },
+  options: {
+    transactionTimestampOlderThan?: string;
+    atBlockHeight?: string;
+  }
+) {
+  try {
+    const { entityType, historyTable, idField, entityId, msgTypePrefixes, entityIdField } = config;
+    const { transactionTimestampOlderThan, atBlockHeight } = options;
+
+  const prefixes = msgTypePrefixes || [];
+  const msgTypeCondition = prefixes.length > 0 
+    ? `AND (${prefixes.map((p, idx) => {
+        const escapedPrefix = p.replace(/'/g, "''");
+        return idx === 0 ? `transaction_message.type LIKE '${escapedPrefix}%'` : `OR transaction_message.type LIKE '${escapedPrefix}%'`;
+      }).join(' ')})`
+    : '';
+
+  const isNumericId = typeof entityId === 'number' || !Number.isNaN(Number(entityId));
+
+  const quotedTable = `"${historyTable}"`;
+  
+  let historyQuery = knex(historyTable)
+    .select(
+      `${historyTable}.*`,
+      "transaction.timestamp",
+      knex.raw('? as activity_entity_type', [entityType]),
+      entityIdField 
+        ? knex.raw(`COALESCE(CAST(${historyTable}.${entityIdField} AS TEXT), CAST(${historyTable}.id AS TEXT)) as activity_entity_id`)
+        : knex.raw('? as activity_entity_id', [String(entityId)]),
+      knex.raw(`(
+        SELECT transaction_message.type 
+        FROM transaction_message 
+        INNER JOIN transaction t ON t.id = transaction_message.tx_id
+        WHERE t.height = ${quotedTable}.height
+        ${msgTypeCondition}
+        ORDER BY transaction_message.index ASC
+        LIMIT 1
+      ) as msg_type`),
+      knex.raw(`(
+        SELECT transaction_message.sender 
+        FROM transaction_message 
+        INNER JOIN transaction t ON t.id = transaction_message.tx_id
+        WHERE t.height = ${quotedTable}.height
+        ${msgTypeCondition}
+        ORDER BY transaction_message.index ASC
+        LIMIT 1
+      ) as sender`)
+    )
+    .leftJoin("transaction", function () {
+      this.on(`${historyTable}.height`, "=", "transaction.height");
+    })
+    .where(function () {
+      this.where(`${historyTable}.${idField}`, entityId);
+    });
+
+  if (atBlockHeight) {
+    const blockHeight = Number(atBlockHeight);
+    if (!Number.isNaN(blockHeight)) {
+      historyQuery = historyQuery.where(function() {
+        this.whereNotNull(`${historyTable}.height`)
+            .andWhere(`${historyTable}.height`, "<=", blockHeight);
+      });
+    }
+  }
+
+  if (transactionTimestampOlderThan) {
+    historyQuery = historyQuery.where("transaction.timestamp", "<", transactionTimestampOlderThan);
+  }
+
+  return historyQuery;
+  } catch (error: any) {
+    console.error("Error building history query:", error);
+    console.error("Query config:", config);
+    throw error;
+  }
+}
+
+export async function buildActivityTimeline(
+  config: ActivityTimelineConfig,
+  options: {
+    responseMaxSize?: number;
+    transactionTimestampOlderThan?: string;
+    atBlockHeight?: string;
+  } = {}
+): Promise<any[]> {
+  try {
+    const { entityType, historyTable, idField, entityId, msgTypePrefixes, relatedEntities } = config;
+    const { responseMaxSize = 64, transactionTimestampOlderThan, atBlockHeight } = options;
+
+  const queries: any[] = [];
+
+  queries.push(
+    buildHistoryQuery(
+      {
+        entityType,
+        historyTable,
+        idField,
+        entityId,
+        msgTypePrefixes,
+        entityIdField: idField,
+      },
+      { transactionTimestampOlderThan, atBlockHeight }
+    )
+  );
+
+  if (relatedEntities && relatedEntities.length > 0) {
+    for (const related of relatedEntities) {
+      queries.push(
+        buildHistoryQuery(
+          {
+            entityType: related.entityType,
+            historyTable: related.historyTable,
+            idField: related.idField,
+            entityId,
+            msgTypePrefixes: related.msgTypePrefixes,
+            entityIdField: related.entityIdField,
+          },
+          { transactionTimestampOlderThan, atBlockHeight }
+        )
+      );
+    }
+  }
+
+  const allResults = await Promise.all(queries.map(async (q, index) => {
+    try {
+      if (process.env.NODE_ENV !== "production") {
+        try {
+          const querySql = typeof q.toQuery === 'function' ? q.toQuery() : (typeof q.toString === 'function' ? q.toString() : JSON.stringify(q));
+          console.log(`[DEBUG] History query ${index} SQL:`, querySql);
+        } catch (e) {
+          console.log(`[DEBUG] Could not generate query SQL for query ${index}`);
+        }
+      }
+      const result = await q;
+      if (process.env.NODE_ENV !== "production") {
+        console.log(`[DEBUG] History query ${index} returned ${result?.length || 0} records`);
+      }
+      return result;
+    } catch (err: any) {
+      console.error(`Query error for query ${index}:`, err);
+      console.error("Error details:", {
+        message: err?.message,
+        stack: err?.stack,
+        code: err?.code,
+        sql: err?.sql,
+        bindings: err?.bindings,
+      });
+      console.error("Query config:", config);
+      if (process.env.NODE_ENV !== "production") {
+        try {
+          const querySql = typeof q.toQuery === 'function' ? q.toQuery() : (typeof q.toString === 'function' ? q.toString() : JSON.stringify(q));
+          console.error(`[DEBUG] Failed query SQL:`, querySql);
+        } catch (e) {
+          console.error(`[DEBUG] Could not generate query SQL:`, e);
+        }
+      }
+      return [];
+    }
+  }));
+  
+  const allRecords: any[] = [];
+
+  for (const result of allResults) {
+    if (Array.isArray(result)) {
+      allRecords.push(...result);
+    }
+  }
+
+  const sortedRecords = allRecords.sort((a, b) => {
+    if (!a.timestamp && !b.timestamp) {
+      const heightDiff = (b.height || 0) - (a.height || 0);
+      if (heightDiff !== 0) return heightDiff;
+      const aCreated = a.created_at ? (a.created_at instanceof Date ? a.created_at.getTime() : new Date(a.created_at).getTime()) : 0;
+      const bCreated = b.created_at ? (b.created_at instanceof Date ? b.created_at.getTime() : new Date(b.created_at).getTime()) : 0;
+      return bCreated - aCreated;
+    }
+    if (!a.timestamp) return 1;
+    if (!b.timestamp) return -1;
+    const timeDiff = new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
+    if (timeDiff !== 0) return timeDiff;
+    const heightDiff = (b.height || 0) - (a.height || 0);
+    if (heightDiff !== 0) return heightDiff;
+    const aCreated = a.created_at ? (a.created_at instanceof Date ? a.created_at.getTime() : new Date(a.created_at).getTime()) : 0;
+    const bCreated = b.created_at ? (b.created_at instanceof Date ? b.created_at.getTime() : new Date(b.created_at).getTime()) : 0;
+    return bCreated - aCreated;
+  });
+
+  const limitedRecords = sortedRecords.slice(0, responseMaxSize);
+
+  return limitedRecords.map((record: any) => {
+    let changes = record.changes;
+    if (typeof changes === "string") {
+      try {
+        changes = JSON.parse(changes);
+      } catch {
+        changes = null;
+      }
+    }
+    changes = filterChangedValues(changes);
+
+    const action = getActionFromMessageType(
+      record.msg_type,
+      record.event_type,
+      record.action
+    );
+
+    let activityEntityId: string | number = entityId;
+    if (record.activity_entity_id !== undefined && record.activity_entity_id !== null) {
+      activityEntityId = record.activity_entity_id;
+    } else if (record.gfd_id !== undefined && record.gfd_id !== null) {
+      activityEntityId = record.gfd_id;
+    } else if (record.gfv_id !== undefined && record.gfv_id !== null) {
+      activityEntityId = record.gfv_id;
+    }
+
+    const activityEntityType = record.activity_entity_type || entityType;
+    const activityEntityIdStr = String(activityEntityId);
+    
+    const activityItem: any = {
+      timestamp: record.timestamp ? new Date(record.timestamp).toISOString() : null,
+      block_height: String(record.height || ""),
+      entity_type: activityEntityType,
+      entity_id: activityEntityIdStr,
+      msg: action,
+      changes: changes,
+    };
+
+    if (record.sender) {
+      activityItem.account = record.sender;
+    }
+
+    return activityItem;
+  });
+  } catch (error: any) {
+    console.error("Error in buildActivityTimeline:", error);
+    console.error("Config:", JSON.stringify(config, null, 2));
+    console.error("Options:", JSON.stringify(options, null, 2));
+    throw error;
+  }
+}

--- a/src/common/utils/query_ordering.ts
+++ b/src/common/utils/query_ordering.ts
@@ -1,0 +1,152 @@
+import { Knex } from "knex";
+
+export const ALLOWED_SORT_ATTRIBUTES = ["id", "modified", "created"] as const;
+
+export type SortAttribute = typeof ALLOWED_SORT_ATTRIBUTES[number];
+
+export interface SortOrder {
+  attribute: SortAttribute;
+  direction: "asc" | "desc";
+}
+
+interface OrderableQueryBuilder {
+  orderBy(column: string, direction?: "asc" | "desc"): any;
+}
+
+export function parseSortParameter(sortParam?: string): SortOrder[] {
+  if (!sortParam || typeof sortParam !== "string") {
+    return [];
+  }
+
+  const sortOrders: SortOrder[] = [];
+  const attributes = sortParam.split(",").map((attr) => attr.trim()).filter(Boolean);
+
+  for (const attr of attributes) {
+    let attribute: string;
+    let direction: "asc" | "desc";
+
+    if (attr.startsWith("-")) {
+      attribute = attr.substring(1);
+      direction = "desc";
+    } else if (attr.startsWith("+")) {
+      attribute = attr.substring(1);
+      direction = "asc";
+    } else {
+      attribute = attr;
+      direction = "asc";
+    }
+
+    if (!ALLOWED_SORT_ATTRIBUTES.includes(attribute as SortAttribute)) {
+      throw new Error(
+        `Invalid sort attribute: "${attribute}". Allowed attributes are: ${ALLOWED_SORT_ATTRIBUTES.join(", ")}`
+      );
+    }
+
+    sortOrders.push({
+      attribute: attribute as SortAttribute,
+      direction,
+    });
+  }
+
+  return sortOrders;
+}
+
+export function applyOrdering<T extends OrderableQueryBuilder>(
+  queryBuilder: T,
+  sortParam?: string,
+  tablePrefix: string = ""
+): T {
+  const sortOrders = parseSortParameter(sortParam);
+  let hasIdInSort = false;
+  let resultQuery = queryBuilder;
+
+  for (const { attribute, direction } of sortOrders) {
+    const columnName = `${tablePrefix}${attribute}`;
+    resultQuery = resultQuery.orderBy(columnName, direction) as T;
+    
+    if (attribute === "id") {
+      hasIdInSort = true;
+    }
+  }
+
+  if (!hasIdInSort) {
+    const idColumnName = `${tablePrefix}id`;
+    resultQuery = resultQuery.orderBy(idColumnName, "desc") as T;
+  }
+
+  return resultQuery;
+}
+
+export function sortByStandardAttributes<T>(
+  items: T[],
+  sortParam: string | undefined,
+  opts: {
+    getId: (item: T) => string | number;
+    getCreated?: (item: T) => string | Date | undefined | null;
+    getModified?: (item: T) => string | Date | undefined | null;
+    defaultAttribute?: SortAttribute;
+    defaultDirection?: "asc" | "desc";
+  }
+): T[] {
+  const sortOrders = sortParam ? parseSortParameter(sortParam) : [];
+  const hasCustomSort = sortOrders.length > 0;
+
+  const effectiveDefaultAttr: SortAttribute = opts.defaultAttribute || "modified";
+  const effectiveDefaultDir: "asc" | "desc" = opts.defaultDirection || "asc";
+
+  return items.sort((a, b) => {
+    const getDateMs = (v: string | Date | undefined | null): number => {
+      if (!v) return 0;
+      if (v instanceof Date) return v.getTime();
+      const d = new Date(v);
+      return Number.isNaN(d.getTime()) ? 0 : d.getTime();
+    };
+
+    const applyOne = (attribute: SortAttribute, direction: "asc" | "desc"): number => {
+      let av: number | string = 0;
+      let bv: number | string = 0;
+
+      if (attribute === "id") {
+        av = String(opts.getId(a));
+        bv = String(opts.getId(b));
+      } else if (attribute === "created") {
+        av = getDateMs(opts.getCreated ? opts.getCreated(a) : undefined);
+        bv = getDateMs(opts.getCreated ? opts.getCreated(b) : undefined);
+      } else if (attribute === "modified") {
+        av = getDateMs(opts.getModified ? opts.getModified(a) : undefined);
+        bv = getDateMs(opts.getModified ? opts.getModified(b) : undefined);
+      }
+
+      let cmp = 0;
+      if (typeof av === "number" && typeof bv === "number") {
+        cmp = av - bv;
+      } else {
+        cmp = String(av).localeCompare(String(bv));
+      }
+
+      if (cmp === 0) return 0;
+      return direction === "asc" ? cmp : -cmp;
+    };
+
+    for (const { attribute, direction } of sortOrders) {
+      const c = applyOne(attribute, direction);
+      if (c !== 0) return c;
+    }
+
+    if (!hasCustomSort) {
+      const c = applyOne(effectiveDefaultAttr, effectiveDefaultDir);
+      if (c !== 0) return c;
+    }
+
+    return applyOne("id", "desc");
+  });
+}
+
+export function validateSortParameter(sortParam?: string): boolean {
+  if (!sortParam) {
+    return true;
+  }
+
+  parseSortParameter(sortParam);
+  return true;
+}

--- a/src/services/api/api.service.ts
+++ b/src/services/api/api.service.ts
@@ -106,6 +106,9 @@ async function parseAtBlockHeight(
   }
 
   ctx.meta.blockHeight = parsedHeight;
+  ctx.meta.$headers = ctx.meta.$headers || {};
+  ctx.meta.$headers["at-block-height"] = String(parsedHeight);
+  ctx.meta.$headers["At-Block-Height"] = String(parsedHeight);
 }
 
 function isTemporaryError(errorMessage: string): boolean {

--- a/src/services/crawl-td/td_processor.service.ts
+++ b/src/services/crawl-td/td_processor.service.ts
@@ -1,5 +1,5 @@
 import { Action, Service } from '@ourparentcenter/moleculer-decorators-extended';
-import { ServiceBroker } from 'moleculer';
+import { Context, ServiceBroker } from 'moleculer';
 import config from '../../config.json' with { type: 'json' };
 import BullableService from '../../base/bullable.service';
 import { BULL_JOB_NAME, SERVICE, TrustDepositEventType } from '../../common';
@@ -138,7 +138,7 @@ export default class CrawlTrustDepositService extends BullableService {
       
       try {
         for (const block of nextBlocks) {
-          await this.processBlockEvents(block);
+          await this.processBlockEventsInternal(block);
           
           if (this._isFreshStart) {
           await delay(processDelay);
@@ -181,7 +181,13 @@ export default class CrawlTrustDepositService extends BullableService {
     }
   }
 
-  private async processBlockEvents(block: Block) {
+  @Action({ name: 'processBlockEvents' })
+  public async processBlockEvents(ctx: Context<{ block: Block }>) {
+    const { block } = ctx.params;
+    return await this.processBlockEventsInternal(block);
+  }
+
+  private async processBlockEventsInternal(block: Block) {
     const blockResult = block.data?.block_result;
     if (!blockResult) return;
 

--- a/src/services/crawl-tr/tr_history.service.ts
+++ b/src/services/crawl-tr/tr_history.service.ts
@@ -16,101 +16,62 @@ export default class TrustRegistryHistoryService extends BaseService {
   }
 
   @Action()
-  public async getTRHistory(ctx: Context<{ tr_id: number; active_gf_only?: boolean; preferred_language?: string }>) {
+  public async getTRHistory(ctx: Context<{ tr_id: number; response_max_size?: number; transaction_timestamp_older_than?: string }>) {
     try {
-      const { tr_id: trID, active_gf_only: activeGFOnly, preferred_language: preferredLanguage } = ctx.params;
+      const { tr_id: trId, response_max_size: responseMaxSize = 64, transaction_timestamp_older_than: transactionTimestampOlderThan } = ctx.params;
+      const atBlockHeight = (ctx.meta as any)?.$headers?.["at-block-height"] || (ctx.meta as any)?.$headers?.["At-Block-Height"];
 
-      const tr = await knex("trust_registry").where("id", trID).first();
+      const tr = await knex("trust_registry").where("id", trId).first();
       if (!tr) return ApiResponder.error(ctx, "Trust Registry not found", 404);
 
-      const trHistoryRows = await knex("trust_registry_history")
-        .where("tr_id", trID)
-        .orderBy("id", "asc");
-
-      let versionQuery = knex("governance_framework_version").where("tr_id", trID).orderBy("version", "asc");
-      if (activeGFOnly) versionQuery = versionQuery.where("version", tr.active_version);
-      const versions = await versionQuery;
-
-      const resultVersions: any[] = [];
-
-      for (const version of versions) {
-        const versionHistory = await knex("governance_framework_version_history")
-          .where({ tr_id: trID, version: version.version })
-          .orderBy("id", "asc");
-
-        let docsQuery = knex("governance_framework_document").where("gfv_id", version.id);
-        if (preferredLanguage) docsQuery = docsQuery.where("language", preferredLanguage);
-        let docs = await docsQuery.orderBy("created", "asc");
-
-        if (preferredLanguage && docs.length === 0) {
-          docs = await knex("governance_framework_document").where("gfv_id", version.id).orderBy("created", "asc");
+      const { buildActivityTimeline } = await import("../../common/utils/activity_timeline_helper");
+      const activity = await buildActivityTimeline(
+        {
+          entityType: "TrustRegistry",
+          historyTable: "trust_registry_history",
+          idField: "tr_id",
+          entityId: trId,
+          msgTypePrefixes: ["/verana.tr.v1", "/veranablockchain.trustregistry"],
+          relatedEntities: [
+            {
+              entityType: "GovernanceFrameworkVersion",
+              historyTable: "governance_framework_version_history",
+              idField: "tr_id",
+              entityIdField: "gfv_id",
+              msgTypePrefixes: ["/verana.tr.v1", "/veranablockchain.trustregistry"],
+            },
+            {
+              entityType: "GovernanceFrameworkDocument",
+              historyTable: "governance_framework_document_history",
+              idField: "tr_id",
+              entityIdField: "gfd_id",
+              msgTypePrefixes: ["/verana.tr.v1", "/veranablockchain.trustregistry"],
+            },
+          ],
+        },
+        {
+          responseMaxSize,
+          transactionTimestampOlderThan,
+          atBlockHeight,
         }
+      );
 
-        const docHistories = await knex("governance_framework_document_history")
-          .where("gfv_id", version.id)
-          .orderBy("id", "asc");
-
-        const docsWithHistory = docs.map((doc: any) => ({
-          id: doc.id,
-          gfv_id: doc.gfv_id,
-          created: doc.created,
-          language: doc.language,
-          url: doc.url,
-          digest_sri: doc.digest_sri,
-          changes: docHistories
-            .filter((dh: any) => dh.gfv_id === version.id && dh.url === doc.url)
-            .map((dh: any) => ({
-              event_type: dh.event_type,
-              height: dh.height,
-              changes: dh.changes,
-              created: dh.created,
-            })),
-        }));
-
-        resultVersions.push({
-          id: version.id,
-          tr_id: version.tr_id,
-          created: version.created,
-          version: version.version,
-          active_since: version.active_since,
-          changes: version.changes,
-          history: versionHistory.map((vh: any) => ({
-            event_type: vh.event_type,
-            height: vh.height,
-            changes: vh.changes,
-            created: vh.created,
-            active_since: vh.active_since,
-          })),
-          documents: docsWithHistory,
-        });
-      }
-
-      const response = {
-        id: tr.id,
-        did: tr.did,
-        controller: tr.controller,
-        created: tr.created,
-        modified: tr.modified,
-        archived: tr.archived,
-        deposit: tr.deposit,
-        aka: tr.aka,
-        language: tr.language,
-        active_version: tr.active_version,
-        changes: tr.changes,
-        history: trHistoryRows.map((h: any) => ({
-          event_type: h.event_type,
-          height: h.height,
-          changes: h.changes,
-          created: h.created,
-          modified: h.modified,
-        })),
-        versions: resultVersions,
+      const result = {
+        entity_type: "TrustRegistry",
+        entity_id: String(trId),
+        activity: activity || [],
       };
 
-      return ApiResponder.success(ctx, { trust_registry: response });
+      return ApiResponder.success(ctx, result, 200);
     } catch (err: any) {
-      this.logger.error("Error fetching TR history", err);
-      return ApiResponder.error(ctx, "Internal Server Error", 500);
+      this.logger.error("Error fetching TR history:", err);
+      this.logger.error("Error stack:", err?.stack);
+      this.logger.error("Error details:", {
+        message: err?.message,
+        code: err?.code,
+        name: err?.name,
+      });
+      return ApiResponder.error(ctx, `Failed to get Trust Registry history: ${err?.message || "Unknown error"}`, 500);
     }
   }
 }

--- a/test/unit/services/crawl-cs/cs_database.spec.ts
+++ b/test/unit/services/crawl-cs/cs_database.spec.ts
@@ -143,10 +143,16 @@ describe("CredentialSchemaDatabaseService API Integration Tests", () => {
 
   it("should get history records for the schema", async () => {
     const res = await broker.call(`${serviceKey}.getHistory`, { id: schema.id });
-    const history = res?.schema?.history;
-
-    expect(Array.isArray(history)).toBe(true);
-    expect(history.length).toBeGreaterThan(0);
-    expect(history[0].credential_schema_id).toBe(schema.id);
+    
+    expect(res).toBeDefined();
+    expect(res.entity_type).toBe("CredentialSchema");
+    expect(res.entity_id).toBe(String(schema.id));
+    expect(Array.isArray(res.activity)).toBe(true);
+    expect(res.activity.length).toBeGreaterThan(0);
+    expect(res.activity[0].timestamp).toBeDefined();
+    expect(res.activity[0].block_height).toBeDefined();
+    expect(res.activity[0].entity_type).toBe("CredentialSchema");
+    expect(res.activity[0].entity_id).toBe(String(schema.id));
+    expect(res.activity[0].msg).toBeDefined();
   });
 });


### PR DESCRIPTION
This PR adds the feature from issue #95:

**Changes:**
- The `/verana/**/history/{id}` API now returns results sorted by timestamp, newest first.
- Updated the response to match the requirements in the issue.
