### PR TITLE
chore: align release please version

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,7 @@
   "include-v-in-tag": true,
   "separate-pull-requests": true,
   "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": false,
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
Based on https://github.com/verana-labs/verana-frontend/pull/178/commits/671d24fa55e5348fdc9c37abc0cb2dd9a873cd31.
When `release please` version starts on 0.x version not upgrade minor version with `feat` and must require `feat!` to increase a major version, but in this case, the dev version is 1.x, so it is required for consistency.
This has been included on https://github.com/verana-labs/verana-frontend/pull/178 (For verana frontend)