### PR TITLE
fix: resolve intermittent 502 errors with health probes and resilience

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,11 +66,12 @@
     #### Request time out ####
     REQUEST_TIMEOUT=300000
 
-    #### Retry plicy settings ####
-    RETRYPOLICY=false
-    RETRIES=5
+    #### Retry policy settings ####
+    # Set to false to disable retry policy (default: true for stability)
+    # RETRYPOLICY=false
+    RETRIES=3
     RETRYDELAY=100
-    RETRYMAXDELAY=1000
+    RETRYMAXDELAY=2000
     RETRYFACTOR=2
 
     #### Max call level ####
@@ -95,16 +96,20 @@
     PREFERLOCAL=true
 
     #### Circuit breaker settings ####
-    BREAKER_ENABLED=false
+    # Circuit breaker prevents cascading failures by stopping requests to failing services
+    # Set to false to disable (default: true for stability)
+    # BREAKER_ENABLED=false
     BREAKERTHRESHOLD=0.5
-    BREAKERMINREQCOUNT=20
-    WINDOWTIME=60
-    HALFOPENTIME=10
+    BREAKERMINREQCOUNT=10
+    WINDOWTIME=30
+    HALFOPENTIME=5
 
     #### Bulkhead settings ####
-    BULKHEAD_ENABLED=false
-    CONCURRENCY=10
-    MAXQUEUESIZE=100
+    # Bulkhead isolates failing services to prevent them from affecting others
+    # Set to false to disable (default: true for stability)
+    # BULKHEAD_ENABLED=false
+    CONCURRENCY=50
+    MAXQUEUESIZE=200
 
     #### Validator ####
     VALIDATOR_ENABLED=true

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -31,6 +31,15 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/enable-cors: "{{ .Values.ingress.public.enableCors | default "true" }}"
+    # Timeout settings to match application timeouts and prevent 502 errors
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "{{ .Values.nginx.connectTimeout | default "30" }}"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "{{ .Values.nginx.readTimeout | default "300" }}"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "{{ .Values.nginx.sendTimeout | default "300" }}"
+    nginx.ingress.kubernetes.io/proxy-body-size: "{{ .Values.nginx.bodySize | default "10m" }}"
+    # Retry settings for transient failures
+    nginx.ingress.kubernetes.io/proxy-next-upstream: "error timeout http_502 http_503 http_504"
+    nginx.ingress.kubernetes.io/proxy-next-upstream-tries: "3"
+    nginx.ingress.kubernetes.io/proxy-next-upstream-timeout: "10"
 spec:
   ingressClassName: nginx
   tls:
@@ -152,6 +161,44 @@ spec:
 {{- end }}
             ports:
             -  containerPort: {{ .Values.apiPort }}
+            # Liveness probe - checks if the process is alive (simple health check)
+            livenessProbe:
+              httpGet:
+                path: /health/live
+                port: {{ .Values.apiPort }}
+              initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds | default 30 }}
+              periodSeconds: {{ .Values.probes.liveness.periodSeconds | default 15 }}
+              timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds | default 5 }}
+              failureThreshold: {{ .Values.probes.liveness.failureThreshold | default 3 }}
+              successThreshold: 1
+            # Readiness probe - checks if service can receive traffic
+            readinessProbe:
+              httpGet:
+                path: /health/ready
+                port: {{ .Values.apiPort }}
+              initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds | default 15 }}
+              periodSeconds: {{ .Values.probes.readiness.periodSeconds | default 10 }}
+              timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds | default 5 }}
+              failureThreshold: {{ .Values.probes.readiness.failureThreshold | default 3 }}
+              successThreshold: 1
+            # Startup probe - allows slow startup without killing the container
+            startupProbe:
+              httpGet:
+                path: /health/live
+                port: {{ .Values.apiPort }}
+              initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds | default 10 }}
+              periodSeconds: {{ .Values.probes.startup.periodSeconds | default 5 }}
+              timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds | default 5 }}
+              failureThreshold: {{ .Values.probes.startup.failureThreshold | default 30 }}
+              successThreshold: 1
+            # Resource limits to prevent OOM and ensure stability
+            resources:
+              requests:
+                cpu: {{ .Values.resources.requests.cpu | default "250m" }}
+                memory: {{ .Values.resources.requests.memory | default "512Mi" }}
+              limits:
+                cpu: {{ .Values.resources.limits.cpu | default "1000m" }}
+                memory: {{ .Values.resources.limits.memory | default "4Gi" }}
         {{- if .Values.database.enabled }}
          -  name: postgres
             image: postgres:14-alpine

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,5 +1,5 @@
 # Global configuration for the application
-global: 
+global:
   domain: testnet.verana.network # Domain for the application
 
 # General configuration
@@ -9,14 +9,40 @@ replicas: 1 # Number of replicas for the Indexer service
 # Ports
 apiPort: 3001
 
-#FIXME: Limit resources as soon as we can calculate requirements (especially for db migration at startup)
-#resources:
-#  requests:
-#    cpu: 250m
-#    memory: 512Mi
-#  limits:
-#    cpu: 500m
-#    memory: 1Gi
+# Resource limits for the indexer container
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: 1000m
+    memory: 4Gi
+
+# Nginx ingress timeout settings (in seconds)
+# These should match or exceed the application's request timeout
+nginx:
+  connectTimeout: "30"
+  readTimeout: "300"    # 5 minutes - matches Moleculer's REQUEST_TIMEOUT
+  sendTimeout: "300"
+  bodySize: "10m"
+
+# Health check probes configuration
+probes:
+  liveness:
+    initialDelaySeconds: 30  # Wait for service to start
+    periodSeconds: 15        # Check every 15 seconds
+    timeoutSeconds: 5        # Timeout for probe
+    failureThreshold: 3      # Restart after 3 failures
+  readiness:
+    initialDelaySeconds: 15  # Shorter initial delay
+    periodSeconds: 10        # Check every 10 seconds
+    timeoutSeconds: 5        # Timeout for probe
+    failureThreshold: 3      # Remove from LB after 3 failures
+  startup:
+    initialDelaySeconds: 10  # Start checking early
+    periodSeconds: 5         # Check frequently during startup
+    timeoutSeconds: 5        # Timeout for probe
+    failureThreshold: 30     # Allow up to 150 seconds (30*5) for startup
 
 # DB and Redis configuration
 database:

--- a/src/moleculer.config.ts
+++ b/src/moleculer.config.ts
@@ -87,17 +87,18 @@ const brokerConfig: BrokerOptions = {
   requestTimeout: +(Config.REQUEST_TIMEOUT || process.env.REQUEST_TIMEOUT || 300000), // 5 minutes default
 
   // Retry policy settings. More info: https://moleculer.services/docs/0.14/fault-tolerance.html#Retry
+  // Retry policy automatically retries failed requests for transient errors
   retryPolicy: {
-    // Enable feature
-    enabled: Config.RETRYPOLICY,
+    // Enable feature - default to true for production stability
+    enabled: Config.RETRYPOLICY !== false,
     // Count of retries
-    retries: Config.RETRIES,
+    retries: Config.RETRIES || 3,
     // First delay in milliseconds.
-    delay: Config.RETRYDELAY,
+    delay: Config.RETRYDELAY || 100,
     // Maximum delay in milliseconds.
-    maxDelay: Config.RETRYMAXDELAY,
+    maxDelay: Config.RETRYMAXDELAY || 2000,
     // Backoff factor for delay. 2 means exponential backoff.
-    factor: Config.RETRYFACTOR,
+    factor: Config.RETRYFACTOR || 2,
     // A function to check failed requests.
     check: (err: Error): boolean =>
       err && err instanceof MoleculerRetryableError && !!err.retryable,
@@ -135,30 +136,32 @@ const brokerConfig: BrokerOptions = {
   },
 
   // Settings of Circuit Breaker. More info: https://moleculer.services/docs/0.14/fault-tolerance.html#Circuit-Breaker
+  // Circuit breaker helps prevent cascading failures by stopping requests to failing services
   circuitBreaker: {
-    // Enable feature
-    enabled: Config.BREAKER_ENABLED || false,
+    // Enable feature - default to true for production stability
+    enabled: Config.BREAKER_ENABLED !== false,
     // Threshold value. 0.5 means that 50% should be failed for tripping.
     threshold: Config.BREAKERTHRESHOLD || 0.5,
     // Minimum request count. Below it, CB does not trip.
-    minRequestCount: Config.BREAKERMINREQCOUNT || 20,
+    minRequestCount: Config.BREAKERMINREQCOUNT || 10,
     // Number of seconds for time window.
-    windowTime: Config.WINDOWTIME || 60,
+    windowTime: Config.WINDOWTIME || 30,
     // Number of milliseconds to switch from open to half-open state
-    halfOpenTime: Config.HALFOPENTIME || 10 * 1000,
+    halfOpenTime: Config.HALFOPENTIME || 5 * 1000,
     // A function to check failed requests.
     check: (err: Error): boolean =>
       err && err instanceof MoleculerRetryableError && err.code >= 500,
   },
 
   // Settings of bulkhead feature. More info: https://moleculer.services/docs/0.14/fault-tolerance.html#Bulkhead
+  // Bulkhead isolates failing services and prevents them from affecting others
   bulkhead: {
-    // Enable feature.
-    enabled: Config.BULKHEAD_ENABLED || false,
-    // Maximum concurrent executions.
-    concurrency: Config.CONCURRENCY || 10,
-    // Maximum size of queue
-    maxQueueSize: Config.MAXQUEUESIZE || 100,
+    // Enable feature - default to true for production stability
+    enabled: Config.BULKHEAD_ENABLED !== false,
+    // Maximum concurrent executions per action.
+    concurrency: Config.CONCURRENCY || 50,
+    // Maximum size of queue - requests will wait in queue if concurrency limit is reached
+    maxQueueSize: Config.MAXQUEUESIZE || 200,
   },
 
   // Enable action & event parameter validation. More info: https://moleculer.services/docs/0.14/validating.html


### PR DESCRIPTION
## Summary

This PR resolves the intermittent 502 Bad Gateway errors reported by LotharKing that caused the frontend "My Ecosystems" page to crash with JSON parse errors when the indexer returned HTML error pages instead of JSON.

**Root Causes Identified:**
- Missing Kubernetes health probes allowed unhealthy pods to receive traffic
- Nginx timeout mismatch (60s default vs 5-minute app timeout) caused premature connection termination
- Resilience features (circuit breaker, retry, bulkhead) were disabled by default
- No DB query caching caused high database load during traffic spikes

**Changes:**
- Add liveness, readiness, and startup health probes (`/health/live`, `/health/ready`, `/health`)
- Configure nginx ingress timeouts aligned with application (300s)
- Enable circuit breaker, retry policy, and bulkhead patterns by default
- Add checkpoint caching with race condition protection (promise memoization)
- Add pod resource limits and requests for stability
- Add nginx retry-on-502/503/504 annotations

## Test Plan

- [x] Local testing: All health endpoints return HTTP 200
  - `/health/live` → `{"status":"ok","timestamp":"..."}`
  - `/health/ready` → `{"status":"ok","ready":true,"indexer":"running",...}`
  - `/health` → `{"status":"ok","service":"verana-indexer",...}`
- [x] Code review by multiple agents (no critical issues remaining)
- [ ] Deploy to staging and verify no 502 errors
- [ ] Monitor `/health/ready` endpoint in Kubernetes
- [ ] Verify "My Ecosystems" page loads without JSON parse errors

## Files Changed

| File | Changes |
|------|---------|
| `src/services/api/api.service.ts` | Health endpoints, checkpoint caching |
| `src/moleculer.config.ts` | Enable circuit breaker, retry, bulkhead |
| `charts/templates/deployment.yaml` | Health probes, nginx annotations, resources |
| `charts/values.yaml` | Configuration values for probes/resources |
| `src/common/utils/health_check.ts` | Enhanced health check utilities |
| `.env.example` | Documentation updates |

## Related Issues

Fixes the issue reported by LotharKing on Discord (502 errors on `/verana/cs/v1/get/38`)