### PR TITLE
feat: implement DID-based event system for WebSocket and VS Agent integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,28 +468,11 @@ For detailed information about the reindexing process, architecture, and trouble
 
 ## Real-Time Event API (WebSocket)
 
-The Verana Indexer provides a **WebSocket** endpoint that broadcasts real-time notifications when blocks are processed. This eliminates the need for polling and enables frontend applications to react immediately when new data becomes available.
+The same WebSocket path supports the legacy global stream and the DID-specific room.
 
-### Endpoint
+**All events:** `ws://localhost:3001/verana/indexer/v1/events`
 
-**WebSocket:** `ws://localhost:3001/verana/indexer/v1/events`
-
-> **Note:** This is a WebSocket endpoint, not an HTTP endpoint. Connect using a WebSocket client, not a regular HTTP GET request.
-
-### Use Case
-
-When a frontend application submits a transaction to the blockchain (e.g., creating a DID), it needs to know when the indexer has processed that transaction's block so it can refresh its data. Instead of polling the indexer every few seconds, the application can subscribe to the events endpoint and receive immediate notifications.
-
-**Example Flow:**
-1. Frontend submits transaction to blockchain (e.g., `MsgAddDID`)
-2. Frontend receives transaction hash and block height from blockchain
-3. Frontend subscribes to indexer events endpoint
-4. When indexer processes the block, frontend receives notification
-5. Frontend queries indexer API to get updated data (e.g., `/verana/dd/v1/list`)
-
-### Message Format
-
-All messages are JSON strings with the following structure:
+Use this mode for the original indexer heartbeat flow. It sends `connected` first, then the legacy `block-processed` object whenever a block is processed. The `block-processed` object shape is kept backward compatible:
 
 ```json
 {
@@ -499,62 +482,63 @@ All messages are JSON strings with the following structure:
 }
 ```
 
-**Event Type:**
-- `block-processed` - Sent whenever a new block is successfully processed by the indexer. The `height` field contains the latest processed block height.
+**DID room:** `ws://localhost:3001/verana/indexer/v1/events?did=<DID>`
 
-### Quick Test
+Use this mode for DID-specific integrations such as VS Agent. The DID room sends `connected` with `did` and `blockHeight`, then live persisted `indexer-event` messages for that DID only. Live DID events are emitted after they are persisted, with one persisted row per affected DID.
 
-**Test the WebSocket connection:**
-
-```bash
-# Run the test script (make sure indexer is running first)
-node --import=tsx test/manual/test-websocket.ts
-```
-
-You should see:
-```
-✅ Connected to Verana Indexer Events WebSocket
-Waiting for block-processed events...
-```
-
-When a block is processed, you'll see:
-```
-📦 Received event: {
-  "type": "block-processed",
-  "height": 123456,
+```json
+{
+  "type": "connected",
+  "did": "did:web:agent.example",
+  "blockHeight": 123456,
   "timestamp": "2025-01-15T10:30:00Z"
 }
-
-🎉 New block processed! Height: 123456, Time: 2025-01-15T10:30:00Z
 ```
 
-### Usage
+```json
+{
+  "type": "indexer-event",
+  "eventType": "StartPermissionVP",
+  "did": "did:web:agent.example",
+  "blockHeight": 123457,
+  "txHash": "A1B2C3",
+  "timestamp": "2025-01-15T10:31:00Z",
+  "payload": {
+    "module": "permission",
+    "messageType": "/verana.perm.v1.MsgStartPermissionVP",
+    "relatedDids": ["did:web:agent.example"]
+  }
+}
+```
 
+Replay missed DID events:
+
+```bash
+curl "http://localhost:3001/verana/indexer/v1/events?did=did:web:agent.example&after_block_height=123456&limit=100"
+```
+
+Manual checks:
+
+```bash
+node --import=tsx test/manual/test-websocket.ts
+DID=did:web:agent.example AFTER_BLOCK_HEIGHT=123456 node --import=tsx test/manual/test-websocket-did-room.ts
+```
+
+Client example:
 
 ```javascript
-const ws = new WebSocket('wss://idx.testnet.verana.network/verana/indexer/v1/events');
+const did = 'did:web:agent.example';
+const ws = new WebSocket(`wss://idx.testnet.verana.network/verana/indexer/v1/events?did=${encodeURIComponent(did)}`);
 
-ws.onopen = () => {
-  console.log('Connected to Verana Indexer Events');
-};
-
-ws.onmessage = (event) => {
+ws.onmessage = async (event) => {
   const data = JSON.parse(event.data);
-  
-  if (data.type === 'block-processed') {
-    console.log(`Block ${data.height} processed at ${data.timestamp}`);
-    
-    if (data.height >= expectedBlockHeight) {
-      fetchUpdatedData();
-    }
+
+  if (data.type === 'connected') {
+    await fetch(`/verana/indexer/v1/events?did=${encodeURIComponent(did)}&after_block_height=${lastSeenBlockHeight}`);
   }
-};
 
-ws.onerror = (error) => {
-  console.error('WebSocket error:', error);
-};
-
-ws.onclose = () => {
-  console.log('WebSocket connection closed');
+  if (data.type === 'indexer-event') {
+    console.log(data.eventType, data.blockHeight, data.payload);
+  }
 };
 ```

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -72,6 +72,109 @@
         }
       }
     },
+    "/verana/indexer/v1/events": {
+      "get": {
+        "tags": [
+          "Indexer"
+        ],
+        "summary": "List indexer transaction events",
+        "description": "Replay persisted trust registry, credential schema, and permission indexer events after a block height. Use the did query parameter to return only events related to a DID.",
+        "operationId": "listIndexerEvents",
+        "parameters": [
+          {
+            "name": "did",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^did:[a-z0-9]+:.+"
+            },
+            "description": "DID to replay events for. Only rows persisted for this DID are returned."
+          },
+          {
+            "name": "after_block_height",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            },
+            "description": "Return events with blockHeight greater than this value."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500,
+              "default": 100
+            },
+            "description": "Maximum number of events to return."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indexer transaction events",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "events": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/IndexerTransactionEvent"
+                      }
+                    },
+                    "count": {
+                      "type": "integer"
+                    },
+                    "afterBlockHeight": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["events", "count", "afterBlockHeight"]
+                },
+                "example": {
+                  "events": [
+                    {
+                      "type": "indexer-event",
+                      "eventType": "StartPermissionVP",
+                      "did": "did:web:agent.example",
+                      "blockHeight": 1794801,
+                      "txHash": "A1B2C3",
+                      "timestamp": "2025-12-17T04:43:12Z",
+                      "payload": {
+                        "module": "permission",
+                        "action": "StartPermissionVP",
+                        "messageType": "/verana.perm.v1.MsgStartPermissionVP",
+                        "txIndex": 0,
+                        "messageIndex": 0,
+                        "sender": "did:web:agent.example",
+                        "relatedDids": ["did:web:agent.example"],
+                        "entityType": "Permission",
+                        "entityId": "42"
+                      }
+                    }
+                  ],
+                  "count": 1,
+                  "afterBlockHeight": 1794800
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          }
+        }
+      }
+    },
     "/verana/indexer/v1/version": {
       "get": {
         "tags": [
@@ -3791,6 +3894,77 @@
           }
         }
       },
+      "IndexerTransactionEvent": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["indexer-event"]
+          },
+          "eventType": {
+            "type": "string",
+            "description": "Transaction action name, such as CreateNewTrustRegistry, UpdateCredentialSchema, or StartPermissionVP."
+          },
+          "did": {
+            "type": "string"
+          },
+          "blockHeight": {
+            "type": "integer"
+          },
+          "txHash": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "payload": {
+            "type": "object",
+            "properties": {
+              "module": {
+                "type": "string",
+                "enum": ["trust-registry", "credential-schema", "permission"]
+              },
+              "action": {
+                "type": "string"
+              },
+              "messageType": {
+                "type": "string"
+              },
+              "txIndex": {
+                "type": "integer"
+              },
+              "messageIndex": {
+                "type": "integer"
+              },
+              "sender": {
+                "type": "string"
+              },
+              "relatedDids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "entityType": {
+                "type": "string"
+              },
+              "entityId": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": [
+          "type",
+          "eventType",
+          "did",
+          "blockHeight",
+          "txHash",
+          "timestamp",
+          "payload"
+        ]
+      },
       "DID": {
         "type": "object",
         "properties": {
@@ -5860,7 +6034,7 @@
       "description": "Statistics operations for querying cumulative and delta metrics across different granularities (HOUR, DAY, MONTH) and entity types (GLOBAL, TRUST_REGISTRY, CREDENTIAL_SCHEMA, PERMISSION)"
     },
     {
-      "description": "## Real-Time Event (WebSocket)\n\n**Endpoint URLs:**\n- Local: `ws://localhost:3001/verana/indexer/v1/events`\n- Devnet: `wss://idx.devnet.verana.network/verana/indexer/v1/events`\n- Testnet: `wss://idx.testnet.verana.network/verana/indexer/v1/events`\n\n**Message Format:**\n```json\n{\n  \"type\": \"block-processed\",\n  \"height\": 123456,\n  \"timestamp\": \"2025-01-15T10:30:00Z\"\n}\n```\n\n**Event Type:** `block-processed` - Sent whenever a new block is successfully processed by the indexer. The `height` field contains the latest processed block height (ISO 8601 format with 'Z' designator).\n\n**Example:**\n```javascript\nconst ws = new WebSocket('ws://localhost:3001/verana/indexer/v1/events');\nws.onmessage = (event) => {\n  const data = JSON.parse(event.data);\n  if (data.type === 'block-processed') {\n    console.log(`Block ${data.height} processed`);\n    // Now safe to query indexer API for updated data\n  }\n};\n```"
+      "description": "## WebSocket Events\n\nThe same path supports the legacy global stream and the DID-specific room.\n\n### All events\nConnect to `ws://localhost:3001/verana/indexer/v1/events` without a `did` query parameter. The first message is `connected`, followed by the legacy `block-processed` object. This object shape is kept backward compatible:\n```json\n{\n  \"type\": \"block-processed\",\n  \"height\": 123456,\n  \"timestamp\": \"2025-01-15T10:30:00Z\"\n}\n```\nRequired fields: `type`, `height`, `timestamp`.\n\n### DID room\nConnect to `ws://localhost:3001/verana/indexer/v1/events?did=<DID>`. The first message is `connected` and includes `did` and `blockHeight`. Use `GET /verana/indexer/v1/events?did=<DID>&after_block_height=<height>&limit=<n>` to replay missed persisted events.\n\nLive DID events use this shape:\n```json\n{\n  \"type\": \"indexer-event\",\n  \"eventType\": \"StartPermissionVP\",\n  \"did\": \"did:web:agent.example\",\n  \"blockHeight\": 123456,\n  \"txHash\": \"A1B2C3\",\n  \"timestamp\": \"2025-01-15T10:30:00Z\",\n  \"payload\": {\n    \"module\": \"permission\",\n    \"action\": \"StartPermissionVP\",\n    \"messageType\": \"/verana.perm.v1.MsgStartPermissionVP\",\n    \"txIndex\": 0,\n    \"messageIndex\": 0,\n    \"sender\": \"did:web:agent.example\",\n    \"relatedDids\": [\"did:web:agent.example\"],\n    \"entityType\": \"Permission\",\n    \"entityId\": \"42\"\n  }\n}\n```\nRequired fields: `type`, `eventType`, `did`, `blockHeight`, `txHash`, `timestamp`, `payload`.\n\nManual tests:\n```bash\nnode --import=tsx test/manual/test-websocket.ts\nDID=did:web:agent.example AFTER_BLOCK_HEIGHT=123456 node --import=tsx test/manual/test-websocket-did-room.ts\n```"
     }
   ]
 }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3897,6 +3897,10 @@
       "IndexerTransactionEvent": {
         "type": "object",
         "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Database id of the persisted indexer event."
+          },
           "type": {
             "type": "string",
             "enum": ["indexer-event"]

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -100,7 +100,7 @@
               "minimum": 0,
               "default": 0
             },
-            "description": "Return events with blockHeight greater than this value."
+            "description": "Return events with block_height greater than this value."
           },
           {
             "name": "limit",
@@ -132,36 +132,36 @@
                     "count": {
                       "type": "integer"
                     },
-                    "afterBlockHeight": {
+                    "after_block_height": {
                       "type": "integer"
                     }
                   },
-                  "required": ["events", "count", "afterBlockHeight"]
+                  "required": ["events", "count", "after_block_height"]
                 },
                 "example": {
                   "events": [
                     {
                       "type": "indexer-event",
-                      "eventType": "StartPermissionVP",
+                      "event_type": "StartPermissionVP",
                       "did": "did:web:agent.example",
-                      "blockHeight": 1794801,
-                      "txHash": "A1B2C3",
+                      "block_height": 1794801,
+                      "tx_hash": "A1B2C3",
                       "timestamp": "2025-12-17T04:43:12Z",
                       "payload": {
                         "module": "permission",
                         "action": "StartPermissionVP",
-                        "messageType": "/verana.perm.v1.MsgStartPermissionVP",
-                        "txIndex": 0,
-                        "messageIndex": 0,
+                        "message_type": "/verana.perm.v1.MsgStartPermissionVP",
+                        "tx_index": 0,
+                        "message_index": 0,
                         "sender": "did:web:agent.example",
-                        "relatedDids": ["did:web:agent.example"],
-                        "entityType": "Permission",
-                        "entityId": "42"
+                        "related_dids": ["did:web:agent.example"],
+                        "entity_type": "Permission",
+                        "entity_id": "42"
                       }
                     }
                   ],
                   "count": 1,
-                  "afterBlockHeight": 1794800
+                  "after_block_height": 1794800
                 }
               }
             }
@@ -3897,25 +3897,21 @@
       "IndexerTransactionEvent": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "integer",
-            "description": "Database id of the persisted indexer event."
-          },
           "type": {
             "type": "string",
             "enum": ["indexer-event"]
           },
-          "eventType": {
+          "event_type": {
             "type": "string",
             "description": "Transaction action name, such as CreateNewTrustRegistry, UpdateCredentialSchema, or StartPermissionVP."
           },
           "did": {
             "type": "string"
           },
-          "blockHeight": {
+          "block_height": {
             "type": "integer"
           },
-          "txHash": {
+          "tx_hash": {
             "type": "string"
           },
           "timestamp": {
@@ -3932,28 +3928,28 @@
               "action": {
                 "type": "string"
               },
-              "messageType": {
+              "message_type": {
                 "type": "string"
               },
-              "txIndex": {
+              "tx_index": {
                 "type": "integer"
               },
-              "messageIndex": {
+              "message_index": {
                 "type": "integer"
               },
               "sender": {
                 "type": "string"
               },
-              "relatedDids": {
+              "related_dids": {
                 "type": "array",
                 "items": {
                   "type": "string"
                 }
               },
-              "entityType": {
+              "entity_type": {
                 "type": "string"
               },
-              "entityId": {
+              "entity_id": {
                 "type": "string"
               }
             }
@@ -3961,10 +3957,10 @@
         },
         "required": [
           "type",
-          "eventType",
+          "event_type",
           "did",
-          "blockHeight",
-          "txHash",
+          "block_height",
+          "tx_hash",
           "timestamp",
           "payload"
         ]
@@ -6038,7 +6034,7 @@
       "description": "Statistics operations for querying cumulative and delta metrics across different granularities (HOUR, DAY, MONTH) and entity types (GLOBAL, TRUST_REGISTRY, CREDENTIAL_SCHEMA, PERMISSION)"
     },
     {
-      "description": "## WebSocket Events\n\nThe same path supports the legacy global stream and the DID-specific room.\n\n### All events\nConnect to `ws://localhost:3001/verana/indexer/v1/events` without a `did` query parameter. The first message is `connected`, followed by the legacy `block-processed` object. This object shape is kept backward compatible:\n```json\n{\n  \"type\": \"block-processed\",\n  \"height\": 123456,\n  \"timestamp\": \"2025-01-15T10:30:00Z\"\n}\n```\nRequired fields: `type`, `height`, `timestamp`.\n\n### DID room\nConnect to `ws://localhost:3001/verana/indexer/v1/events?did=<DID>`. The first message is `connected` and includes `did` and `blockHeight`. Use `GET /verana/indexer/v1/events?did=<DID>&after_block_height=<height>&limit=<n>` to replay missed persisted events.\n\nLive DID events use this shape:\n```json\n{\n  \"type\": \"indexer-event\",\n  \"eventType\": \"StartPermissionVP\",\n  \"did\": \"did:web:agent.example\",\n  \"blockHeight\": 123456,\n  \"txHash\": \"A1B2C3\",\n  \"timestamp\": \"2025-01-15T10:30:00Z\",\n  \"payload\": {\n    \"module\": \"permission\",\n    \"action\": \"StartPermissionVP\",\n    \"messageType\": \"/verana.perm.v1.MsgStartPermissionVP\",\n    \"txIndex\": 0,\n    \"messageIndex\": 0,\n    \"sender\": \"did:web:agent.example\",\n    \"relatedDids\": [\"did:web:agent.example\"],\n    \"entityType\": \"Permission\",\n    \"entityId\": \"42\"\n  }\n}\n```\nRequired fields: `type`, `eventType`, `did`, `blockHeight`, `txHash`, `timestamp`, `payload`.\n\nManual tests:\n```bash\nnode --import=tsx test/manual/test-websocket.ts\nDID=did:web:agent.example AFTER_BLOCK_HEIGHT=123456 node --import=tsx test/manual/test-websocket-did-room.ts\n```"
+      "description": "## WebSocket Events\n\nThe same path supports the legacy global stream and the DID-specific room.\n\n### All events\nConnect to `ws://localhost:3001/verana/indexer/v1/events` without a `did` query parameter. The first message is `connected`, followed by the legacy `block-processed` object. This object shape is kept backward compatible:\n```json\n{\n  \"type\": \"block-processed\",\n  \"height\": 123456,\n  \"timestamp\": \"2025-01-15T10:30:00Z\"\n}\n```\nRequired fields: `type`, `height`, `timestamp`.\n\n### DID room\nConnect to `ws://localhost:3001/verana/indexer/v1/events?did=<DID>`. The first message is `connected` and includes `did` and `block_height`. Use `GET /verana/indexer/v1/events?did=<DID>&after_block_height=<height>&limit=<n>` to replay missed persisted events.\n\nLive DID events use this shape:\n```json\n{\n  \"type\": \"indexer-event\",\n  \"event_type\": \"StartPermissionVP\",\n  \"did\": \"did:web:agent.example\",\n  \"block_height\": 123456,\n  \"tx_hash\": \"A1B2C3\",\n  \"timestamp\": \"2025-01-15T10:30:00Z\",\n  \"payload\": {\n    \"module\": \"permission\",\n    \"action\": \"StartPermissionVP\",\n    \"message_type\": \"/verana.perm.v1.MsgStartPermissionVP\",\n    \"tx_index\": 0,\n    \"message_index\": 0,\n    \"sender\": \"did:web:agent.example\",\n    \"related_dids\": [\"did:web:agent.example\"],\n    \"entity_type\": \"Permission\",\n    \"entity_id\": \"42\"\n  }\n}\n```\nRequired fields: `type`, `event_type`, `did`, `block_height`, `tx_hash`, `timestamp`, `payload`.\n\nManual tests:\n```bash\nnode --import=tsx test/manual/test-websocket.ts\nDID=did:web:agent.example AFTER_BLOCK_HEIGHT=123456 node --import=tsx test/manual/test-websocket-did-room.ts\n```"
     }
   ]
 }

--- a/src/migrations/20260420000000_create_indexer_events.ts
+++ b/src/migrations/20260420000000_create_indexer_events.ts
@@ -1,0 +1,32 @@
+import { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  const exists = await knex.schema.hasTable("indexer_events");
+  if (exists) return;
+
+  await knex.schema.createTable("indexer_events", (table) => {
+    table.bigIncrements("id").primary();
+    table.text("event_type").notNullable();
+    table.text("did").notNullable();
+    table.bigInteger("block_height").notNullable();
+    table.text("tx_hash").notNullable();
+    table.integer("tx_index").notNullable().defaultTo(0);
+    table.integer("message_index").notNullable().defaultTo(0);
+    table.text("message_type").notNullable();
+    table.text("module").notNullable();
+    table.text("entity_type").nullable();
+    table.text("entity_id").nullable();
+    table.timestamp("timestamp").notNullable();
+    table.jsonb("payload").notNullable().defaultTo("{}");
+    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
+
+    table.unique(["did", "tx_hash", "message_index", "event_type"], "idx_events_did_tx_msg_type_unique");
+    table.index(["did", "block_height", "tx_index", "message_index", "id"], "idx_events_did_replay_order");
+    table.index(["block_height", "tx_index", "message_index", "id"], "idx_events_replay_order");
+    table.index(["event_type"], "idx_events_event_type");
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists("indexer_events");
+}

--- a/src/scripts/reindex-modules.ts
+++ b/src/scripts/reindex-modules.ts
@@ -61,6 +61,7 @@ const TABLES_TO_DROP = [
   "account",
   "permission_scheduled_flips",
   "entity_participant_changes",
+  "indexer_events",
 ];
 
 const SEQUENCES_TO_RESET = [
@@ -90,6 +91,7 @@ const SEQUENCES_TO_RESET = [
   "daily_statistics_id_seq",
   "account_id_seq",
   "stats_id_seq",
+  "indexer_events_id_seq",
 ];
 
 async function waitForDatabase(config: Knex.Config, maxRetries = 30, delayMs = 2000): Promise<void> {
@@ -562,6 +564,7 @@ const MIGRATION_TO_TABLES: Record<string, string[]> = {
   "20260126000001_create_did_history": ["did_history"],
   "20260202020000_create_global_metrics": ["global_metrics"],
   "20260317000000_add_permission_flips": ["permission_scheduled_flips", "permissions"],
+  "20260420000000_create_indexer_events": ["indexer_events"],
   "partition-transaction-table": ["transaction"],
   "transaction_message_partition": ["transaction_message"]
 };
@@ -651,7 +654,8 @@ async function runMigrations(db: Knex): Promise<void> {
       "20250115000000_add_permission_new_attributes",
       "20260305000000_add_participant_role_counters",
       "20260126000000_add_trust_registry_statistics",
-      "20260126000002_add_credential_schema_statistics"
+      "20260126000002_add_credential_schema_statistics",
+      "20260420000000_create_indexer_events"
     ];
     
     const transactionPartitionMigrationNames = [

--- a/src/services/api/api.service.ts
+++ b/src/services/api/api.service.ts
@@ -10,6 +10,7 @@ import knex from "../../common/utils/db_connection";
 import { swaggerUiComponent } from "./swagger_ui";
 import { eventsBroadcaster } from "./events_broadcaster";
 import { indexerStatusManager } from "../manager/indexer_status.manager";
+import { isUnknownMessageError } from "./api_shared";
 
 const BLOCK_CHECKPOINT_JOB = BULL_JOB_NAME.HANDLE_TRANSACTION;
 const REQUEST_ACCEPTED_NS = Symbol("requestAcceptedNs");
@@ -131,12 +132,6 @@ async function parseAtBlockHeight(
   ctx.meta.$headers = ctx.meta.$headers || {};
   ctx.meta.$headers["at-block-height"] = String(parsedHeight);
   ctx.meta.$headers["At-Block-Height"] = String(parsedHeight);
-}
-
-function isUnknownMessageError(errorMessage: string): boolean {
-  if (!errorMessage) return false;
-  return errorMessage.includes('Unknown Verana message types') ||
-         errorMessage.includes('UNKNOWN VERANA MESSAGE TYPES');
 }
 
 async function attachHeaders(ctx: Context<any, any>, res: ServerResponse) {

--- a/src/services/api/api.service.ts
+++ b/src/services/api/api.service.ts
@@ -404,6 +404,7 @@ function createRoute(
       createRoute("/verana/indexer/v1", {
         "GET block-height": `${SERVICE.V1.IndexerMetaService.path}.getBlockHeight`,
         "GET changes/:block_height": `${SERVICE.V1.IndexerMetaService.path}.listChanges`,
+        "GET events": `${SERVICE.V1.IndexerEventsService.path}.listEvents`,
         "GET version": `${SERVICE.V1.IndexerMetaService.path}.getVersion`,
         "GET status": `${SERVICE.V1.IndexerStatusService.path}.getDetailedStatus`,
         "GET errors/download": `v1.LogsService.downloadErrors`,

--- a/src/services/api/api_shared.ts
+++ b/src/services/api/api_shared.ts
@@ -38,3 +38,8 @@ export function applyBlockHeightFilter(
   return query;
 }
 
+export function toIsoSeconds(value: Date | string = new Date()): string {
+  const date = value instanceof Date ? value : new Date(value);
+  return date.toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+

--- a/src/services/api/api_shared.ts
+++ b/src/services/api/api_shared.ts
@@ -1,0 +1,40 @@
+export type LoggerLike = {
+  info?: (...args: any[]) => void;
+  warn?: (...args: any[]) => void;
+  error?: (...args: any[]) => void;
+};
+
+export function createLogger(logger?: LoggerLike) {
+  const base = logger ?? console;
+  return {
+    info: (...args: any[]) => (base.info ? base.info(...args) : console.log(...args)),
+    warn: (...args: any[]) => (base.warn ? base.warn(...args) : console.warn(...args)),
+    error: (...args: any[]) => (base.error ? base.error(...args) : console.error(...args)),
+  };
+}
+
+export function isUnknownMessageError(errorMessage: string): boolean {
+  if (!errorMessage) return false;
+  return (
+    errorMessage.includes("Unknown Verana message types") ||
+    errorMessage.includes("UNKNOWN VERANA MESSAGE TYPES")
+  );
+}
+
+export function isValidDid(value: unknown): value is string {
+  return typeof value === "string" && /^did:[a-z0-9]+:.+/i.test(value.trim());
+}
+
+export function applyBlockHeightFilter(
+  query: { andWhere: (...args: any[]) => any },
+  args: { blockHeight?: unknown; afterBlockHeight?: unknown },
+  column: string
+) {
+  if (Number.isInteger(args.blockHeight)) {
+    query.andWhere(column, Number(args.blockHeight));
+  } else if (Number.isInteger(args.afterBlockHeight)) {
+    query.andWhere(column, ">", Number(args.afterBlockHeight));
+  }
+  return query;
+}
+

--- a/src/services/api/events.service.ts
+++ b/src/services/api/events.service.ts
@@ -25,22 +25,32 @@ export default class IndexerEventsService extends BaseService {
   public async broadcastBlockProcessed(ctx: Context<{ height: number; timestamp?: string }>) {
     const { height, timestamp } = ctx.params;
     const eventTimestamp = timestamp ? new Date(timestamp) : new Date();
-    
+
+    let eventsNotified = 0;
     try {
       const events = await persistIndexerEventsForBlock(height);
       events.forEach((event) => eventsBroadcaster.broadcastIndexerEvent(event));
-      eventsBroadcaster.broadcastBlockProcessed(height, eventTimestamp);
-      
+      eventsNotified = events.length;
       return {
         success: true,
         clientsNotified: eventsBroadcaster.getWSClientCount(),
-        eventsNotified: events.length,
+        eventsNotified,
         height,
         timestamp: eventTimestamp.toISOString(),
       };
     } catch (error) {
       this.logger.error("[IndexerEventsService] Error broadcasting block processed:", error);
-      throw error;
+      return {
+        success: false,
+        clientsNotified: eventsBroadcaster.getWSClientCount(),
+        eventsNotified,
+        height,
+        timestamp: eventTimestamp.toISOString(),
+        error: (error as any)?.message ?? String(error),
+      };
+    } finally {
+      // Keep legacy heartbeat even if persistence fails.
+      eventsBroadcaster.broadcastBlockProcessed(height, eventTimestamp);
     }
   }
 

--- a/src/services/api/events.service.ts
+++ b/src/services/api/events.service.ts
@@ -2,7 +2,8 @@ import { Action, Service } from "@ourparentcenter/moleculer-decorators-extended"
 import { Context, Errors, ServiceBroker } from "moleculer";
 import BaseService from "../../base/base.service";
 import { SERVICE } from "../../common";
-import { eventsBroadcaster, isValidDid } from "./events_broadcaster";
+import { eventsBroadcaster } from "./events_broadcaster";
+import { isValidDid } from "./api_shared";
 import { listIndexerEvents, persistIndexerEventsForBlock } from "./indexer_events_query";
 
 @Service({

--- a/src/services/api/events.service.ts
+++ b/src/services/api/events.service.ts
@@ -1,8 +1,9 @@
 import { Action, Service } from "@ourparentcenter/moleculer-decorators-extended";
-import { Context, ServiceBroker } from "moleculer";
+import { Context, Errors, ServiceBroker } from "moleculer";
 import BaseService from "../../base/base.service";
 import { SERVICE } from "../../common";
-import { eventsBroadcaster } from "./events_broadcaster";
+import { eventsBroadcaster, isValidDid } from "./events_broadcaster";
+import { listIndexerEvents, persistIndexerEventsForBlock } from "./indexer_events_query";
 
 @Service({
   name: SERVICE.V1.IndexerEventsService.key,
@@ -25,11 +26,14 @@ export default class IndexerEventsService extends BaseService {
     const eventTimestamp = timestamp ? new Date(timestamp) : new Date();
     
     try {
+      const events = await persistIndexerEventsForBlock(height);
+      events.forEach((event) => eventsBroadcaster.broadcastIndexerEvent(event));
       eventsBroadcaster.broadcastBlockProcessed(height, eventTimestamp);
       
       return {
         success: true,
         clientsNotified: eventsBroadcaster.getWSClientCount(),
+        eventsNotified: events.length,
         height,
         timestamp: eventTimestamp.toISOString(),
       };
@@ -37,5 +41,35 @@ export default class IndexerEventsService extends BaseService {
       this.logger.error("[IndexerEventsService] Error broadcasting block processed:", error);
       throw error;
     }
+  }
+
+  @Action({
+    name: "listEvents",
+    params: {
+      did: { type: "string", trim: true, pattern: /^did:[a-z0-9]+:.+/i },
+      after_block_height: { type: "number", integer: true, min: 0, optional: true, convert: true },
+      limit: { type: "number", integer: true, min: 1, max: 500, optional: true, convert: true },
+    },
+  })
+  public async listEvents(ctx: Context<{
+    did: string;
+    after_block_height?: number;
+    limit?: number;
+  }>) {
+    if (!isValidDid(ctx.params.did)) {
+      throw new Errors.MoleculerClientError("Invalid did query parameter", 400, "INVALID_DID");
+    }
+
+    const afterBlockHeight = ctx.params.after_block_height ?? 0;
+    const events = await listIndexerEvents({
+      afterBlockHeight,
+      did: ctx.params.did,
+      limit: ctx.params.limit,
+    });
+    return {
+      events,
+      count: events.length,
+      afterBlockHeight,
+    };
   }
 }

--- a/src/services/api/events.service.ts
+++ b/src/services/api/events.service.ts
@@ -3,7 +3,6 @@ import { Context, Errors, ServiceBroker } from "moleculer";
 import BaseService from "../../base/base.service";
 import { SERVICE } from "../../common";
 import { eventsBroadcaster } from "./events_broadcaster";
-import { isValidDid } from "./api_shared";
 import { listIndexerEvents, persistIndexerEventsForBlock } from "./indexer_events_query";
 
 @Service({
@@ -26,15 +25,13 @@ export default class IndexerEventsService extends BaseService {
     const { height, timestamp } = ctx.params;
     const eventTimestamp = timestamp ? new Date(timestamp) : new Date();
 
-    let eventsNotified = 0;
     try {
       const events = await persistIndexerEventsForBlock(height);
       events.forEach((event) => eventsBroadcaster.broadcastIndexerEvent(event));
-      eventsNotified = events.length;
       return {
         success: true,
         clientsNotified: eventsBroadcaster.getWSClientCount(),
-        eventsNotified,
+        eventsNotified: events.length,
         height,
         timestamp: eventTimestamp.toISOString(),
       };
@@ -43,7 +40,7 @@ export default class IndexerEventsService extends BaseService {
       return {
         success: false,
         clientsNotified: eventsBroadcaster.getWSClientCount(),
-        eventsNotified,
+        eventsNotified: 0,
         height,
         timestamp: eventTimestamp.toISOString(),
         error: (error as any)?.message ?? String(error),
@@ -67,20 +64,25 @@ export default class IndexerEventsService extends BaseService {
     after_block_height?: number;
     limit?: number;
   }>) {
-    if (!isValidDid(ctx.params.did)) {
-      throw new Errors.MoleculerClientError("Invalid did query parameter", 400, "INVALID_DID");
-    }
-
     const afterBlockHeight = ctx.params.after_block_height ?? 0;
-    const events = await listIndexerEvents({
-      afterBlockHeight,
-      did: ctx.params.did,
-      limit: ctx.params.limit,
-    });
-    return {
-      events,
-      count: events.length,
-      afterBlockHeight,
-    };
+    try {
+      const events = await listIndexerEvents({
+        afterBlockHeight,
+        did: ctx.params.did,
+        limit: ctx.params.limit,
+      });
+      return {
+        events,
+        count: events.length,
+        after_block_height: afterBlockHeight,
+      };
+    } catch (error) {
+      this.logger.error("[IndexerEventsService] Error listing indexer events:", error);
+      throw new Errors.MoleculerError(
+        "Failed to list indexer events",
+        500,
+        "INDEXER_EVENTS_QUERY_FAILED"
+      );
+    }
   }
 }

--- a/src/services/api/events_broadcaster.ts
+++ b/src/services/api/events_broadcaster.ts
@@ -1,85 +1,128 @@
+import { IncomingMessage, Server } from "http";
 import { WebSocket, WebSocketServer } from "ws";
-import { Server } from "http";
 import { indexerStatusManager } from "../manager/indexer_status.manager";
+import type { IndexerEventRecord } from "./indexer_events_query";
 
-function isTemporaryError(errorMessage: string): boolean {
-  if (!errorMessage) return false;
-  const lowerMessage = errorMessage.toLowerCase();
-  return lowerMessage.includes('timeout') ||
-         lowerMessage.includes('exceeded') ||
-         lowerMessage.includes('timed out') ||
-         lowerMessage.includes('econnrefused') ||
-         lowerMessage.includes('etimedout') ||
-         lowerMessage.includes('econaborted') ||
-         lowerMessage.includes('network') ||
-         lowerMessage.includes('connection') ||
-         lowerMessage.includes('non-critical') ||
-         lowerMessage.includes('service will continue');
-}
+type Logger = {
+  info?: (...args: any[]) => void;
+  warn?: (...args: any[]) => void;
+  error?: (...args: any[]) => void;
+};
+
+type ClientDidParseResult = {
+  did?: string;
+  invalidDid?: string;
+};
+
+type IndexerStatusMessage = {
+  indexerStatus: "running" | "stopped";
+  crawlingStatus: "active" | "stopped";
+  stoppedAt?: string;
+  stoppedReason?: string;
+  lastError?: {
+    message: string;
+    timestamp: string;
+    service?: string;
+  };
+};
 
 function isUnknownMessageError(errorMessage: string): boolean {
   if (!errorMessage) return false;
-  return errorMessage.includes('Unknown Verana message types') ||
-         errorMessage.includes('UNKNOWN VERANA MESSAGE TYPES');
+  return errorMessage.includes("Unknown Verana message types") ||
+    errorMessage.includes("UNKNOWN VERANA MESSAGE TYPES");
+}
+
+export function isValidDid(value: unknown): value is string {
+  return typeof value === "string" && /^did:[a-z0-9]+:.+/i.test(value.trim());
+}
+
+function toIsoSeconds(value: Date = new Date()): string {
+  return value.toISOString().replace(/\.\d{3}Z$/, "Z");
 }
 
 export class EventsBroadcaster {
   private wss: WebSocketServer | null = null;
   private wsClients: Set<WebSocket> = new Set();
   private clientAlive: Map<WebSocket, boolean> = new Map();
+  private clientDids: Map<WebSocket, string> = new Map();
+  private didRooms: Map<string, Set<WebSocket>> = new Map();
   private pingInterval: NodeJS.Timeout | null = null;
   private readonly MAX_CLIENTS = 10000;
   private readonly PING_INTERVAL = 30000;
-  private logger: {
-    info?: (...args: any[]) => void;
-    warn?: (...args: any[]) => void;
-    error?: (...args: any[]) => void;
-  } = console;
+  private logger: Logger = console;
 
-  setLogger(logger: {
-    info?: (...args: any[]) => void;
-    warn?: (...args: any[]) => void;
-    error?: (...args: any[]) => void;
-  }): void {
+  setLogger(logger: Logger): void {
     this.logger = logger;
   }
 
   private logInfo(...args: any[]): void {
-    if (this.logger.info) {
-      this.logger.info(...args);
-    } else {
-      console.log(...args);
-    }
+    if (this.logger.info) this.logger.info(...args);
+    else console.log(...args);
   }
 
   private logWarn(...args: any[]): void {
-    if (this.logger.warn) {
-      this.logger.warn(...args);
-    } else {
-      console.warn(...args);
-    }
+    if (this.logger.warn) this.logger.warn(...args);
+    else console.warn(...args);
   }
 
   private logError(...args: any[]): void {
-    if (this.logger.error) {
-      this.logger.error(...args);
-    } else {
-      console.error(...args);
+    if (this.logger.error) this.logger.error(...args);
+    else console.error(...args);
+  }
+
+  private parseClientDid(req: IncomingMessage): ClientDidParseResult {
+    const host = req.headers.host || "localhost";
+    const url = new URL(req.url || "/verana/indexer/v1/events", `http://${host}`);
+    const did = (url.searchParams.get("did") || "").trim();
+    if (!did) return {};
+    return isValidDid(did) ? { did } : { invalidDid: did };
+  }
+
+  private addToRoom(ws: WebSocket, did: string): void {
+    let room = this.didRooms.get(did);
+    if (!room) {
+      room = new Set<WebSocket>();
+      this.didRooms.set(did, room);
+    }
+    room.add(ws);
+  }
+
+  private removeFromRoom(ws: WebSocket, did: string): void {
+    const room = this.didRooms.get(did);
+    if (!room) return;
+    room.delete(ws);
+    if (room.size === 0) this.didRooms.delete(did);
+  }
+
+  private cleanupClient(ws: WebSocket): void {
+    const did = this.clientDids.get(ws);
+    if (did) this.removeFromRoom(ws, did);
+
+    const hadClient = this.wsClients.delete(ws);
+    this.clientAlive.delete(ws);
+    this.clientDids.delete(ws);
+
+    if (hadClient) {
+      this.logInfo(`[EventsBroadcaster] WebSocket client disconnected. Total clients: ${this.wsClients.size}`);
     }
   }
 
- 
-  private getCurrentIndexerStatus(): {
-    indexerStatus: "running" | "stopped";
-    crawlingStatus: "active" | "stopped";
-    stoppedAt?: string;
-    stoppedReason?: string;
-    lastError?: {
-      message: string;
-      timestamp: string;
-      service?: string;
-    };
-  } {
+  private sendJson(ws: WebSocket, eventData: Record<string, unknown>): boolean {
+    if (ws.readyState !== WebSocket.OPEN) {
+      this.cleanupClient(ws);
+      return false;
+    }
+
+    try {
+      ws.send(JSON.stringify(eventData), { compress: false });
+      return true;
+    } catch {
+      this.cleanupClient(ws);
+      return false;
+    }
+  }
+
+  private getCurrentIndexerStatus(): IndexerStatusMessage {
     const status = indexerStatusManager.getStatus();
     return {
       indexerStatus: status.isRunning ? "running" : "stopped",
@@ -94,12 +137,13 @@ export class EventsBroadcaster {
     indexerStatusManager.setStatusChangeCallback((status) => {
       this.broadcastIndexerStatus(status);
     });
+
     if (this.wss) {
       this.logWarn("[EventsBroadcaster] WebSocket server already initialized");
       return;
     }
 
-    this.wss = new WebSocketServer({ 
+    this.wss = new WebSocketServer({
       server,
       path: "/verana/indexer/v1/events",
       perMessageDeflate: false,
@@ -110,74 +154,76 @@ export class EventsBroadcaster {
           return false;
         }
         return true;
-      }
+      },
     });
 
-    this.wss.on("connection", (ws: WebSocket) => {
+    this.wss.on("connection", async (ws: WebSocket, req: IncomingMessage) => {
       if (this.wsClients.size >= this.MAX_CLIENTS) {
         ws.close(1013, "Server overloaded");
         return;
       }
 
+      const { did, invalidDid } = this.parseClientDid(req);
+      if (invalidDid) {
+        ws.close(1008, "Invalid did query parameter");
+        return;
+      }
+
       this.wsClients.add(ws);
       this.clientAlive.set(ws, true);
+      if (did) {
+        this.clientDids.set(ws, did);
+        this.addToRoom(ws, did);
+      }
 
       this.logInfo(`[EventsBroadcaster] New WebSocket client connected. Total clients: ${this.wsClients.size}`);
 
+      ws.on("close", () => this.cleanupClient(ws));
+      ws.on("error", (error) => {
+        this.logError("[EventsBroadcaster] WebSocket error:", error);
+        this.cleanupClient(ws);
+      });
+      ws.on("pong", () => {
+        this.clientAlive.set(ws, true);
+      });
+
       try {
-        const status = this.getCurrentIndexerStatus();
-        const connectionMessage: any = {
+        const [status, detailedStatus] = await Promise.all([
+          Promise.resolve(this.getCurrentIndexerStatus()),
+          indexerStatusManager.getDetailedStatus().catch(() => null),
+        ]);
+
+        const connectionMessage: Record<string, unknown> = {
           type: "connected",
           message: "Connected to Verana Indexer Events",
           indexerStatus: status.indexerStatus,
           crawlingStatus: status.crawlingStatus,
-          timestamp: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')
+          blockHeight: detailedStatus?.lastProcessedBlock ?? null,
+          timestamp: toIsoSeconds(),
         };
-        
+        if (did) connectionMessage.did = did;
+
         if (status.crawlingStatus === "stopped") {
-          if (status.stoppedAt) {
-            connectionMessage.stoppedAt = status.stoppedAt;
-          }
-          const errorMessage = status.lastError?.message || status.stoppedReason || '';
-          const isUnknown = isUnknownMessageError(errorMessage);
-          
-          if (isUnknown) {
-            if (status.stoppedReason) {
-              connectionMessage.stoppedReason = status.stoppedReason;
-            }
+          if (status.stoppedAt) connectionMessage.stoppedAt = status.stoppedAt;
+
+          const errorMessage = status.lastError?.message || status.stoppedReason || "";
+          if (isUnknownMessageError(errorMessage)) {
+            if (status.stoppedReason) connectionMessage.stoppedReason = status.stoppedReason;
             if (status.lastError) {
               connectionMessage.lastError = {
                 message: status.lastError.message,
                 timestamp: status.lastError.timestamp,
-                service: status.lastError.service
+                service: status.lastError.service,
               };
             }
           }
         }
-        
-        ws.send(JSON.stringify(connectionMessage), { compress: false });
+
+        this.sendJson(ws, connectionMessage);
       } catch (error) {
         this.logError("[EventsBroadcaster] Error sending welcome message:", error);
-        this.wsClients.delete(ws);
-        this.clientAlive.delete(ws);
-        return;
+        this.cleanupClient(ws);
       }
-
-      const cleanup = () => {
-        this.wsClients.delete(ws);
-        this.clientAlive.delete(ws);
-        this.logInfo(`[EventsBroadcaster] WebSocket client disconnected. Total clients: ${this.wsClients.size}`);
-      };
-
-      ws.on("close", cleanup);
-      ws.on("error", (error) => {
-        this.logError("[EventsBroadcaster] WebSocket error:", error);
-        cleanup();
-      });
-
-      ws.on("pong", () => {
-        this.clientAlive.set(ws, true);
-      });
     });
 
     this.wss.on("error", (error) => {
@@ -192,90 +238,65 @@ export class EventsBroadcaster {
   }
 
   private pingClients(): void {
-    const deadClients: WebSocket[] = [];
-    
+    const staleClients: WebSocket[] = [];
+
     this.wsClients.forEach((ws) => {
       const isAlive = this.clientAlive.get(ws);
       if (isAlive === false) {
-        deadClients.push(ws);
+        staleClients.push(ws);
         return;
       }
+
       this.clientAlive.set(ws, false);
       try {
         ws.ping();
-      } catch (error) {
-        deadClients.push(ws);
+      } catch {
+        staleClients.push(ws);
       }
     });
 
-    deadClients.forEach((ws) => {
+    staleClients.forEach((ws) => {
       try {
         ws.terminate();
-      } catch (error) {
-        // Ignore termination errors
+      } catch {
+        // Best effort cleanup.
       }
-      this.wsClients.delete(ws);
-      this.clientAlive.delete(ws);
+      this.cleanupClient(ws);
     });
+  }
+
+  broadcastIndexerEvent(event: IndexerEventRecord): void {
+    this.broadcastToDid(event.did, event as unknown as Record<string, unknown>);
   }
 
   broadcastBlockProcessed(height: number, timestamp: Date | string): void {
-    if (this.wsClients.size === 0) {
-      return;
-    }
-
     const eventTimestamp = timestamp instanceof Date ? timestamp : new Date(timestamp);
-    // Format timestamp as ISO 8601 with 'Z' designator (without milliseconds)
-    const isoString = eventTimestamp.toISOString();
-    const timestampFormatted = isoString.replace(/\.\d{3}Z$/, 'Z');
-    
-    const eventData = {
+    this.broadcastToGlobalClients({
       type: "block-processed",
       height,
-      timestamp: timestampFormatted
-    };
-    this.broadcastMessage(eventData);
+      timestamp: toIsoSeconds(eventTimestamp),
+    });
   }
 
+  broadcastIndexerStatus(status: IndexerStatusMessage): void {
+    if (this.wsClients.size === 0) return;
 
-  broadcastIndexerStatus(status: {
-    indexerStatus: "running" | "stopped";
-    crawlingStatus: "active" | "stopped";
-    stoppedAt?: string;
-    stoppedReason?: string;
-    lastError?: {
-      message: string;
-      timestamp: string;
-      service?: string;
-    };
-  }): void {
-    if (this.wsClients.size === 0) {
-      return;
-    }
-
-    const errorMessage = status.lastError?.message || status.stoppedReason || '';
-    const isUnknown = isUnknownMessageError(errorMessage);
-
-    const eventData: any = {
+    const errorMessage = status.lastError?.message || status.stoppedReason || "";
+    const eventData: Record<string, unknown> = {
       type: "indexer-status",
       indexerStatus: status.indexerStatus,
       crawlingStatus: status.crawlingStatus,
-      timestamp: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z')
+      timestamp: toIsoSeconds(),
     };
 
-    if (status.stoppedAt) {
-      eventData.stoppedAt = status.stoppedAt;
-    }
-
-    if (isUnknown) {
-      if (status.stoppedReason) {
-        eventData.stoppedReason = status.stoppedReason;
-      }
+    if (status.stoppedAt) eventData.stoppedAt = status.stoppedAt;
+    if (isUnknownMessageError(errorMessage)) {
+      if (status.stoppedReason) eventData.stoppedReason = status.stoppedReason;
       if (status.lastError) {
         eventData.lastError = {
           message: status.lastError.message,
           timestamp: status.lastError.timestamp,
-          service: status.lastError.service
+          service: status.lastError.service,
         };
       }
     }
@@ -283,38 +304,40 @@ export class EventsBroadcaster {
     this.broadcastMessage(eventData);
   }
 
- 
-  private broadcastMessage(eventData: Record<string, any>): void {
-    if (this.wsClients.size === 0) {
-      return;
-    }
-
-    const message = JSON.stringify(eventData);
-    const deadClients: WebSocket[] = [];
+  private broadcastMessage(eventData: Record<string, unknown>): void {
     let sentCount = 0;
-    
     this.wsClients.forEach((ws) => {
-      if (ws.readyState === WebSocket.OPEN) {
-        try {
-          ws.send(message, { compress: false });
-          sentCount++;
-        } catch (error) {
-          deadClients.push(ws);
-        }
-      } else {
-        deadClients.push(ws);
-      }
+      if (this.sendJson(ws, eventData)) sentCount++;
     });
-
-    if (deadClients.length > 0) {
-      deadClients.forEach((ws) => {
-        this.wsClients.delete(ws);
-        this.clientAlive.delete(ws);
-      });
-    }
 
     if (sentCount > 0) {
       this.logInfo(`[EventsBroadcaster] Broadcasted ${eventData.type} to ${sentCount} WebSocket client(s)`);
+    }
+  }
+
+  private broadcastToGlobalClients(eventData: Record<string, unknown>): void {
+    let sentCount = 0;
+    this.wsClients.forEach((ws) => {
+      if (this.clientDids.has(ws)) return;
+      if (this.sendJson(ws, eventData)) sentCount++;
+    });
+
+    if (sentCount > 0) {
+      this.logInfo(`[EventsBroadcaster] Broadcasted ${eventData.type} to ${sentCount} global WebSocket client(s)`);
+    }
+  }
+
+  private broadcastToDid(did: string, eventData: Record<string, unknown>): void {
+    const room = this.didRooms.get(did);
+    if (!room || room.size === 0) return;
+
+    let sentCount = 0;
+    Array.from(room).forEach((ws) => {
+      if (this.sendJson(ws, eventData)) sentCount++;
+    });
+
+    if (sentCount > 0) {
+      this.logInfo(`[EventsBroadcaster] Broadcasted ${eventData.eventType || eventData.type} to ${sentCount} DID subscriber(s)`);
     }
   }
 
@@ -335,13 +358,15 @@ export class EventsBroadcaster {
         } else {
           ws.terminate();
         }
-      } catch (error) {
-        // Ignore close errors
+      } catch {
+        // Best effort close.
       }
     });
-    
+
     this.wsClients.clear();
     this.clientAlive.clear();
+    this.clientDids.clear();
+    this.didRooms.clear();
 
     if (this.wss) {
       this.wss.close(() => {

--- a/src/services/api/events_broadcaster.ts
+++ b/src/services/api/events_broadcaster.ts
@@ -2,12 +2,7 @@ import { IncomingMessage, Server } from "http";
 import { WebSocket, WebSocketServer } from "ws";
 import { indexerStatusManager } from "../manager/indexer_status.manager";
 import type { IndexerEventRecord } from "./indexer_events_query";
-
-type Logger = {
-  info?: (...args: any[]) => void;
-  warn?: (...args: any[]) => void;
-  error?: (...args: any[]) => void;
-};
+import { createLogger, isUnknownMessageError, isValidDid, type LoggerLike } from "./api_shared";
 
 type ClientDidParseResult = {
   did?: string;
@@ -26,16 +21,6 @@ type IndexerStatusMessage = {
   };
 };
 
-function isUnknownMessageError(errorMessage: string): boolean {
-  if (!errorMessage) return false;
-  return errorMessage.includes("Unknown Verana message types") ||
-    errorMessage.includes("UNKNOWN VERANA MESSAGE TYPES");
-}
-
-export function isValidDid(value: unknown): value is string {
-  return typeof value === "string" && /^did:[a-z0-9]+:.+/i.test(value.trim());
-}
-
 function toIsoSeconds(value: Date = new Date()): string {
   return value.toISOString().replace(/\.\d{3}Z$/, "Z");
 }
@@ -49,25 +34,10 @@ export class EventsBroadcaster {
   private pingInterval: NodeJS.Timeout | null = null;
   private readonly MAX_CLIENTS = 10000;
   private readonly PING_INTERVAL = 30000;
-  private logger: Logger = console;
+  private logger = createLogger(console);
 
-  setLogger(logger: Logger): void {
-    this.logger = logger;
-  }
-
-  private logInfo(...args: any[]): void {
-    if (this.logger.info) this.logger.info(...args);
-    else console.log(...args);
-  }
-
-  private logWarn(...args: any[]): void {
-    if (this.logger.warn) this.logger.warn(...args);
-    else console.warn(...args);
-  }
-
-  private logError(...args: any[]): void {
-    if (this.logger.error) this.logger.error(...args);
-    else console.error(...args);
+  setLogger(logger: LoggerLike): void {
+    this.logger = createLogger(logger);
   }
 
   private parseClientDid(req: IncomingMessage): ClientDidParseResult {
@@ -103,7 +73,7 @@ export class EventsBroadcaster {
     this.clientDids.delete(ws);
 
     if (hadClient) {
-      this.logInfo(`[EventsBroadcaster] WebSocket client disconnected. Total clients: ${this.wsClients.size}`);
+      this.logger.info(`[EventsBroadcaster] WebSocket client disconnected. Total clients: ${this.wsClients.size}`);
     }
   }
 
@@ -139,7 +109,7 @@ export class EventsBroadcaster {
     });
 
     if (this.wss) {
-      this.logWarn("[EventsBroadcaster] WebSocket server already initialized");
+      this.logger.warn("[EventsBroadcaster] WebSocket server already initialized");
       return;
     }
 
@@ -150,7 +120,7 @@ export class EventsBroadcaster {
       maxPayload: 1024,
       verifyClient: () => {
         if (this.wsClients.size >= this.MAX_CLIENTS) {
-          this.logWarn(`[EventsBroadcaster] Max clients reached (${this.MAX_CLIENTS}), rejecting connection`);
+          this.logger.warn(`[EventsBroadcaster] Max clients reached (${this.MAX_CLIENTS}), rejecting connection`);
           return false;
         }
         return true;
@@ -176,11 +146,11 @@ export class EventsBroadcaster {
         this.addToRoom(ws, did);
       }
 
-      this.logInfo(`[EventsBroadcaster] New WebSocket client connected. Total clients: ${this.wsClients.size}`);
+      this.logger.info(`[EventsBroadcaster] New WebSocket client connected. Total clients: ${this.wsClients.size}`);
 
       ws.on("close", () => this.cleanupClient(ws));
       ws.on("error", (error) => {
-        this.logError("[EventsBroadcaster] WebSocket error:", error);
+        this.logger.error("[EventsBroadcaster] WebSocket error:", error);
         this.cleanupClient(ws);
       });
       ws.on("pong", () => {
@@ -221,20 +191,20 @@ export class EventsBroadcaster {
 
         this.sendJson(ws, connectionMessage);
       } catch (error) {
-        this.logError("[EventsBroadcaster] Error sending welcome message:", error);
+        this.logger.error("[EventsBroadcaster] Error sending welcome message:", error);
         this.cleanupClient(ws);
       }
     });
 
     this.wss.on("error", (error) => {
-      this.logError("[EventsBroadcaster] WebSocketServer error:", error);
+      this.logger.error("[EventsBroadcaster] WebSocketServer error:", error);
     });
 
     this.pingInterval = setInterval(() => {
       this.pingClients();
     }, this.PING_INTERVAL);
 
-    this.logInfo("[EventsBroadcaster] WebSocket server initialized on /verana/indexer/v1/events");
+    this.logger.info("[EventsBroadcaster] WebSocket server initialized on /verana/indexer/v1/events");
   }
 
   private pingClients(): void {
@@ -311,7 +281,7 @@ export class EventsBroadcaster {
     });
 
     if (sentCount > 0) {
-      this.logInfo(`[EventsBroadcaster] Broadcasted ${eventData.type} to ${sentCount} WebSocket client(s)`);
+      this.logger.info(`[EventsBroadcaster] Broadcasted ${eventData.type} to ${sentCount} WebSocket client(s)`);
     }
   }
 
@@ -323,7 +293,7 @@ export class EventsBroadcaster {
     });
 
     if (sentCount > 0) {
-      this.logInfo(`[EventsBroadcaster] Broadcasted ${eventData.type} to ${sentCount} global WebSocket client(s)`);
+      this.logger.info(`[EventsBroadcaster] Broadcasted ${eventData.type} to ${sentCount} global WebSocket client(s)`);
     }
   }
 
@@ -337,7 +307,7 @@ export class EventsBroadcaster {
     });
 
     if (sentCount > 0) {
-      this.logInfo(`[EventsBroadcaster] Broadcasted ${eventData.eventType || eventData.type} to ${sentCount} DID subscriber(s)`);
+      this.logger.info(`[EventsBroadcaster] Broadcasted ${eventData.eventType || eventData.type} to ${sentCount} DID subscriber(s)`);
     }
   }
 
@@ -370,7 +340,7 @@ export class EventsBroadcaster {
 
     if (this.wss) {
       this.wss.close(() => {
-        this.logInfo("[EventsBroadcaster] WebSocket server closed");
+        this.logger.info("[EventsBroadcaster] WebSocket server closed");
       });
       this.wss = null;
     }

--- a/src/services/api/events_broadcaster.ts
+++ b/src/services/api/events_broadcaster.ts
@@ -2,7 +2,7 @@ import { IncomingMessage, Server } from "http";
 import { WebSocket, WebSocketServer } from "ws";
 import { indexerStatusManager } from "../manager/indexer_status.manager";
 import type { IndexerEventRecord } from "./indexer_events_query";
-import { createLogger, isUnknownMessageError, isValidDid, type LoggerLike } from "./api_shared";
+import { createLogger, isUnknownMessageError, isValidDid, toIsoSeconds, type LoggerLike } from "./api_shared";
 
 type ClientDidParseResult = {
   did?: string;
@@ -20,10 +20,6 @@ type IndexerStatusMessage = {
     service?: string;
   };
 };
-
-function toIsoSeconds(value: Date = new Date()): string {
-  return value.toISOString().replace(/\.\d{3}Z$/, "Z");
-}
 
 export class EventsBroadcaster {
   private wss: WebSocketServer | null = null;
@@ -159,7 +155,7 @@ export class EventsBroadcaster {
 
       try {
         const [status, detailedStatus] = await Promise.all([
-          Promise.resolve(this.getCurrentIndexerStatus()),
+          this.getCurrentIndexerStatus(),
           indexerStatusManager.getDetailedStatus().catch(() => null),
         ]);
 
@@ -168,7 +164,7 @@ export class EventsBroadcaster {
           message: "Connected to Verana Indexer Events",
           indexerStatus: status.indexerStatus,
           crawlingStatus: status.crawlingStatus,
-          blockHeight: detailedStatus?.lastProcessedBlock ?? null,
+          block_height: detailedStatus?.lastProcessedBlock ?? null,
           timestamp: toIsoSeconds(),
         };
         if (did) connectionMessage.did = did;
@@ -307,7 +303,11 @@ export class EventsBroadcaster {
     });
 
     if (sentCount > 0) {
-      this.logger.info(`[EventsBroadcaster] Broadcasted ${eventData.eventType || eventData.type} to ${sentCount} DID subscriber(s)`);
+      const label =
+        typeof (eventData as any).event_type === "string"
+          ? (eventData as any).event_type
+          : String((eventData as any).type ?? "unknown");
+      this.logger.info(`[EventsBroadcaster] Broadcasted ${label} to ${sentCount} DID subscriber(s)`);
     }
   }
 

--- a/src/services/api/indexer_events_query.ts
+++ b/src/services/api/indexer_events_query.ts
@@ -146,9 +146,46 @@ const TABLE_COLUMNS_TTL_MS = 10 * 60 * 1000;
 const tableColumnsCache = new Map<string, { expiresAt: number; value: Promise<Set<string>> }>();
 
 const DID_QUERY_CACHE_TTL_MS = 60 * 1000;
-const permissionSnapshotCache = new Map<string, { expiresAt: number; value: Promise<any> }>();
-const credentialSchemaSnapshotCache = new Map<string, { expiresAt: number; value: Promise<any> }>();
-const trustRegistrySnapshotCache = new Map<string, { expiresAt: number; value: Promise<any> }>();
+const CACHE_MAX_ENTRIES = 5000;
+
+class ExpiringBoundedMap<K, V extends { expiresAt: number }> extends Map<K, V> {
+  constructor(private readonly maxEntries: number) {
+    super();
+  }
+
+  private pruneExpired(now = Date.now()): void {
+    for (const [key, entry] of super.entries()) {
+      if (entry.expiresAt <= now) {
+        super.delete(key);
+      }
+    }
+  }
+
+  override get(key: K): V | undefined {
+    const entry = super.get(key);
+    if (!entry) return undefined;
+    if (entry.expiresAt <= Date.now()) {
+      super.delete(key);
+      return undefined;
+    }
+    return entry;
+  }
+
+  override set(key: K, value: V): this {
+    this.pruneExpired();
+    super.set(key, value);
+    while (this.size > this.maxEntries) {
+      const oldestKey = this.keys().next().value as K | undefined;
+      if (oldestKey === undefined) break;
+      super.delete(oldestKey);
+    }
+    return this;
+  }
+}
+
+const permissionSnapshotCache = new ExpiringBoundedMap<string, { expiresAt: number; value: Promise<any> }>(CACHE_MAX_ENTRIES);
+const credentialSchemaSnapshotCache = new ExpiringBoundedMap<string, { expiresAt: number; value: Promise<any> }>(CACHE_MAX_ENTRIES);
+const trustRegistrySnapshotCache = new ExpiringBoundedMap<string, { expiresAt: number; value: Promise<any> }>(CACHE_MAX_ENTRIES);
 
 function toIsoSeconds(value: Date | string): string {
   const date = value instanceof Date ? value : new Date(value);
@@ -397,6 +434,7 @@ async function buildIndexerTxEvents(args: {
   afterBlockHeight?: number;
   blockHeight?: number;
   limit?: number;
+  offset?: number;
 }): Promise<IndexerTxEvent[]> {
   const limit = Math.max(1, Math.min(500, Math.floor(Number(args.limit ?? 100))));
   const query = knex("transaction_message as tm")
@@ -421,14 +459,24 @@ async function buildIndexerTxEvents(args: {
     .limit(limit);
 
   applyBlockHeightFilter(query, args, "tx.height");
+  if (Number.isInteger(args.offset) && Number(args.offset) > 0) {
+    query.offset(Number(args.offset));
+  }
 
   const rows = (await query) as EventRow[];
   return (await Promise.all(rows.map((row) => toIndexerEvent(row)))).filter(Boolean) as IndexerTxEvent[];
 }
 
 export async function persistIndexerEventsForBlock(blockHeight: number): Promise<IndexerEventRecord[]> {
-  const txEvents = await buildIndexerTxEvents({ blockHeight, limit: 500 });
-  const rows = txEvents.flatMap(toEventRows);
+  const rows: Array<Record<string, unknown>> = [];
+  const pageSize = 500;
+  let offset = 0;
+  while (true) {
+    const txEvents = await buildIndexerTxEvents({ blockHeight, limit: pageSize, offset });
+    rows.push(...txEvents.flatMap(toEventRows));
+    if (txEvents.length < pageSize) break;
+    offset += pageSize;
+  }
   let insertedIds: number[] = [];
 
   if (rows.length > 0) {
@@ -443,7 +491,15 @@ export async function persistIndexerEventsForBlock(blockHeight: number): Promise
   }
 
   if (insertedIds.length === 0) return [];
-  return listIndexerEvents({ ids: insertedIds, limit: 500 });
+
+  const results: IndexerEventRecord[] = [];
+  const chunkSize = 500;
+  for (let i = 0; i < insertedIds.length; i += chunkSize) {
+    const chunk = insertedIds.slice(i, i + chunkSize);
+    const rows = await listIndexerEvents({ ids: chunk, limit: chunk.length });
+    results.push(...rows);
+  }
+  return results;
 }
 
 export async function listIndexerEvents(args: {

--- a/src/services/api/indexer_events_query.ts
+++ b/src/services/api/indexer_events_query.ts
@@ -4,6 +4,7 @@ import {
   VeranaPermissionMessageTypes,
   VeranaTrustRegistryMessageTypes,
 } from "../../common/verana-message-types";
+import { applyBlockHeightFilter, isValidDid } from "./api_shared";
 
 export type IndexerTxEvent = {
   type: "transaction-executed";
@@ -140,7 +141,14 @@ const EVENT_META: Record<string, EventMeta> = {
 };
 
 const WATCHED_MESSAGE_TYPES = Object.keys(EVENT_META);
-const tableColumnsCache = new Map<string, Promise<Set<string>>>();
+
+const TABLE_COLUMNS_TTL_MS = 10 * 60 * 1000;
+const tableColumnsCache = new Map<string, { expiresAt: number; value: Promise<Set<string>> }>();
+
+const DID_QUERY_CACHE_TTL_MS = 60 * 1000;
+const permissionSnapshotCache = new Map<string, { expiresAt: number; value: Promise<any> }>();
+const credentialSchemaSnapshotCache = new Map<string, { expiresAt: number; value: Promise<any> }>();
+const trustRegistrySnapshotCache = new Map<string, { expiresAt: number; value: Promise<any> }>();
 
 function toIsoSeconds(value: Date | string): string {
   const date = value instanceof Date ? value : new Date(value);
@@ -148,7 +156,7 @@ function toIsoSeconds(value: Date | string): string {
 }
 
 function isDid(value: unknown): value is string {
-  return typeof value === "string" && value.startsWith("did:");
+  return isValidDid(value);
 }
 
 function addDid(out: Set<string>, value: unknown): void {
@@ -181,14 +189,15 @@ function readNumber(content: unknown, keys: string[]): number | null {
 }
 
 async function getTableColumns(tableName: string): Promise<Set<string>> {
-  let columns = tableColumnsCache.get(tableName);
-  if (!columns) {
-    columns = knex(tableName)
-      .columnInfo()
-      .then((info) => new Set(Object.keys(info)));
-    tableColumnsCache.set(tableName, columns);
-  }
-  return columns;
+  const now = Date.now();
+  const cached = tableColumnsCache.get(tableName);
+  if (cached && cached.expiresAt > now) return cached.value;
+
+  const value = knex(tableName)
+    .columnInfo()
+    .then((info) => new Set(Object.keys(info)));
+  tableColumnsCache.set(tableName, { expiresAt: now + TABLE_COLUMNS_TTL_MS, value });
+  return value;
 }
 
 async function existingColumns(tableName: string, columns: string[]): Promise<string[]> {
@@ -198,15 +207,27 @@ async function existingColumns(tableName: string, columns: string[]): Promise<st
 
 async function addTrustRegistryDids(trId: number | null, height: number, dids: Set<string>): Promise<void> {
   if (!trId) return;
+  const now = Date.now();
+  const cacheKey = `${trId}:${height}`;
+  const cached = trustRegistrySnapshotCache.get(cacheKey);
+  if (cached && cached.expiresAt > now) {
+    const row = await cached.value;
+    addDid(dids, (row as any)?.did);
+    addDid(dids, (row as any)?.controller);
+    return;
+  }
   const columns = await existingColumns("trust_registry_history", ["did", "controller"]);
   if (columns.length === 0) return;
 
-  const row = await knex("trust_registry_history")
+  const value = knex("trust_registry_history")
     .select(columns)
     .where("tr_id", trId)
     .where("height", "<=", height)
     .orderBy("height", "desc")
     .first();
+  trustRegistrySnapshotCache.set(cacheKey, { expiresAt: now + DID_QUERY_CACHE_TTL_MS, value });
+
+  const row = await value;
   addDid(dids, (row as any)?.did);
   addDid(dids, (row as any)?.controller);
 }
@@ -215,6 +236,9 @@ async function enrichRelatedDids(row: EventRow, meta: EventMeta, dids: Set<strin
   if (meta.module === "permission") {
     const permissionId = readNumber(row.content, ["id", "permission_id", "permissionId", "perm_id", "permId"]);
     if (!permissionId) return undefined;
+    const now = Date.now();
+    const permCacheKey = `${permissionId}:${row.block_height}`;
+    const cachedPerm = permissionSnapshotCache.get(permCacheKey);
     const columns = await existingColumns("permission_history", [
       "permission_id",
       "did",
@@ -226,12 +250,19 @@ async function enrichRelatedDids(row: EventRow, meta: EventMeta, dids: Set<strin
       "repaid_by",
       "schema_id",
     ]);
-    const perm = await knex("permission_history")
-      .select(columns)
-      .where("permission_id", permissionId)
-      .where("height", "<=", row.block_height)
-      .orderBy("height", "desc")
-      .first();
+    const permPromise =
+      cachedPerm && cachedPerm.expiresAt > now
+        ? cachedPerm.value
+        : knex("permission_history")
+          .select(columns)
+          .where("permission_id", permissionId)
+          .where("height", "<=", row.block_height)
+          .orderBy("height", "desc")
+          .first();
+    if (!cachedPerm || cachedPerm.expiresAt <= now) {
+      permissionSnapshotCache.set(permCacheKey, { expiresAt: now + DID_QUERY_CACHE_TTL_MS, value: permPromise });
+    }
+    const perm = await permPromise;
     addDid(dids, (perm as any)?.did);
     addDid(dids, (perm as any)?.grantee);
     addDid(dids, (perm as any)?.created_by);
@@ -241,12 +272,21 @@ async function enrichRelatedDids(row: EventRow, meta: EventMeta, dids: Set<strin
     addDid(dids, (perm as any)?.repaid_by);
     const schemaId = Number((perm as any)?.schema_id);
     if (Number.isInteger(schemaId) && schemaId > 0) {
-      const cs = await knex("credential_schema_history")
-        .select("tr_id")
-        .where("credential_schema_id", schemaId)
-        .where("height", "<=", row.block_height)
-        .orderBy("height", "desc")
-        .first();
+      const csCacheKey = `${schemaId}:${row.block_height}`;
+      const cachedCs = credentialSchemaSnapshotCache.get(csCacheKey);
+      const csPromise =
+        cachedCs && cachedCs.expiresAt > now
+          ? cachedCs.value
+          : knex("credential_schema_history")
+            .select("tr_id")
+            .where("credential_schema_id", schemaId)
+            .where("height", "<=", row.block_height)
+            .orderBy("height", "desc")
+            .first();
+      if (!cachedCs || cachedCs.expiresAt <= now) {
+        credentialSchemaSnapshotCache.set(csCacheKey, { expiresAt: now + DID_QUERY_CACHE_TTL_MS, value: csPromise });
+      }
+      const cs = await csPromise;
       await addTrustRegistryDids(Number((cs as any)?.tr_id) || null, row.block_height, dids);
     }
     return String(permissionId);
@@ -380,11 +420,7 @@ async function buildIndexerTxEvents(args: {
     .orderBy("tm.index", "asc")
     .limit(limit);
 
-  if (Number.isInteger(args.blockHeight)) {
-    query.andWhere("tx.height", Number(args.blockHeight));
-  } else if (Number.isInteger(args.afterBlockHeight)) {
-    query.andWhere("tx.height", ">", Number(args.afterBlockHeight));
-  }
+  applyBlockHeightFilter(query, args, "tx.height");
 
   const rows = (await query) as EventRow[];
   return (await Promise.all(rows.map((row) => toIndexerEvent(row)))).filter(Boolean) as IndexerTxEvent[];
@@ -443,11 +479,7 @@ export async function listIndexerEvents(args: {
 
   if (args.ids) query.whereIn("id", args.ids);
   if (args.did) query.where("did", args.did);
-  if (Number.isInteger(args.blockHeight)) {
-    query.andWhere("block_height", Number(args.blockHeight));
-  } else if (Number.isInteger(args.afterBlockHeight)) {
-    query.andWhere("block_height", ">", Number(args.afterBlockHeight));
-  }
+  applyBlockHeightFilter(query, args, "block_height");
 
   const rows = (await query) as Array<Record<string, any>>;
   return rows.map(fromStoredRow);

--- a/src/services/api/indexer_events_query.ts
+++ b/src/services/api/indexer_events_query.ts
@@ -4,7 +4,7 @@ import {
   VeranaPermissionMessageTypes,
   VeranaTrustRegistryMessageTypes,
 } from "../../common/verana-message-types";
-import { applyBlockHeightFilter, isValidDid } from "./api_shared";
+import { applyBlockHeightFilter, isValidDid, toIsoSeconds } from "./api_shared";
 
 export type IndexerTxEvent = {
   type: "transaction-executed";
@@ -23,23 +23,22 @@ export type IndexerTxEvent = {
 };
 
 export type IndexerEventRecord = {
-  id?: number;
   type: "indexer-event";
-  eventType: string;
+  event_type: string;
   did: string;
-  blockHeight: number;
-  txHash: string;
+  block_height: number;
+  tx_hash: string;
   timestamp: string;
   payload: {
     module: IndexerTxEvent["module"];
     action: string;
-    messageType: string;
-    txIndex: number;
-    messageIndex: number;
+    message_type: string;
+    tx_index: number;
+    message_index: number;
     sender: string;
-    relatedDids: string[];
-    entityType?: string;
-    entityId?: string;
+    related_dids: string[];
+    entity_type?: string;
+    entity_id?: string;
   };
 };
 
@@ -162,6 +161,7 @@ class ExpiringBoundedMap<K, V extends { expiresAt: number }> extends Map<K, V> {
   }
 
   override get(key: K): V | undefined {
+    this.pruneExpired();
     const entry = super.get(key);
     if (!entry) return undefined;
     if (entry.expiresAt <= Date.now()) {
@@ -187,21 +187,12 @@ const permissionSnapshotCache = new ExpiringBoundedMap<string, { expiresAt: numb
 const credentialSchemaSnapshotCache = new ExpiringBoundedMap<string, { expiresAt: number; value: Promise<any> }>(CACHE_MAX_ENTRIES);
 const trustRegistrySnapshotCache = new ExpiringBoundedMap<string, { expiresAt: number; value: Promise<any> }>(CACHE_MAX_ENTRIES);
 
-function toIsoSeconds(value: Date | string): string {
-  const date = value instanceof Date ? value : new Date(value);
-  return date.toISOString().replace(/\.\d{3}Z$/, "Z");
-}
-
-function isDid(value: unknown): value is string {
-  return isValidDid(value);
-}
-
 function addDid(out: Set<string>, value: unknown): void {
-  if (isDid(value)) out.add(value);
+  if (isValidDid(value)) out.add(value);
 }
 
 function collectDids(value: unknown, out: Set<string>): void {
-  if (isDid(value)) {
+  if (isValidDid(value)) {
     out.add(value);
     return;
   }
@@ -396,36 +387,40 @@ function toEventRows(event: IndexerTxEvent): Array<Record<string, unknown>> {
     payload: {
       module: event.module,
       action: event.action,
-      messageType: event.messageType,
-      txIndex: event.txIndex,
-      messageIndex: event.messageIndex,
+      message_type: event.messageType,
+      tx_index: event.txIndex,
+      message_index: event.messageIndex,
       sender: event.sender,
-      relatedDids: event.relatedDids,
-      entityType: event.entityType,
-      entityId: event.entityId,
+      related_dids: event.relatedDids,
+      entity_type: event.entityType,
+      entity_id: event.entityId,
     },
   }));
 }
 
 function fromStoredRow(row: Record<string, any>): IndexerEventRecord {
   return {
-    id: Number(row.id),
     type: "indexer-event",
-    eventType: String(row.event_type),
+    event_type: String(row.event_type),
     did: String(row.did),
-    blockHeight: Number(row.block_height),
-    txHash: String(row.tx_hash),
+    block_height: Number(row.block_height),
+    tx_hash: String(row.tx_hash),
     timestamp: toIsoSeconds(row.timestamp),
     payload: {
       module: row.payload?.module ?? row.module,
       action: row.payload?.action ?? row.event_type,
-      messageType: row.payload?.messageType ?? row.message_type,
-      txIndex: Number(row.payload?.txIndex ?? row.tx_index ?? 0),
-      messageIndex: Number(row.payload?.messageIndex ?? row.message_index ?? 0),
+      // Backward compatible: accept old camelCase payload keys.
+      message_type: row.payload?.message_type ?? row.payload?.messageType ?? row.message_type,
+      tx_index: Number(row.payload?.tx_index ?? row.payload?.txIndex ?? row.tx_index ?? 0),
+      message_index: Number(row.payload?.message_index ?? row.payload?.messageIndex ?? row.message_index ?? 0),
       sender: String(row.payload?.sender ?? ""),
-      relatedDids: Array.isArray(row.payload?.relatedDids) ? row.payload.relatedDids : [String(row.did)],
-      entityType: row.payload?.entityType ?? row.entity_type ?? undefined,
-      entityId: row.payload?.entityId ?? row.entity_id ?? undefined,
+      related_dids: Array.isArray(row.payload?.related_dids)
+        ? row.payload.related_dids
+        : Array.isArray(row.payload?.relatedDids)
+          ? row.payload.relatedDids
+          : [String(row.did)],
+      entity_type: row.payload?.entity_type ?? row.payload?.entityType ?? row.entity_type ?? undefined,
+      entity_id: row.payload?.entity_id ?? row.payload?.entityId ?? row.entity_id ?? undefined,
     },
   };
 }

--- a/src/services/api/indexer_events_query.ts
+++ b/src/services/api/indexer_events_query.ts
@@ -1,0 +1,454 @@
+import knex from "../../common/utils/db_connection";
+import {
+  VeranaCredentialSchemaMessageTypes,
+  VeranaPermissionMessageTypes,
+  VeranaTrustRegistryMessageTypes,
+} from "../../common/verana-message-types";
+
+export type IndexerTxEvent = {
+  type: "transaction-executed";
+  module: "trust-registry" | "credential-schema" | "permission";
+  action: string;
+  messageType: string;
+  blockHeight: number;
+  txHash: string;
+  txIndex: number;
+  messageIndex: number;
+  sender: string;
+  relatedDids: string[];
+  entityType?: string;
+  entityId?: string;
+  timestamp: string;
+};
+
+export type IndexerEventRecord = {
+  id?: number;
+  type: "indexer-event";
+  eventType: string;
+  did: string;
+  blockHeight: number;
+  txHash: string;
+  timestamp: string;
+  payload: {
+    module: IndexerTxEvent["module"];
+    action: string;
+    messageType: string;
+    txIndex: number;
+    messageIndex: number;
+    sender: string;
+    relatedDids: string[];
+    entityType?: string;
+    entityId?: string;
+  };
+};
+
+type EventRow = {
+  message_id: number;
+  tx_id: number;
+  message_index: number;
+  message_type: string;
+  sender: string;
+  content: unknown;
+  block_height: number;
+  tx_hash: string;
+  tx_index: number;
+  timestamp: Date | string;
+};
+
+type EventMeta = {
+  module: IndexerTxEvent["module"];
+  action: string;
+  entityType?: string;
+};
+
+const EVENT_META: Record<string, EventMeta> = {
+  [VeranaTrustRegistryMessageTypes.CreateTrustRegistry]: {
+    module: "trust-registry",
+    action: "CreateNewTrustRegistry",
+    entityType: "TrustRegistry",
+  },
+  [VeranaTrustRegistryMessageTypes.UpdateTrustRegistry]: {
+    module: "trust-registry",
+    action: "UpdateTrustRegistry",
+    entityType: "TrustRegistry",
+  },
+  [VeranaTrustRegistryMessageTypes.AddGovernanceFrameworkDoc]: {
+    module: "trust-registry",
+    action: "AddGovernanceFrameworkDocument",
+    entityType: "GovernanceFrameworkDocument",
+  },
+  [VeranaTrustRegistryMessageTypes.IncreaseGovernanceFrameworkVersion]: {
+    module: "trust-registry",
+    action: "IncreaseActiveGFVersion",
+    entityType: "GovernanceFrameworkVersion",
+  },
+  [VeranaCredentialSchemaMessageTypes.CreateCredentialSchema]: {
+    module: "credential-schema",
+    action: "CreateNewCredentialSchema",
+    entityType: "CredentialSchema",
+  },
+  [VeranaCredentialSchemaMessageTypes.UpdateCredentialSchema]: {
+    module: "credential-schema",
+    action: "UpdateCredentialSchema",
+    entityType: "CredentialSchema",
+  },
+  [VeranaCredentialSchemaMessageTypes.ArchiveCredentialSchema]: {
+    module: "credential-schema",
+    action: "ArchiveCredentialSchema",
+    entityType: "CredentialSchema",
+  },
+  [VeranaPermissionMessageTypes.StartPermissionVP]: {
+    module: "permission",
+    action: "StartPermissionVP",
+    entityType: "Permission",
+  },
+  [VeranaPermissionMessageTypes.RenewPermissionVP]: {
+    module: "permission",
+    action: "RenewPermissionVP",
+    entityType: "Permission",
+  },
+  [VeranaPermissionMessageTypes.SetPermissionVPToValidated]: {
+    module: "permission",
+    action: "SetPermissionVPToValidated",
+    entityType: "Permission",
+  },
+  [VeranaPermissionMessageTypes.ExtendPermission]: {
+    module: "permission",
+    action: "AdjustPermission",
+    entityType: "Permission",
+  },
+  [VeranaPermissionMessageTypes.RevokePermission]: {
+    module: "permission",
+    action: "RevokePermission",
+    entityType: "Permission",
+  },
+  [VeranaPermissionMessageTypes.SlashPermissionTrustDeposit]: {
+    module: "permission",
+    action: "SlashPermissionTrustDeposit",
+    entityType: "Permission",
+  },
+  [VeranaPermissionMessageTypes.RepayPermissionSlashedTrustDeposit]: {
+    module: "permission",
+    action: "RepayPermissionSlashedTrustDeposit",
+    entityType: "Permission",
+  },
+  [VeranaPermissionMessageTypes.CancelPermissionVPLastRequest]: {
+    module: "permission",
+    action: "CancelPermissionVPLastRequest",
+    entityType: "Permission",
+  },
+};
+
+const WATCHED_MESSAGE_TYPES = Object.keys(EVENT_META);
+const tableColumnsCache = new Map<string, Promise<Set<string>>>();
+
+function toIsoSeconds(value: Date | string): string {
+  const date = value instanceof Date ? value : new Date(value);
+  return date.toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+function isDid(value: unknown): value is string {
+  return typeof value === "string" && value.startsWith("did:");
+}
+
+function addDid(out: Set<string>, value: unknown): void {
+  if (isDid(value)) out.add(value);
+}
+
+function collectDids(value: unknown, out: Set<string>): void {
+  if (isDid(value)) {
+    out.add(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectDids(item, out));
+    return;
+  }
+  if (value && typeof value === "object") {
+    Object.values(value as Record<string, unknown>).forEach((item) => collectDids(item, out));
+  }
+}
+
+function readNumber(content: unknown, keys: string[]): number | null {
+  if (!content || typeof content !== "object") return null;
+  const obj = content as Record<string, unknown>;
+  for (const key of keys) {
+    const raw = obj[key];
+    const n = Number(raw);
+    if (Number.isInteger(n) && n > 0) return n;
+  }
+  return null;
+}
+
+async function getTableColumns(tableName: string): Promise<Set<string>> {
+  let columns = tableColumnsCache.get(tableName);
+  if (!columns) {
+    columns = knex(tableName)
+      .columnInfo()
+      .then((info) => new Set(Object.keys(info)));
+    tableColumnsCache.set(tableName, columns);
+  }
+  return columns;
+}
+
+async function existingColumns(tableName: string, columns: string[]): Promise<string[]> {
+  const available = await getTableColumns(tableName);
+  return columns.filter((column) => available.has(column));
+}
+
+async function addTrustRegistryDids(trId: number | null, height: number, dids: Set<string>): Promise<void> {
+  if (!trId) return;
+  const columns = await existingColumns("trust_registry_history", ["did", "controller"]);
+  if (columns.length === 0) return;
+
+  const row = await knex("trust_registry_history")
+    .select(columns)
+    .where("tr_id", trId)
+    .where("height", "<=", height)
+    .orderBy("height", "desc")
+    .first();
+  addDid(dids, (row as any)?.did);
+  addDid(dids, (row as any)?.controller);
+}
+
+async function enrichRelatedDids(row: EventRow, meta: EventMeta, dids: Set<string>): Promise<string | undefined> {
+  if (meta.module === "permission") {
+    const permissionId = readNumber(row.content, ["id", "permission_id", "permissionId", "perm_id", "permId"]);
+    if (!permissionId) return undefined;
+    const columns = await existingColumns("permission_history", [
+      "permission_id",
+      "did",
+      "grantee",
+      "created_by",
+      "extended_by",
+      "revoked_by",
+      "slashed_by",
+      "repaid_by",
+      "schema_id",
+    ]);
+    const perm = await knex("permission_history")
+      .select(columns)
+      .where("permission_id", permissionId)
+      .where("height", "<=", row.block_height)
+      .orderBy("height", "desc")
+      .first();
+    addDid(dids, (perm as any)?.did);
+    addDid(dids, (perm as any)?.grantee);
+    addDid(dids, (perm as any)?.created_by);
+    addDid(dids, (perm as any)?.extended_by);
+    addDid(dids, (perm as any)?.revoked_by);
+    addDid(dids, (perm as any)?.slashed_by);
+    addDid(dids, (perm as any)?.repaid_by);
+    const schemaId = Number((perm as any)?.schema_id);
+    if (Number.isInteger(schemaId) && schemaId > 0) {
+      const cs = await knex("credential_schema_history")
+        .select("tr_id")
+        .where("credential_schema_id", schemaId)
+        .where("height", "<=", row.block_height)
+        .orderBy("height", "desc")
+        .first();
+      await addTrustRegistryDids(Number((cs as any)?.tr_id) || null, row.block_height, dids);
+    }
+    return String(permissionId);
+  }
+
+  if (meta.module === "credential-schema") {
+    const schemaId = readNumber(row.content, ["id", "schema_id", "schemaId", "credential_schema_id", "credentialSchemaId"]);
+    const trIdFromContent = readNumber(row.content, ["tr_id", "trId", "trust_registry_id", "trustRegistryId"]);
+    let trId = trIdFromContent;
+    if (schemaId) {
+      const columns = await existingColumns("credential_schema_history", ["credential_schema_id", "tr_id"]);
+      const cs = await knex("credential_schema_history")
+        .select(columns)
+        .where("credential_schema_id", schemaId)
+        .where("height", "<=", row.block_height)
+        .orderBy("height", "desc")
+        .first();
+      trId = Number((cs as any)?.tr_id) || trId;
+    }
+    await addTrustRegistryDids(trId, row.block_height, dids);
+    return schemaId ? String(schemaId) : undefined;
+  }
+
+  const trId =
+    readNumber(row.content, ["id", "tr_id", "trId", "trust_registry_id", "trustRegistryId"]) ??
+    readNumber(row.content, ["gfv_id", "gfvId", "gfd_id", "gfdId"]);
+  await addTrustRegistryDids(trId, row.block_height, dids);
+  return trId ? String(trId) : undefined;
+}
+
+async function toIndexerEvent(row: EventRow): Promise<IndexerTxEvent | null> {
+  const meta = EVENT_META[row.message_type];
+  if (!meta) return null;
+
+  const relatedDids = new Set<string>();
+  addDid(relatedDids, row.sender);
+  collectDids(row.content, relatedDids);
+  const entityId = await enrichRelatedDids(row, meta, relatedDids);
+
+  return {
+    type: "transaction-executed",
+    module: meta.module,
+    action: meta.action,
+    messageType: row.message_type,
+    blockHeight: Number(row.block_height),
+    txHash: row.tx_hash,
+    txIndex: Number(row.tx_index),
+    messageIndex: Number(row.message_index),
+    sender: row.sender,
+    relatedDids: Array.from(relatedDids).sort(),
+    entityType: meta.entityType,
+    entityId,
+    timestamp: toIsoSeconds(row.timestamp),
+  };
+}
+
+function toEventRows(event: IndexerTxEvent): Array<Record<string, unknown>> {
+  return event.relatedDids.map((did) => ({
+    event_type: event.action,
+    did,
+    block_height: event.blockHeight,
+    tx_hash: event.txHash,
+    tx_index: event.txIndex,
+    message_index: event.messageIndex,
+    message_type: event.messageType,
+    module: event.module,
+    entity_type: event.entityType ?? null,
+    entity_id: event.entityId ?? null,
+    timestamp: event.timestamp,
+    payload: {
+      module: event.module,
+      action: event.action,
+      messageType: event.messageType,
+      txIndex: event.txIndex,
+      messageIndex: event.messageIndex,
+      sender: event.sender,
+      relatedDids: event.relatedDids,
+      entityType: event.entityType,
+      entityId: event.entityId,
+    },
+  }));
+}
+
+function fromStoredRow(row: Record<string, any>): IndexerEventRecord {
+  return {
+    id: Number(row.id),
+    type: "indexer-event",
+    eventType: String(row.event_type),
+    did: String(row.did),
+    blockHeight: Number(row.block_height),
+    txHash: String(row.tx_hash),
+    timestamp: toIsoSeconds(row.timestamp),
+    payload: {
+      module: row.payload?.module ?? row.module,
+      action: row.payload?.action ?? row.event_type,
+      messageType: row.payload?.messageType ?? row.message_type,
+      txIndex: Number(row.payload?.txIndex ?? row.tx_index ?? 0),
+      messageIndex: Number(row.payload?.messageIndex ?? row.message_index ?? 0),
+      sender: String(row.payload?.sender ?? ""),
+      relatedDids: Array.isArray(row.payload?.relatedDids) ? row.payload.relatedDids : [String(row.did)],
+      entityType: row.payload?.entityType ?? row.entity_type ?? undefined,
+      entityId: row.payload?.entityId ?? row.entity_id ?? undefined,
+    },
+  };
+}
+
+async function buildIndexerTxEvents(args: {
+  afterBlockHeight?: number;
+  blockHeight?: number;
+  limit?: number;
+}): Promise<IndexerTxEvent[]> {
+  const limit = Math.max(1, Math.min(500, Math.floor(Number(args.limit ?? 100))));
+  const query = knex("transaction_message as tm")
+    .innerJoin("transaction as tx", "tx.id", "tm.tx_id")
+    .whereIn("tm.type", WATCHED_MESSAGE_TYPES)
+    .andWhere("tx.code", 0)
+    .select(
+      "tm.id as message_id",
+      "tm.tx_id",
+      "tm.index as message_index",
+      "tm.type as message_type",
+      "tm.sender",
+      "tm.content",
+      "tx.height as block_height",
+      "tx.hash as tx_hash",
+      "tx.index as tx_index",
+      "tx.timestamp"
+    )
+    .orderBy("tx.height", "asc")
+    .orderBy("tx.index", "asc")
+    .orderBy("tm.index", "asc")
+    .limit(limit);
+
+  if (Number.isInteger(args.blockHeight)) {
+    query.andWhere("tx.height", Number(args.blockHeight));
+  } else if (Number.isInteger(args.afterBlockHeight)) {
+    query.andWhere("tx.height", ">", Number(args.afterBlockHeight));
+  }
+
+  const rows = (await query) as EventRow[];
+  return (await Promise.all(rows.map((row) => toIndexerEvent(row)))).filter(Boolean) as IndexerTxEvent[];
+}
+
+export async function persistIndexerEventsForBlock(blockHeight: number): Promise<IndexerEventRecord[]> {
+  const txEvents = await buildIndexerTxEvents({ blockHeight, limit: 500 });
+  const rows = txEvents.flatMap(toEventRows);
+  let insertedIds: number[] = [];
+
+  if (rows.length > 0) {
+    const inserted = await knex("indexer_events")
+      .insert(rows)
+      .onConflict(["did", "tx_hash", "message_index", "event_type"])
+      .ignore()
+      .returning("id");
+    insertedIds = inserted
+      .map((row: number | string | { id?: number | string }) => Number(typeof row === "object" ? row.id : row))
+      .filter((id): id is number => Number.isInteger(id));
+  }
+
+  if (insertedIds.length === 0) return [];
+  return listIndexerEvents({ ids: insertedIds, limit: 500 });
+}
+
+export async function listIndexerEvents(args: {
+  afterBlockHeight?: number;
+  blockHeight?: number;
+  did?: string;
+  ids?: number[];
+  limit?: number;
+}): Promise<IndexerEventRecord[]> {
+  const limit = Math.max(1, Math.min(500, Math.floor(Number(args.limit ?? 100))));
+  const query = knex("indexer_events")
+    .select(
+      "id",
+      "event_type",
+      "did",
+      "block_height",
+      "tx_hash",
+      "tx_index",
+      "message_index",
+      "message_type",
+      "module",
+      "entity_type",
+      "entity_id",
+      "timestamp",
+      "payload"
+    )
+    .orderBy("block_height", "asc")
+    .orderBy("tx_index", "asc")
+    .orderBy("message_index", "asc")
+    .orderBy("did", "asc")
+    .orderBy("id", "asc")
+    .limit(limit);
+
+  if (args.ids) query.whereIn("id", args.ids);
+  if (args.did) query.where("did", args.did);
+  if (Number.isInteger(args.blockHeight)) {
+    query.andWhere("block_height", Number(args.blockHeight));
+  } else if (Number.isInteger(args.afterBlockHeight)) {
+    query.andWhere("block_height", ">", Number(args.afterBlockHeight));
+  }
+
+  const rows = (await query) as Array<Record<string, any>>;
+  return rows.map(fromStoredRow);
+}

--- a/src/services/crawl-genesis/crawl_genesis.service.ts
+++ b/src/services/crawl-genesis/crawl_genesis.service.ts
@@ -217,7 +217,7 @@ export default class CrawlGenesisService extends BullableService {
     try {
       const accountsInDb = await Account.query().findOne({});
       if (accountsInDb) {
-        this.logger.error('DB already contains some accounts');
+        this.logger.warn('DB already contains some accounts; skipping genesis account import');
         done = true;
       }
     } catch (error: any) {

--- a/test/manual/test-websocket-did-room.ts
+++ b/test/manual/test-websocket-did-room.ts
@@ -1,0 +1,73 @@
+/* eslint-disable no-console */
+
+import WebSocket from "ws";
+
+type IndexerEventMessage = {
+  type: "indexer-event";
+  eventType: string;
+  did: string;
+  blockHeight: number;
+  txHash: string;
+  timestamp: string;
+  payload: Record<string, unknown>;
+};
+
+type ConnectedMessage = {
+  type: "connected";
+  did?: string;
+  blockHeight?: number | null;
+  timestamp: string;
+};
+
+type Message = ConnectedMessage | IndexerEventMessage | Record<string, unknown>;
+
+const baseUrl = process.env.INDEXER_WS_URL || "ws://localhost:3001/verana/indexer/v1/events";
+const did = process.env.DID || "did:web:agent.example";
+const afterBlockHeight = Number(process.env.AFTER_BLOCK_HEIGHT || 0);
+const wsUrl = `${baseUrl}?did=${encodeURIComponent(did)}`;
+
+function httpReplayUrl(blockHeight: number): string {
+  const httpBase = (process.env.INDEXER_HTTP_URL || "http://localhost:3001").replace(/\/$/, "");
+  return `${httpBase}/verana/indexer/v1/events?did=${encodeURIComponent(did)}&after_block_height=${blockHeight}`;
+}
+
+async function replayMissedEvents(blockHeight: number): Promise<void> {
+  const url = httpReplayUrl(blockHeight);
+  const response = await fetch(url);
+  const body = await response.json();
+  console.log("Replay response:", JSON.stringify(body, null, 2));
+}
+
+const ws = new WebSocket(wsUrl);
+
+ws.on("open", () => {
+  console.log(`Connected to DID room: ${did}`);
+});
+
+ws.on("message", async (data: WebSocket.Data) => {
+  const message = JSON.parse(data.toString()) as Message;
+  console.log("Received:", JSON.stringify(message, null, 2));
+
+  if (message.type === "connected") {
+    const connectedAt = Number(message.blockHeight ?? afterBlockHeight);
+    await replayMissedEvents(afterBlockHeight || connectedAt);
+  }
+
+  if (message.type === "indexer-event") {
+    console.log(`DID event ${message.eventType} at block ${message.blockHeight}`);
+  }
+});
+
+ws.on("error", (err: Error) => {
+  console.error("WebSocket error:", err.message);
+});
+
+ws.on("close", () => {
+  console.log("WebSocket connection closed");
+});
+
+process.on("SIGINT", () => {
+  ws.close();
+  process.exit(0);
+});
+

--- a/test/unit/services/api/events_broadcaster.spec.ts
+++ b/test/unit/services/api/events_broadcaster.spec.ts
@@ -1,6 +1,88 @@
-import { EventsBroadcaster } from "../../../../src/services/api/events_broadcaster";
 import { createServer, Server } from "http";
 import { WebSocket } from "ws";
+import { EventsBroadcaster } from "../../../../src/services/api/events_broadcaster";
+import type { IndexerEventRecord } from "../../../../src/services/api/indexer_events_query";
+
+function waitForMessage(ws: WebSocket, predicate: (message: any) => boolean, timeoutMs = 1500): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      ws.off("message", onMessage);
+      reject(new Error("Timed out waiting for WebSocket message"));
+    }, timeoutMs);
+
+    const onMessage = (data: WebSocket.RawData) => {
+      const message = JSON.parse(data.toString());
+      if (!predicate(message)) return;
+      clearTimeout(timeout);
+      ws.off("message", onMessage);
+      resolve(message);
+    };
+
+    ws.on("message", onMessage);
+  });
+}
+
+function waitForOpen(ws: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    ws.once("open", () => resolve());
+    ws.once("error", reject);
+  });
+}
+
+function waitForClose(ws: WebSocket): Promise<{ code: number; reason: string }> {
+  return new Promise((resolve) => {
+    ws.once("close", (code, reason) => {
+      resolve({ code, reason: reason.toString() });
+    });
+  });
+}
+
+function waitForCondition(predicate: () => boolean, timeoutMs = 1500): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const startedAt = Date.now();
+    const check = () => {
+      if (predicate()) {
+        resolve();
+        return;
+      }
+      if (Date.now() - startedAt >= timeoutMs) {
+        reject(new Error("Timed out waiting for condition"));
+        return;
+      }
+      setTimeout(check, 25);
+    };
+    check();
+  });
+}
+
+function closeSocket(ws: WebSocket): void {
+  if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+    ws.close();
+  }
+}
+
+function makeEvent(did: string, overrides: Partial<IndexerEventRecord> = {}): IndexerEventRecord {
+  return {
+    type: "indexer-event",
+    eventType: "StartPermissionVP",
+    did,
+    blockHeight: 123456,
+    txHash: "ABC123",
+    timestamp: "2025-01-15T10:30:00Z",
+    payload: {
+      module: "permission",
+      action: "StartPermissionVP",
+      messageType: "/verana.perm.v1.MsgStartPermissionVP",
+      txIndex: 0,
+      messageIndex: 0,
+      sender: did,
+      relatedDids: [did],
+      entityType: "Permission",
+      entityId: "42",
+    },
+    ...overrides,
+  };
+}
 
 describe("EventsBroadcaster", () => {
   let broadcaster: EventsBroadcaster;
@@ -8,372 +90,198 @@ describe("EventsBroadcaster", () => {
   const TEST_PORT = 9999;
   const WS_URL = `ws://localhost:${TEST_PORT}/verana/indexer/v1/events`;
 
-  beforeAll(() => {
-    broadcaster = new EventsBroadcaster();
+  beforeAll((done) => {
     httpServer = createServer();
-    broadcaster.initialize(httpServer);
-    httpServer.listen(TEST_PORT);
+    httpServer.listen(TEST_PORT, done);
   });
 
   afterAll((done) => {
+    broadcaster?.close();
+    httpServer.close(() => done());
+  });
+
+  beforeEach(() => {
+    broadcaster?.close();
+    broadcaster = new EventsBroadcaster();
+    broadcaster.setLogger({ info: () => {}, warn: () => {}, error: () => {} });
+    broadcaster.initialize(httpServer);
+  });
+
+  afterEach(() => {
     broadcaster.close();
-    setTimeout(() => {
-      httpServer.close(() => {
-        done();
-      });
-    }, 100);
   });
 
-  beforeEach((done) => {
-    if (broadcaster) {
-      broadcaster.close();
-    }
-    setTimeout(() => {
-      broadcaster = new EventsBroadcaster();
-      broadcaster.initialize(httpServer);
-      setTimeout(() => {
-        done();
-      }, 150);
-    }, 200);
+  it("accepts WebSocket connections and sends a connected message", async () => {
+    const ws = new WebSocket(WS_URL);
+    await waitForOpen(ws);
+
+    const message = await waitForMessage(ws, (msg) => msg.type === "connected");
+    expect(message).toMatchObject({
+      type: "connected",
+      message: "Connected to Verana Indexer Events",
+    });
+    expect(Object.prototype.hasOwnProperty.call(message, "blockHeight")).toBe(true);
+    expect(message.did).toBeUndefined();
+    expect(broadcaster.getWSClientCount()).toBe(1);
+
+    closeSocket(ws);
+    await waitForClose(ws);
+    await waitForCondition(() => broadcaster.getWSClientCount() === 0);
+    expect(broadcaster.getWSClientCount()).toBe(0);
   });
 
-  describe("WebSocket Connection", () => {
-    it("should accept WebSocket connections", (done) => {
-      const ws = new WebSocket(WS_URL);
+  it("rejects an invalid DID query", async () => {
+    const ws = new WebSocket(`${WS_URL}?did=${encodeURIComponent("not-a-did")}`);
+    const close = await waitForClose(ws);
 
-      ws.on("open", () => {
-        expect(broadcaster.getWSClientCount()).toBe(1);
-        ws.close();
-      });
-
-      ws.on("close", () => {
-        setTimeout(() => {
-          expect(broadcaster.getWSClientCount()).toBe(0);
-          done();
-        }, 100);
-      });
-
-      ws.on("error", (error) => {
-        done(error);
-      });
-    }, 10000);
-
-    it("should send welcome message on connection", (done) => {
-      const ws = new WebSocket(WS_URL);
-      let welcomeReceived = false;
-
-      ws.on("open", () => {
-        setTimeout(() => {
-          if (!welcomeReceived) {
-            ws.close();
-            done(new Error("Welcome message not received"));
-          }
-        }, 1000);
-      });
-
-      ws.on("message", (data) => {
-        try {
-          const message = JSON.parse(data.toString());
-          expect(message.type).toBe("connected");
-          expect(message.message).toBe("Connected to Verana Indexer Events");
-          welcomeReceived = true;
-          ws.close();
-        } catch (error) {
-          done(error);
-        }
-      });
-
-      ws.on("close", () => {
-        if (welcomeReceived) {
-          done();
-        }
-      });
-
-      ws.on("error", (error) => {
-        done(error);
-      });
-    }, 10000);
-
-    it("should handle multiple concurrent connections", (done) => {
-      const clients: WebSocket[] = [];
-      const clientCount = 3;
-      let connectedCount = 0;
-
-      for (let i = 0; i < clientCount; i++) {
-        const ws = new WebSocket(WS_URL);
-        clients.push(ws);
-
-        ws.on("open", () => {
-          connectedCount++;
-          if (connectedCount === clientCount) {
-            expect(broadcaster.getWSClientCount()).toBe(clientCount);
-            clients.forEach((client) => client.close());
-          }
-        });
-
-        ws.on("close", () => {
-          if (clients.every((c) => c.readyState === WebSocket.CLOSED)) {
-            setTimeout(() => {
-              expect(broadcaster.getWSClientCount()).toBe(0);
-              done();
-            }, 200);
-          }
-        });
-
-        ws.on("error", (error) => {
-          done(error);
-        });
-      }
-    }, 15000);
+    expect(close.code).toBe(1008);
+    expect(close.reason).toBe("Invalid did query parameter");
+    expect(broadcaster.getWSClientCount()).toBe(0);
   });
 
-  describe("Block Processed Events", () => {
-    it("should broadcast block-processed events to all connected clients", (done) => {
-      const ws1 = new WebSocket(WS_URL);
-      const ws2 = new WebSocket(WS_URL);
-      const receivedMessages: any[] = [];
-      let bothConnected = false;
+  it("includes did and blockHeight in DID room connected messages", async () => {
+    const did = "did:web:agent.example";
+    const ws = new WebSocket(`${WS_URL}?did=${encodeURIComponent(did)}`);
+    await waitForOpen(ws);
 
-      const checkDone = () => {
-        if (bothConnected && receivedMessages.length === 2) {
-          receivedMessages.forEach((msg) => {
-            expect(msg.type).toBe("block-processed");
-            expect(msg.height).toBe(123456);
-            expect(msg.timestamp).toBeDefined();
-          });
-          ws1.close();
-          ws2.close();
-          done();
-        }
-      };
+    const message = await waitForMessage(ws, (msg) => msg.type === "connected");
+    expect(message.did).toBe(did);
+    expect(Object.prototype.hasOwnProperty.call(message, "blockHeight")).toBe(true);
 
-      ws1.on("open", () => {
-        ws2.on("open", () => {
-          bothConnected = true;
-          broadcaster.broadcastBlockProcessed(123456, new Date());
-        });
-      });
-
-      ws1.on("message", (data) => {
-        const message = JSON.parse(data.toString());
-        if (message.type === "block-processed") {
-          receivedMessages.push(message);
-          checkDone();
-        }
-      });
-
-      ws2.on("message", (data) => {
-        const message = JSON.parse(data.toString());
-        if (message.type === "block-processed") {
-          receivedMessages.push(message);
-          checkDone();
-        }
-      });
-
-      ws1.on("error", (error) => done(error));
-      ws2.on("error", (error) => done(error));
-    }, 10000);
-
-    it("should format timestamp correctly", (done) => {
-      const ws = new WebSocket(WS_URL);
-      const testTimestamp = new Date("2025-01-15T10:30:00.000Z");
-      const expectedFormat = "2025-01-15T10:30:00Z";
-      let blockProcessedReceived = false;
-
-      ws.on("open", () => {
-        broadcaster.broadcastBlockProcessed(789012, testTimestamp);
-      });
-
-      ws.on("message", (data) => {
-        const message = JSON.parse(data.toString());
-        if (message.type === "block-processed") {
-          expect(message.timestamp).toBe(expectedFormat);
-          expect(new Date(message.timestamp).getTime()).toBe(testTimestamp.getTime());
-          blockProcessedReceived = true;
-          ws.close();
-        }
-      });
-
-      ws.on("close", () => {
-        if (blockProcessedReceived) {
-          done();
-        } else {
-          done(new Error("Block processed message not received"));
-        }
-      });
-
-      ws.on("error", (error) => {
-        done(error);
-      });
-    }, 10000);
-
-    it("should handle string timestamps", (done) => {
-      const ws = new WebSocket(WS_URL);
-      const testTimestamp = "2025-01-15T10:30:00.000Z";
-      const expectedFormat = "2025-01-15T10:30:00Z";
-      let blockProcessedReceived = false;
-
-      ws.on("open", () => {
-        broadcaster.broadcastBlockProcessed(345678, testTimestamp);
-      });
-
-      ws.on("message", (data) => {
-        const message = JSON.parse(data.toString());
-        if (message.type === "block-processed") {
-          expect(message.timestamp).toBe(expectedFormat);
-          blockProcessedReceived = true;
-          ws.close();
-        }
-      });
-
-      ws.on("close", () => {
-        if (blockProcessedReceived) {
-          done();
-        } else {
-          done(new Error("Block processed message not received"));
-        }
-      });
-
-      ws.on("error", (error) => {
-        done(error);
-      });
-    }, 10000);
+    closeSocket(ws);
   });
 
-  describe("Client Management", () => {
-    it("should track client count correctly", (done) => {
-      expect(broadcaster.getWSClientCount()).toBe(0);
+  it("delivers persisted indexer events only to matching DID subscribers", async () => {
+    const did = "did:web:agent.example";
+    const otherDid = "did:web:other.example";
+    const wsMatch = new WebSocket(`${WS_URL}?did=${encodeURIComponent(did)}`);
+    const wsOther = new WebSocket(`${WS_URL}?did=${encodeURIComponent(otherDid)}`);
+    await Promise.all([waitForOpen(wsMatch), waitForOpen(wsOther)]);
+    await Promise.all([
+      waitForMessage(wsMatch, (msg) => msg.type === "connected"),
+      waitForMessage(wsOther, (msg) => msg.type === "connected"),
+    ]);
 
-      const ws1 = new WebSocket(WS_URL);
-      const ws2 = new WebSocket(WS_URL);
-      let ws1Open = false;
-      let ws2Open = false;
-      let ws1Closed = false;
-      let ws2Closed = false;
+    const matchPromise = waitForMessage(wsMatch, (msg) => msg.type === "indexer-event");
+    let otherReceived = false;
+    wsOther.on("message", (data) => {
+      const message = JSON.parse(data.toString());
+      if (message.type === "indexer-event") otherReceived = true;
+    });
 
-      const checkBothOpen = () => {
-        if (ws1Open && ws2Open) {
-          setTimeout(() => {
-            const count = broadcaster.getWSClientCount();
-            expect(count).toBe(2);
-            ws1.close();
-            ws2.close();
-          }, 100);
-        }
-      };
+    broadcaster.broadcastIndexerEvent(makeEvent(did));
+    const received = await matchPromise;
+    await new Promise((resolve) => {
+      setTimeout(resolve, 200);
+    });
 
-      const checkBothClosed = () => {
-        if (ws1Closed && ws2Closed) {
-          setTimeout(() => {
-            expect(broadcaster.getWSClientCount()).toBe(0);
-            done();
-          }, 200);
-        }
-      };
+    expect(received.did).toBe(did);
+    expect(received.eventType).toBe("StartPermissionVP");
+    expect(otherReceived).toBe(false);
 
-      ws1.on("open", () => {
-        ws1Open = true;
-        setTimeout(() => {
-          const count = broadcaster.getWSClientCount();
-          expect(count).toBeGreaterThanOrEqual(1);
-        }, 50);
-        checkBothOpen();
-      });
-
-      ws2.on("open", () => {
-        ws2Open = true;
-        checkBothOpen();
-      });
-
-      ws1.on("close", () => {
-        ws1Closed = true;
-        checkBothClosed();
-      });
-
-      ws2.on("close", () => {
-        ws2Closed = true;
-        checkBothClosed();
-      });
-
-      ws1.on("error", (error) => done(error));
-      ws2.on("error", (error) => done(error));
-    }, 15000);
-
-    it("should cleanup disconnected clients", (done) => {
-      const ws = new WebSocket(WS_URL);
-
-      ws.on("open", () => {
-        expect(broadcaster.getWSClientCount()).toBe(1);
-        ws.close();
-      });
-
-      ws.on("close", () => {
-        setTimeout(() => {
-          expect(broadcaster.getWSClientCount()).toBe(0);
-          done();
-        }, 200);
-      });
-
-      ws.on("error", (error) => {
-        done(error);
-      });
-    }, 10000);
+    closeSocket(wsMatch);
+    closeSocket(wsOther);
   });
 
-  describe("Real-time Event Flow", () => {
-    it("should receive multiple block-processed events in sequence", (done) => {
-      const ws = new WebSocket(WS_URL);
-      const receivedHeights: number[] = [];
-      const expectedHeights = [100, 101, 102];
+  it("delivers multi-DID events to each relevant DID subscriber", async () => {
+    const didA = "did:web:agent-a.example";
+    const didB = "did:web:agent-b.example";
+    const wsA = new WebSocket(`${WS_URL}?did=${encodeURIComponent(didA)}`);
+    const wsB = new WebSocket(`${WS_URL}?did=${encodeURIComponent(didB)}`);
+    await Promise.all([waitForOpen(wsA), waitForOpen(wsB)]);
+    await Promise.all([
+      waitForMessage(wsA, (msg) => msg.type === "connected"),
+      waitForMessage(wsB, (msg) => msg.type === "connected"),
+    ]);
 
-      ws.on("open", () => {
-        setTimeout(() => broadcaster.broadcastBlockProcessed(100, new Date()), 100);
-        setTimeout(() => broadcaster.broadcastBlockProcessed(101, new Date()), 200);
-        setTimeout(() => broadcaster.broadcastBlockProcessed(102, new Date()), 300);
-      });
+    const eventA = makeEvent(didA, {
+      payload: { ...makeEvent(didA).payload, relatedDids: [didA, didB] },
+    });
+    const eventB = makeEvent(didB, {
+      txHash: eventA.txHash,
+      payload: { ...eventA.payload, relatedDids: [didA, didB] },
+    });
 
-      ws.on("message", (data) => {
-        const message = JSON.parse(data.toString());
-        if (message.type === "block-processed") {
-          receivedHeights.push(message.height);
-          if (receivedHeights.length === expectedHeights.length) {
-            expect(receivedHeights).toEqual(expectedHeights);
-            ws.close();
-          }
-        }
-      });
+    const messageA = waitForMessage(wsA, (msg) => msg.type === "indexer-event");
+    const messageB = waitForMessage(wsB, (msg) => msg.type === "indexer-event");
+    broadcaster.broadcastIndexerEvent(eventA);
+    broadcaster.broadcastIndexerEvent(eventB);
 
-      ws.on("close", () => {
-        if (receivedHeights.length === expectedHeights.length) {
-          done();
-        } else {
-          done(new Error(`Expected ${expectedHeights.length} events, got ${receivedHeights.length}`));
-        }
-      });
+    await expect(messageA).resolves.toMatchObject({ did: didA, payload: { relatedDids: [didA, didB] } });
+    await expect(messageB).resolves.toMatchObject({ did: didB, payload: { relatedDids: [didA, didB] } });
 
-      ws.on("error", (error) => {
-        done(error);
-      });
-    }, 10000);
+    closeSocket(wsA);
+    closeSocket(wsB);
   });
 
-  describe("Error Handling", () => {
-    it("should handle client errors gracefully", (done) => {
-      const ws = new WebSocket(WS_URL);
+  it("broadcasts legacy block-processed events to global subscribers only", async () => {
+    const ws = new WebSocket(WS_URL);
+    const didWs = new WebSocket(`${WS_URL}?did=${encodeURIComponent("did:web:agent.example")}`);
+    await waitForOpen(ws);
+    await waitForOpen(didWs);
+    await waitForMessage(ws, (msg) => msg.type === "connected");
+    await waitForMessage(didWs, (msg) => msg.type === "connected");
 
-      ws.on("open", () => {
-        expect(broadcaster.getWSClientCount()).toBe(1);
-        ws.terminate();
-      });
+    const blockProcessed = waitForMessage(ws, (msg) => msg.type === "block-processed");
+    let didRoomReceivedBlockProcessed = false;
+    didWs.on("message", (data) => {
+      const message = JSON.parse(data.toString());
+      if (message.type === "block-processed") didRoomReceivedBlockProcessed = true;
+    });
 
-      ws.on("error", () => {
-      });
+    broadcaster.broadcastBlockProcessed(123456, new Date("2025-01-15T10:30:00.000Z"));
+    const message = await blockProcessed;
+    expect(Object.keys(message)).toEqual(["type", "height", "timestamp"]);
+    expect(message).toMatchObject({
+      type: "block-processed",
+      height: 123456,
+      timestamp: "2025-01-15T10:30:00Z",
+    });
 
-      setTimeout(() => {
-        expect(broadcaster.getWSClientCount()).toBe(0);
-        done();
-      }, 500);
-    }, 10000);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 200);
+    });
+    expect(didRoomReceivedBlockProcessed).toBe(false);
+
+    closeSocket(ws);
+    closeSocket(didWs);
+  });
+
+  it("does not send DID indexer events to global subscribers", async () => {
+    const ws = new WebSocket(WS_URL);
+    await waitForOpen(ws);
+    await waitForMessage(ws, (msg) => msg.type === "connected");
+
+    let receivedIndexerEvent = false;
+    ws.on("message", (data) => {
+      const message = JSON.parse(data.toString());
+      if (message.type === "indexer-event") receivedIndexerEvent = true;
+    });
+
+    broadcaster.broadcastIndexerEvent(makeEvent("did:web:agent.example"));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 200);
+    });
+
+    expect(receivedIndexerEvent).toBe(false);
+    closeSocket(ws);
+  });
+
+  it("cleans up clients on close and error/terminate", async () => {
+    const wsClose = new WebSocket(`${WS_URL}?did=${encodeURIComponent("did:web:close.example")}`);
+    await waitForOpen(wsClose);
+    expect(broadcaster.getWSClientCount()).toBe(1);
+    closeSocket(wsClose);
+    await waitForClose(wsClose);
+    await waitForCondition(() => broadcaster.getWSClientCount() === 0);
+    expect(broadcaster.getWSClientCount()).toBe(0);
+
+    const wsTerminate = new WebSocket(`${WS_URL}?did=${encodeURIComponent("did:web:error.example")}`);
+    await waitForOpen(wsTerminate);
+    expect(broadcaster.getWSClientCount()).toBe(1);
+    wsTerminate.terminate();
+    await waitForClose(wsTerminate);
+    await waitForCondition(() => broadcaster.getWSClientCount() === 0);
+    expect(broadcaster.getWSClientCount()).toBe(0);
   });
 });
-

--- a/test/unit/services/api/events_broadcaster.spec.ts
+++ b/test/unit/services/api/events_broadcaster.spec.ts
@@ -64,21 +64,21 @@ function closeSocket(ws: WebSocket): void {
 function makeEvent(did: string, overrides: Partial<IndexerEventRecord> = {}): IndexerEventRecord {
   return {
     type: "indexer-event",
-    eventType: "StartPermissionVP",
+    event_type: "StartPermissionVP",
     did,
-    blockHeight: 123456,
-    txHash: "ABC123",
+    block_height: 123456,
+    tx_hash: "ABC123",
     timestamp: "2025-01-15T10:30:00Z",
     payload: {
       module: "permission",
       action: "StartPermissionVP",
-      messageType: "/verana.perm.v1.MsgStartPermissionVP",
-      txIndex: 0,
-      messageIndex: 0,
+      message_type: "/verana.perm.v1.MsgStartPermissionVP",
+      tx_index: 0,
+      message_index: 0,
       sender: did,
-      relatedDids: [did],
-      entityType: "Permission",
-      entityId: "42",
+      related_dids: [did],
+      entity_type: "Permission",
+      entity_id: "42",
     },
     ...overrides,
   };
@@ -120,7 +120,7 @@ describe("EventsBroadcaster", () => {
       type: "connected",
       message: "Connected to Verana Indexer Events",
     });
-    expect(Object.prototype.hasOwnProperty.call(message, "blockHeight")).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(message, "block_height")).toBe(true);
     expect(message.did).toBeUndefined();
     expect(broadcaster.getWSClientCount()).toBe(1);
 
@@ -139,14 +139,14 @@ describe("EventsBroadcaster", () => {
     expect(broadcaster.getWSClientCount()).toBe(0);
   });
 
-  it("includes did and blockHeight in DID room connected messages", async () => {
+  it("includes did and block_height in DID room connected messages", async () => {
     const did = "did:web:agent.example";
     const ws = new WebSocket(`${WS_URL}?did=${encodeURIComponent(did)}`);
     await waitForOpen(ws);
 
     const message = await waitForMessage(ws, (msg) => msg.type === "connected");
     expect(message.did).toBe(did);
-    expect(Object.prototype.hasOwnProperty.call(message, "blockHeight")).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(message, "block_height")).toBe(true);
 
     closeSocket(ws);
   });
@@ -176,7 +176,7 @@ describe("EventsBroadcaster", () => {
     });
 
     expect(received.did).toBe(did);
-    expect(received.eventType).toBe("StartPermissionVP");
+    expect(received.event_type).toBe("StartPermissionVP");
     expect(otherReceived).toBe(false);
 
     closeSocket(wsMatch);
@@ -195,11 +195,11 @@ describe("EventsBroadcaster", () => {
     ]);
 
     const eventA = makeEvent(didA, {
-      payload: { ...makeEvent(didA).payload, relatedDids: [didA, didB] },
+      payload: { ...makeEvent(didA).payload, related_dids: [didA, didB] },
     });
     const eventB = makeEvent(didB, {
-      txHash: eventA.txHash,
-      payload: { ...eventA.payload, relatedDids: [didA, didB] },
+      tx_hash: eventA.tx_hash,
+      payload: { ...eventA.payload, related_dids: [didA, didB] },
     });
 
     const messageA = waitForMessage(wsA, (msg) => msg.type === "indexer-event");
@@ -207,8 +207,8 @@ describe("EventsBroadcaster", () => {
     broadcaster.broadcastIndexerEvent(eventA);
     broadcaster.broadcastIndexerEvent(eventB);
 
-    await expect(messageA).resolves.toMatchObject({ did: didA, payload: { relatedDids: [didA, didB] } });
-    await expect(messageB).resolves.toMatchObject({ did: didB, payload: { relatedDids: [didA, didB] } });
+    await expect(messageA).resolves.toMatchObject({ did: didA, payload: { related_dids: [didA, didB] } });
+    await expect(messageB).resolves.toMatchObject({ did: didB, payload: { related_dids: [didA, didB] } });
 
     closeSocket(wsA);
     closeSocket(wsB);

--- a/test/unit/services/api/indexer_events_query.spec.ts
+++ b/test/unit/services/api/indexer_events_query.spec.ts
@@ -1,0 +1,137 @@
+import knex from "../../../../src/common/utils/db_connection";
+import { VeranaPermissionMessageTypes } from "../../../../src/common/verana-message-types";
+import { up as createIndexerEventsTable } from "../../../../src/migrations/20260420000000_create_indexer_events";
+import { listIndexerEvents, persistIndexerEventsForBlock } from "../../../../src/services/api/indexer_events_query";
+
+describe("indexer_events_query", () => {
+  const runId = `${Date.now()}-${Math.floor(Math.random() * 10000)}`;
+  const baseHeight = 7_000_000 + Math.floor(Math.random() * 100_000);
+  let nextId = 90_000_000 + Math.floor(Math.random() * 1_000_000);
+  const did = `did:web:indexer-events-${runId}.example`;
+  const otherDid = `did:web:indexer-events-other-${runId}.example`;
+  const txHashes: string[] = [];
+  const heights: number[] = [];
+
+  beforeAll(async () => {
+    await createIndexerEventsTable(knex);
+  });
+
+  async function insertBlock(height: number): Promise<void> {
+    heights.push(height);
+    await knex("block").insert({
+      height,
+      hash: `block-${runId}-${height}`,
+      time: new Date("2025-01-15T10:30:00Z"),
+      proposer_address: "validator",
+      data: {},
+    });
+  }
+
+  async function insertTxMessage(args: {
+    height: number;
+    txIndex: number;
+    messageIndex: number;
+    hash: string;
+    sender?: string;
+    content?: Record<string, unknown>;
+  }): Promise<void> {
+    txHashes.push(args.hash);
+    const txId = nextId++;
+    const messageId = nextId++;
+    const [tx] = await knex("transaction")
+      .insert({
+        id: txId,
+        height: args.height,
+        hash: args.hash,
+        codespace: "",
+        code: 0,
+        gas_used: 1,
+        gas_wanted: 1,
+        gas_limit: 1,
+        fee: {},
+        timestamp: new Date("2025-01-15T10:30:00Z"),
+        data: {},
+        index: args.txIndex,
+      })
+      .returning("id");
+
+    await knex("transaction_message").insert({
+      id: messageId,
+      tx_id: typeof tx === "object" ? tx.id : tx,
+      index: args.messageIndex,
+      type: VeranaPermissionMessageTypes.StartPermissionVP,
+      sender: args.sender ?? did,
+      content: args.content ?? { id: 42, applicant: did },
+    });
+  }
+
+  afterEach(async () => {
+    if (txHashes.length > 0) {
+      await knex("indexer_events").whereIn("tx_hash", txHashes).delete();
+      const txIds = await knex("transaction").whereIn("hash", txHashes).pluck("id");
+      if (txIds.length > 0) await knex("transaction_message").whereIn("tx_id", txIds).delete();
+      await knex("transaction").whereIn("hash", txHashes).delete();
+      txHashes.length = 0;
+    }
+
+    if (heights.length > 0) {
+      await knex("block").whereIn("height", heights).delete();
+      heights.length = 0;
+    }
+  });
+
+  it("replays events after a block height for one DID", async () => {
+    await insertBlock(baseHeight);
+    await insertBlock(baseHeight + 1);
+    await insertTxMessage({ height: baseHeight, txIndex: 0, messageIndex: 0, hash: `tx-${runId}-before` });
+    await insertTxMessage({ height: baseHeight + 1, txIndex: 0, messageIndex: 0, hash: `tx-${runId}-after` });
+
+    await persistIndexerEventsForBlock(baseHeight);
+    await persistIndexerEventsForBlock(baseHeight + 1);
+
+    const events = await listIndexerEvents({ did, afterBlockHeight: baseHeight, limit: 10 });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      did,
+      blockHeight: baseHeight + 1,
+      txHash: `tx-${runId}-after`,
+      type: "indexer-event",
+    });
+  });
+
+  it("returns deterministic replay ordering", async () => {
+    await insertBlock(baseHeight + 10);
+    await insertTxMessage({ height: baseHeight + 10, txIndex: 1, messageIndex: 0, hash: `tx-${runId}-order-2` });
+    await insertTxMessage({ height: baseHeight + 10, txIndex: 0, messageIndex: 1, hash: `tx-${runId}-order-1b` });
+    await insertTxMessage({ height: baseHeight + 10, txIndex: 0, messageIndex: 0, hash: `tx-${runId}-order-1a` });
+
+    await persistIndexerEventsForBlock(baseHeight + 10);
+
+    const events = await listIndexerEvents({ did, afterBlockHeight: baseHeight + 9, limit: 10 });
+    expect(events.map((event) => event.txHash)).toEqual([
+      `tx-${runId}-order-1a`,
+      `tx-${runId}-order-1b`,
+      `tx-${runId}-order-2`,
+    ]);
+  });
+
+  it("persists one row per affected DID and protects duplicate inserts", async () => {
+    await insertBlock(baseHeight + 20);
+    await insertTxMessage({
+      height: baseHeight + 20,
+      txIndex: 0,
+      messageIndex: 0,
+      hash: `tx-${runId}-multi-did`,
+      content: { id: 42, applicant: did, validator: otherDid, nested: { duplicate: did } },
+    });
+
+    const firstPersist = await persistIndexerEventsForBlock(baseHeight + 20);
+    const secondPersist = await persistIndexerEventsForBlock(baseHeight + 20);
+    const rows = await knex("indexer_events").where("tx_hash", `tx-${runId}-multi-did`).orderBy("did", "asc");
+
+    expect(firstPersist.map((event) => event.did).sort()).toEqual([did, otherDid]);
+    expect(secondPersist).toEqual([]);
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.did)).toEqual([did, otherDid]);
+  });
+});

--- a/test/unit/services/api/indexer_events_query.spec.ts
+++ b/test/unit/services/api/indexer_events_query.spec.ts
@@ -93,8 +93,8 @@ describe("indexer_events_query", () => {
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({
       did,
-      blockHeight: baseHeight + 1,
-      txHash: `tx-${runId}-after`,
+      block_height: baseHeight + 1,
+      tx_hash: `tx-${runId}-after`,
       type: "indexer-event",
     });
   });
@@ -108,7 +108,7 @@ describe("indexer_events_query", () => {
     await persistIndexerEventsForBlock(baseHeight + 10);
 
     const events = await listIndexerEvents({ did, afterBlockHeight: baseHeight + 9, limit: 10 });
-    expect(events.map((event) => event.txHash)).toEqual([
+    expect(events.map((event) => event.tx_hash)).toEqual([
       `tx-${runId}-order-1a`,
       `tx-${runId}-order-1b`,
       `tx-${runId}-order-2`,


### PR DESCRIPTION
This PR implements a **DID-based event system in the Verana Indexer** to support VS Agent VPR integration.

Previously, the indexer only broadcasted generic `block-processed` events. This change enhances the system to:

* Emit **transaction-level events** for TR, CS, and PERM modules
* Filter and stream events **per DID** via WebSocket (DID-specific rooms)
* Persist events in a new `indexer_events` table for reliable tracking
* Provide an HTTP API to **replay missed events** after a given block height

This ensures that VS Agents and other clients can:

* Receive **real-time updates relevant to their DID only**
* Recover missed events after downtime
* Maintain consistent state with blockchain activity


###  **Why this change**

VS Agent requires reliable tracking of all events related to its DID.
This implementation provides:

* **Real-time event delivery (WebSocket)**
* **Event persistence + replay (HTTP API)**
* **DID-based filtering for scalability and correctness**

---

###  **Key Features**

* DID-scoped WebSocket subscriptions (`?did=<DID>`)
* New API:
  `GET /verana/indexer/v1/events?did=<DID>&after_block_height=<height>`
* Support for multiple modules:

  * Trust Registry
  * Credential Schema
  * Permission
* Deterministic ordering and deduplication of events

---

###  Example Event

```json
 {
  "id": 1,
  "type": "indexer-event",
  "event_type": "CreateNewTrustRegistry",
  "did": "did:example:123456789abcdefghi",
  "block_height": 343,
  "tx_hash": "E87D69D6310C2B8B09C5A49DF287689652B241BD7B1B44765694C541E6D0807F",
  "timestamp": "2025-10-02T17:20:55Z",
  "payload": {
    "module": "trust-registry",
    "action": "CreateNewTrustRegistry",
    "message_type": "/verana.tr.v1.MsgCreateTrustRegistry",
    "tx_index": 0,
    "message_index": 0,
    "sender": "verana1sxau0xyttphpck7vhlvt8s82ez70nlzw2mhya0",
    "related_dids": [
      "did:example:123456789abcdefghi"
    ],
    "entity_type": "TrustRegistry",
    "entity_id": "1"
  }
}
```
