### PR TITLE
feat: add reindex job for k8s deployment

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -152,6 +152,64 @@ helm upgrade --install idx ./verana-indexer-chart \
   --set resources.limits.memory=512Mi
 ```
 
+## Reindexing
+
+When you need to re-process all blocks from the beginning (e.g., after schema changes or data fixes), use the built-in reindex support instead of manually changing commands.
+
+### How it works
+
+1. A **pre-upgrade Helm hook Job** runs `pnpm reindex:prepare`, which:
+   - Drops module tables (transaction, accounts, DIDs, etc.)
+   - Resets all service checkpoints to 0
+   - Runs migrations to recreate tables
+   - Resets ID sequences
+   - Preserves the `block` table (blocks are NOT re-fetched from RPC)
+2. The Job connects to the DB via the K8s Service name (not localhost)
+3. After the Job succeeds, the StatefulSet rolls out normally
+4. `pnpm start` picks up from the reset checkpoints and re-processes all blocks
+
+### Configuration
+
+| Parameter                          | Description                              | Default |
+| ---------------------------------- | ---------------------------------------- | ------- |
+| `reindex.enabled`                  | Enable the pre-upgrade reindex Job       | `false` |
+| `reindex.resources.requests.cpu`   | CPU request for the Job                  | `100m`  |
+| `reindex.resources.requests.memory`| Memory request for the Job               | `256Mi` |
+| `reindex.resources.limits.cpu`     | CPU limit for the Job                    | `500m`  |
+| `reindex.resources.limits.memory`  | Memory limit for the Job                 | `512Mi` |
+| `reindex.backoffLimit`             | Number of retries before marking failed  | `3`     |
+| `reindex.activeDeadlineSeconds`    | Timeout for the Job                      | `600`   |
+
+### Usage
+
+**Trigger a reindex:**
+
+```bash
+helm upgrade --set reindex.enabled=true <release> <chart> -n <namespace>
+```
+
+**After the upgrade completes, disable reindex for future upgrades:**
+
+```bash
+helm upgrade --set reindex.enabled=false <release> <chart> -n <namespace>
+```
+
+> **Important:** If you leave `reindex.enabled=true`, every subsequent `helm upgrade` will re-run the reindex Job. Always set it back to `false` after the reindex completes.
+
+### Local development
+
+For local development (outside K8s), you can still use the original commands:
+
+```bash
+# Full reindex with auto-restart (local dev)
+pnpm reindex:dev
+
+# Or just the DB reset step (no service startup)
+pnpm reindex:prepare:dev
+```
+
+---
+
 ## Usage
 
 1. Update values in your `values.yaml` file as needed.

--- a/charts/templates/reindex-job.yaml
+++ b/charts/templates/reindex-job.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.reindex.enabled }}
+# Pre-upgrade Job: resets module tables and checkpoints so the indexer
+# re-processes all blocks from the beginning on its next start.
+#
+# The Job connects to the DB via the K8s Service (not localhost) because
+# it runs in a separate pod from the StatefulSet sidecars.
+#
+# Usage:
+#   helm upgrade --set reindex.enabled=true <release> <chart>
+#
+# After the upgrade succeeds, disable it for future upgrades:
+#   helm upgrade --set reindex.enabled=false <release> <chart>
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Values.name }}-reindex-{{ .Release.Revision }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.name }}
+    component: reindex
+  annotations:
+    # Run before the StatefulSet is updated
+    helm.sh/hook: pre-upgrade
+    # Delete the Job after it succeeds (keep on failure for debugging)
+    helm.sh/hook-delete-policy: hook-succeeded
+    # Run before other pre-upgrade hooks (weight -5)
+    helm.sh/hook-weight: "-5"
+spec:
+  backoffLimit: {{ .Values.reindex.backoffLimit | default 3 }}
+  activeDeadlineSeconds: {{ .Values.reindex.activeDeadlineSeconds | default 600 }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.name }}
+        component: reindex
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: reindex-prepare
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.Version }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["sh", "-c", "pnpm reindex:prepare"]
+          {{- if .Values.reindex.resources }}
+          resources:
+{{- toYaml .Values.reindex.resources | nindent 12 }}
+          {{- end }}
+          env:
+            - name: NODE_ENV
+              value: production
+            # Connect to DB via the K8s Service name (not localhost),
+            # since this Job runs in a separate pod from the DB sidecar.
+            - name: POSTGRES_HOST
+              value: {{ .Values.name }}
+            - name: POSTGRES_USER
+              value: {{ .Values.database.user }}
+{{- if .Values.database.pwd }}
+            - name: POSTGRES_PASSWORD
+              value: {{ .Values.database.pwd }}
+{{- else if .Values.database.pwdSecret }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.pwdSecret.name }}
+                  key: {{ .Values.database.pwdSecret.key }}
+{{- end }}
+            - name: POSTGRES_DB
+              value: {{ .Values.database.db }}
+            # Redis is needed for BullMQ queue cleanup (if applicable)
+            - name: QUEUE_JOB_REDIS
+              value: redis://{{ .Values.name }}:6379
+{{- with .Values.extraEnv }}
+{{- toYaml . | nindent 12 }}
+{{- end }}
+{{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -27,7 +27,10 @@ resources:
     memory: 4Gi
 
 # Node.js memory settings (should be ~75% of memory limit)
-nodeOptions: "--max-old-space-size=3072"
+# --max-semi-space-size=64: critical for GC — prevents short-lived objects from
+#   being promoted to old generation too fast during heavy processing
+# --expose-gc: allows the memory guard to trigger manual GC when heap is high
+nodeOptions: "--max-old-space-size=3072 --max-semi-space-size=64 --expose-gc"
 
 # DB and Redis configuration
 database:
@@ -77,6 +80,30 @@ ingress:
     whitelistSourceRange: "" # e.g. "xxx.xx.xxx.xxx/32"
     tlsSecret: "private.{{ .Values.name }}.{{ .Values.global.domain }}-cert"
     host: ""
+
+# Reindex configuration
+# When enabled, a pre-upgrade Job runs `pnpm reindex:prepare` to reset module
+# tables and checkpoints before the indexer starts. The indexer (pnpm start)
+# then re-processes all blocks from the beginning using existing block data.
+#
+# Usage:
+#   helm upgrade --set reindex.enabled=true <release> <chart>
+#
+# After the upgrade completes, disable it for subsequent upgrades:
+#   helm upgrade --set reindex.enabled=false <release> <chart>
+reindex:
+  enabled: false
+  # Resource limits for the reindex Job (DB reset is lightweight)
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  # Timeout in seconds for the reindex Job to complete
+  backoffLimit: 3
+  activeDeadlineSeconds: 600
 
 # Extra environment variables for the indexer container.
 # Accepts any valid Kubernetes env entry (value, valueFrom, secretKeyRef, etc.)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "migrate:dev": "cross-env NODE_OPTIONS=\"--import=tsx\" node ./src/scripts/migrate-if-needed.ts",
     "reindex": "pnpm run build && cross-env NODE_OPTIONS=\" --expose-gc\" node dist/src/scripts/reindex-with-restart.js",
     "reindex:dev": "cross-env NODE_OPTIONS=\"--import=tsx  --expose-gc\" node ./src/scripts/reindex-with-restart.ts",
+    "reindex:prepare": "node dist/src/scripts/reindex-modules.js",
+    "reindex:prepare:dev": "cross-env NODE_OPTIONS=\"--import=tsx\" node ./src/scripts/reindex-modules.ts",
     "build": "pnpm run clean && tsc --project tsconfig.build.json && node ./src/scripts/fix-imports.cjs",
     "up": "docker-compose -f ./docker/docker-compose.yml up -d",
     "stop": "docker-compose -f ./docker/docker-compose.yml stop",


### PR DESCRIPTION
In order to make easier the reindexing process in our deployments, we divide it in two steps: DB preparation and the reindexing itself. 

We add here a Helm pre-upgrade hook Job that runs `pnpm reindex:prepare` before the StatefulSet rolls out. Connects to DB via K8s Service name (not localhost). Only created when `reindex.enabled=true`.

So the workflow would be: 

```bash
# Trigger reindex on next upgrade
helm upgrade --set reindex.enabled=true <release> <chart> -n <namespace>

# After it completes, disable for future upgrades
helm upgrade --set reindex.enabled=false <release> <chart> -n <namespace>
```

And the logic behind it is:

1. Pre-upgrade Job runs: drops module tables, resets checkpoints, runs migrations
2. Job succeeds: StatefulSet rolls out with new image
3. `pnpm start` picks up from reset checkpoints: re-processes all blocks using existing block data
4. K8s `restartPolicy` handles any OOM crashes naturally (no custom restart wrapper needed)

Previous reindexing scripts (e.g. pnpm reindex:dev) still work.
