### PR TITLE
feat: add snapshot endpoint for initial sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ A list of services is shown below:
 
 You can view detail database schema [here](./docs/database_schema.md)
 
+
 ## Setup
 
 This setup guide is for **local development** and connecting to the **Verana testnet**. For production deployments or other networks, adjust the configuration accordingly.

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -173,6 +173,128 @@
         }
       }
     },
+    "/verana/indexer/v1/snapshot": {
+      "get": {
+        "tags": [
+          "Indexer"
+        ],
+        "summary": "Get DID-linked object snapshot at block height",
+        "description": "Return the current indexed state for all objects linked to the given DID. The block_height parameter is accepted and echoed back, and is used for filtering on current tables where height columns exist (height <= block_height). This endpoint does not query history tables.",
+        "operationId": "getIndexerSnapshot",
+        "parameters": [
+          {
+            "name": "did",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^did:[a-z0-9]+:.+"
+            },
+            "description": "DID to fetch the snapshot for."
+          },
+          {
+            "name": "block_height",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "description": "Snapshot block height. Accepted for client bootstrap compatibility and applied where current tables support filtering (height <= block_height). This endpoint does not query history tables."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Snapshot response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "did": {
+                      "type": "string",
+                      "example": "did:example"
+                    },
+                    "block_height": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "example": 123
+                    },
+                    "trust_registries": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "schemas": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      },
+                      "description": "Credential schemas linked to the DID."
+                    },
+                    "permissions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    },
+                    "count": {
+                      "type": "object",
+                      "properties": {
+                        "trust_registries": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "schemas": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "permissions": {
+                          "type": "integer",
+                          "minimum": 0
+                        }
+                      },
+                      "required": [
+                        "trust_registries",
+                        "schemas",
+                        "permissions"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "did",
+                    "block_height",
+                    "trust_registries",
+                    "schemas",
+                    "permissions",
+                    "count"
+                  ]
+                },
+                "example": {
+                  "did": "did:example",
+                  "block_height": 123,
+                  "trust_registries": [],
+                  "schemas": [],
+                  "permissions": [],
+                  "count": {
+                    "trust_registries": 0,
+                    "schemas": 0,
+                    "permissions": 0
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
     "/verana/indexer/v1/version": {
       "get": {
         "tags": [

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -179,7 +179,7 @@
           "Indexer"
         ],
         "summary": "Get DID-linked current indexed snapshot",
-        "description": "Returns a current indexed snapshot for DID-linked objects. block_height is applied only on current tables that expose a height column. This endpoint does not query history tables.",
+        "description": "Returns the indexed snapshot for DID-linked objects at a specific block height. Only applies to current tables that expose a height column; does not query history tables.",
         "operationId": "getIndexerSnapshot",
         "parameters": [
           {

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -178,8 +178,8 @@
         "tags": [
           "Indexer"
         ],
-        "summary": "Get DID-linked object snapshot at block height",
-        "description": "Return the current indexed state for all objects linked to the given DID. The block_height parameter is accepted and echoed back, and is used for filtering on current tables where height columns exist (height <= block_height). This endpoint does not query history tables.",
+        "summary": "Get DID-linked current indexed snapshot",
+        "description": "Returns a current indexed snapshot for DID-linked objects. block_height is applied only on current tables that expose a height column. This endpoint does not query history tables.",
         "operationId": "getIndexerSnapshot",
         "parameters": [
           {
@@ -200,7 +200,7 @@
               "type": "integer",
               "minimum": 0
             },
-            "description": "Snapshot block height. Accepted for client bootstrap compatibility and applied where current tables support filtering (height <= block_height). This endpoint does not query history tables."
+              "description": "Snapshot block height. Applied only on current tables that expose a height column; this endpoint does not query history tables."
           }
         ],
         "responses": {

--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -224,6 +224,10 @@ export const SERVICE = {
       key: "IndexerEventsService",
       path: "v1.IndexerEventsService",
     },
+    IndexerSnapshotService: {
+      key: "IndexerSnapshotService",
+      path: "v1.IndexerSnapshotService",
+    },
     IndexerStatusService: {
       key: "IndexerStatusService",
       path: "v1.IndexerStatusService",

--- a/src/services/api/api.service.ts
+++ b/src/services/api/api.service.ts
@@ -403,6 +403,7 @@ function createRoute(
         "GET block-height": `${SERVICE.V1.IndexerMetaService.path}.getBlockHeight`,
         "GET changes/:block_height": `${SERVICE.V1.IndexerMetaService.path}.listChanges`,
         "GET events": `${SERVICE.V1.IndexerEventsService.path}.listEvents`,
+        "GET snapshot": `${SERVICE.V1.IndexerSnapshotService.path}.getSnapshot`,
         "GET version": `${SERVICE.V1.IndexerMetaService.path}.getVersion`,
         "GET status": `${SERVICE.V1.IndexerStatusService.path}.getDetailedStatus`,
         "GET errors/download": `v1.LogsService.downloadErrors`,

--- a/src/services/api/snapshot.service.ts
+++ b/src/services/api/snapshot.service.ts
@@ -1,0 +1,195 @@
+import { Action, Service } from "@ourparentcenter/moleculer-decorators-extended";
+import { Context, Errors, ServiceBroker } from "moleculer";
+import knex from "../../common/utils/db_connection";
+import { SERVICE } from "../../common";
+import ApiResponder from "../../common/utils/apiResponse";
+import BaseService from "../../base/base.service";
+import { isValidDid } from "./api_shared";
+
+type SnapshotResponse = {
+  did: string;
+  block_height: number;
+  trust_registries: any[];
+  schemas: any[];
+  permissions: any[];
+  count: {
+    trust_registries: number;
+    schemas: number;
+    permissions: number;
+  };
+};
+
+type SnapshotTables = {
+  hasTrustRegistry: boolean;
+  hasCredentialSchemas: boolean;
+  hasPermissions: boolean;
+  credentialSchemasHasHeight: boolean;
+  permissionsHasHeight: boolean;
+};
+
+const TABLE_CHECK_TTL_MS = 60_000;
+let cachedTables: { expiresAt: number; value: Promise<SnapshotTables> } | null = null;
+
+async function getSnapshotTables(): Promise<SnapshotTables> {
+  const now = Date.now();
+  if (cachedTables && cachedTables.expiresAt > now) return cachedTables.value;
+
+  const value = (async () => {
+    const [hasTrustRegistry, hasCredentialSchemas, hasPermissions] = await Promise.all([
+      knex.schema.hasTable("trust_registry"),
+      knex.schema.hasTable("credential_schemas"),
+      knex.schema.hasTable("permissions"),
+    ]);
+
+    const [credentialSchemasHasHeight, permissionsHasHeight] = await Promise.all([
+      hasCredentialSchemas ? knex.schema.hasColumn("credential_schemas", "height") : Promise.resolve(false),
+      hasPermissions ? knex.schema.hasColumn("permissions", "height") : Promise.resolve(false),
+    ]);
+
+    return {
+      hasTrustRegistry,
+      hasCredentialSchemas,
+      hasPermissions,
+      credentialSchemasHasHeight,
+      permissionsHasHeight,
+    };
+  })();
+
+  cachedTables = { expiresAt: now + TABLE_CHECK_TTL_MS, value };
+  return value;
+}
+
+function parseNonNegativeInteger(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const n = typeof value === "number" ? value : Number(String(value).trim());
+  if (!Number.isInteger(n) || n < 0) return null;
+  return n;
+}
+
+async function fetchTrustRegistriesAtHeight(did: string, height: number, tables: SnapshotTables): Promise<any[]> {
+  if (!tables.hasTrustRegistry) return [];
+
+  return knex("trust_registry")
+    .select("*")
+    .where((qb) => {
+      qb.where("did", did).orWhere("corporation", did);
+    })
+    .andWhere("height", "<=", height)
+    .orderBy("id", "asc");
+}
+
+async function fetchCredentialSchemasAtHeight(trIds: number[], _height: number, tables: SnapshotTables): Promise<any[]> {
+  if (!tables.hasCredentialSchemas) return [];
+  if (trIds.length === 0) return [];
+
+  const query = knex("credential_schemas")
+    .select("*")
+    .whereIn("tr_id", trIds)
+    .orderBy("id", "asc");
+
+  if (tables.credentialSchemasHasHeight) {
+    query.andWhere("height", "<=", _height);
+  }
+
+  return query;
+}
+
+async function fetchPermissionsAtHeight(args: {
+  did: string;
+  blockHeight: number;
+  schemaIds: number[];
+  tables: SnapshotTables;
+}): Promise<any[]> {
+  const { did, schemaIds, tables, blockHeight } = args;
+  if (!tables.hasPermissions) return [];
+
+  const query = knex("permissions")
+    .select("*")
+    .where((qb) => {
+      qb.where("did", did).orWhere("corporation", did);
+      if (schemaIds.length > 0) qb.orWhereIn("schema_id", schemaIds);
+    })
+    .orderBy("id", "asc");
+
+  if (tables.permissionsHasHeight) {
+    query.andWhere("height", "<=", blockHeight);
+  }
+
+  return query;
+}
+
+export async function getDidSnapshotAtHeight(args: { did: string; blockHeight: number }): Promise<SnapshotResponse> {
+  const { did, blockHeight } = args;
+  const tables = await getSnapshotTables();
+
+  const trustRegistries = await fetchTrustRegistriesAtHeight(did, blockHeight, tables);
+  const trIds = trustRegistries
+    .map((row: any) => Number(row.id))
+    .filter((id) => Number.isInteger(id) && id >= 0);
+
+  const credentialSchemas = await fetchCredentialSchemasAtHeight(trIds, blockHeight, tables);
+  const schemaIds = credentialSchemas
+    .map((row: any) => Number(row.id))
+    .filter((id) => Number.isInteger(id) && id >= 0);
+
+  const permissions = await fetchPermissionsAtHeight({
+    did,
+    blockHeight,
+    schemaIds,
+    tables,
+  });
+
+  return {
+    did,
+    block_height: blockHeight,
+    trust_registries: trustRegistries,
+    schemas: credentialSchemas,
+    permissions,
+    count: {
+      trust_registries: trustRegistries.length,
+      schemas: credentialSchemas.length,
+      permissions: permissions.length,
+    },
+  };
+}
+
+@Service({
+  name: SERVICE.V1.IndexerSnapshotService.key,
+  version: 1,
+})
+export default class IndexerSnapshotService extends BaseService {
+  public constructor(public broker: ServiceBroker) {
+    super(broker);
+  }
+
+  @Action({
+    name: "getSnapshot",
+    params: {
+      did: { type: "string", optional: true, trim: true },
+      block_height: { type: "any", optional: true },
+    },
+  })
+  public async getSnapshot(ctx: Context<{ did?: string; block_height?: unknown }>): Promise<SnapshotResponse | any> {
+    try {
+      const did = typeof ctx.params.did === "string" ? ctx.params.did.trim() : "";
+      if (!did) return ApiResponder.error(ctx, "Missing did", 400);
+      if (!isValidDid(did)) return ApiResponder.error(ctx, "Invalid did", 400);
+
+      const blockHeight = parseNonNegativeInteger(ctx.params.block_height);
+      if (blockHeight === null) {
+        if (ctx.params.block_height === undefined || ctx.params.block_height === null || String(ctx.params.block_height).trim() === "") {
+          return ApiResponder.error(ctx, "Missing block_height", 400);
+        }
+        return ApiResponder.error(ctx, "Invalid block_height", 400);
+      }
+
+      const snapshot = await getDidSnapshotAtHeight({ did, blockHeight });
+      return ApiResponder.success(ctx, snapshot, 200);
+    } catch (err: any) {
+      this.logger.error("[IndexerSnapshotService] Failed to build snapshot:", err);
+      if (err instanceof Errors.MoleculerError) throw err;
+      throw new Errors.MoleculerError("Failed to build snapshot", 500, "SNAPSHOT_FAILED");
+    }
+  }
+}
+

--- a/src/services/api/snapshot.service.ts
+++ b/src/services/api/snapshot.service.ts
@@ -6,12 +6,14 @@ import ApiResponder from "../../common/utils/apiResponse";
 import BaseService from "../../base/base.service";
 import { isValidDid } from "./api_shared";
 
+type SnapshotRow = Record<string, unknown>;
+
 type SnapshotResponse = {
   did: string;
   block_height: number;
-  trust_registries: any[];
-  schemas: any[];
-  permissions: any[];
+  trust_registries: SnapshotRow[];
+  schemas: SnapshotRow[];
+  permissions: SnapshotRow[];
   count: {
     trust_registries: number;
     schemas: number;
@@ -69,7 +71,7 @@ function parseNonNegativeInteger(value: unknown): number | null {
   return n;
 }
 
-async function fetchTrustRegistriesAtHeight(did: string, height: number, tables: SnapshotTables): Promise<any[]> {
+async function fetchTrustRegistriesAtHeight(did: string, height: number, tables: SnapshotTables): Promise<SnapshotRow[]> {
   if (!tables.hasTrustRegistry) return [];
 
   const query = knex("trust_registry")
@@ -83,7 +85,7 @@ async function fetchTrustRegistriesAtHeight(did: string, height: number, tables:
   return query.orderBy("id", "asc");
 }
 
-async function fetchCredentialSchemasAtHeight(trIds: number[], _height: number, tables: SnapshotTables): Promise<any[]> {
+async function fetchCredentialSchemasAtHeight(trIds: number[], _height: number, tables: SnapshotTables): Promise<SnapshotRow[]> {
   if (!tables.hasCredentialSchemas) return [];
   if (trIds.length === 0) return [];
 
@@ -103,10 +105,11 @@ async function fetchPermissionsAtHeight(args: {
   did: string;
   blockHeight: number;
   schemaIds: number[];
+  schemaTrIds?: number[];
   corporationAddresses: string[];
   tables: SnapshotTables;
-}): Promise<any[]> {
-  const { did, schemaIds, corporationAddresses, tables, blockHeight } = args;
+}): Promise<SnapshotRow[]> {
+  const { did, schemaIds, schemaTrIds = [], corporationAddresses, tables, blockHeight } = args;
   if (!tables.hasPermissions) return [];
 
   const query = knex("permissions")
@@ -115,6 +118,15 @@ async function fetchPermissionsAtHeight(args: {
       qb.where("did", did);
       if (corporationAddresses.length > 0) qb.orWhere((q) => q.whereIn("corporation", corporationAddresses));
       if (schemaIds.length > 0) qb.orWhereIn("schema_id", schemaIds);
+      if (tables.hasCredentialSchemas && schemaTrIds.length > 0) {
+        const schemaQuery = knex("credential_schemas")
+          .select("id")
+          .whereIn("tr_id", schemaTrIds);
+        if (tables.credentialSchemasHasHeight) {
+          schemaQuery.andWhere("height", "<=", blockHeight);
+        }
+        qb.orWhereIn("schema_id", schemaQuery);
+      }
     })
     .orderBy("id", "asc");
 
@@ -131,30 +143,29 @@ export async function getDidSnapshotAtHeight(args: { did: string; blockHeight: n
 
   const trustRegistries = await fetchTrustRegistriesAtHeight(did, blockHeight, tables);
   const trIds = trustRegistries
-    .map((row: any) => Number(row.id))
+    .map((row) => Number(row.id))
     .filter((id) => Number.isInteger(id) && id >= 0);
 
   const corporationAddresses = Array.from(
     new Set(
       trustRegistries
-        .map((row: any) => row.corporation)
+        .map((row) => row.corporation)
         .filter((corp): corp is string => typeof corp === "string" && corp.trim().length > 0)
         .map((corp) => corp.trim())
     )
   );
 
-  const credentialSchemas = await fetchCredentialSchemasAtHeight(trIds, blockHeight, tables);
-  const schemaIds = credentialSchemas
-    .map((row: any) => Number(row.id))
-    .filter((id) => Number.isInteger(id) && id >= 0);
-
-  const permissions = await fetchPermissionsAtHeight({
-    did,
-    blockHeight,
-    schemaIds,
-    corporationAddresses,
-    tables,
-  });
+  const [credentialSchemas, permissions] = await Promise.all([
+    fetchCredentialSchemasAtHeight(trIds, blockHeight, tables),
+    fetchPermissionsAtHeight({
+      did,
+      blockHeight,
+      schemaIds: [],
+      schemaTrIds: trIds,
+      corporationAddresses,
+      tables,
+    }),
+  ]);
 
   return {
     did,
@@ -187,7 +198,7 @@ export default class IndexerSnapshotService extends BaseService {
     },
     rest: "GET /snapshot",
   })
-  public async getSnapshot(ctx: Context<{ did?: string; block_height?: unknown }>): Promise<SnapshotResponse | any> {
+  public async getSnapshot(ctx: Context<{ did?: string; block_height?: unknown }>) {
     try {
       const did = typeof ctx.params.did === "string" ? ctx.params.did.trim() : "";
       if (!did) return ApiResponder.error(ctx, "Missing did", 400);
@@ -203,7 +214,7 @@ export default class IndexerSnapshotService extends BaseService {
 
       const snapshot = await getDidSnapshotAtHeight({ did, blockHeight });
       return ApiResponder.success(ctx, snapshot, 200);
-    } catch (err: any) {
+    } catch (err: unknown) {
       this.logger.error("[IndexerSnapshotService] Failed to build snapshot:", err);
       if (err instanceof Errors.MoleculerError) throw err;
       throw new Errors.MoleculerError("Failed to build snapshot", 500, "SNAPSHOT_FAILED");

--- a/src/services/api/snapshot.service.ts
+++ b/src/services/api/snapshot.service.ts
@@ -23,6 +23,7 @@ type SnapshotTables = {
   hasTrustRegistry: boolean;
   hasCredentialSchemas: boolean;
   hasPermissions: boolean;
+  trustRegistryHasHeight: boolean;
   credentialSchemasHasHeight: boolean;
   permissionsHasHeight: boolean;
 };
@@ -41,7 +42,8 @@ async function getSnapshotTables(): Promise<SnapshotTables> {
       knex.schema.hasTable("permissions"),
     ]);
 
-    const [credentialSchemasHasHeight, permissionsHasHeight] = await Promise.all([
+    const [trustRegistryHasHeight, credentialSchemasHasHeight, permissionsHasHeight] = await Promise.all([
+      hasTrustRegistry ? knex.schema.hasColumn("trust_registry", "height") : Promise.resolve(false),
       hasCredentialSchemas ? knex.schema.hasColumn("credential_schemas", "height") : Promise.resolve(false),
       hasPermissions ? knex.schema.hasColumn("permissions", "height") : Promise.resolve(false),
     ]);
@@ -50,6 +52,7 @@ async function getSnapshotTables(): Promise<SnapshotTables> {
       hasTrustRegistry,
       hasCredentialSchemas,
       hasPermissions,
+      trustRegistryHasHeight,
       credentialSchemasHasHeight,
       permissionsHasHeight,
     };
@@ -69,13 +72,15 @@ function parseNonNegativeInteger(value: unknown): number | null {
 async function fetchTrustRegistriesAtHeight(did: string, height: number, tables: SnapshotTables): Promise<any[]> {
   if (!tables.hasTrustRegistry) return [];
 
-  return knex("trust_registry")
+  const query = knex("trust_registry")
     .select("*")
-    .where((qb) => {
-      qb.where("did", did).orWhere("corporation", did);
-    })
-    .andWhere("height", "<=", height)
-    .orderBy("id", "asc");
+    .where("did", did);
+
+  if (tables.trustRegistryHasHeight) {
+    query.andWhere("height", "<=", height);
+  }
+
+  return query.orderBy("id", "asc");
 }
 
 async function fetchCredentialSchemasAtHeight(trIds: number[], _height: number, tables: SnapshotTables): Promise<any[]> {
@@ -98,15 +103,17 @@ async function fetchPermissionsAtHeight(args: {
   did: string;
   blockHeight: number;
   schemaIds: number[];
+  corporationAddresses: string[];
   tables: SnapshotTables;
 }): Promise<any[]> {
-  const { did, schemaIds, tables, blockHeight } = args;
+  const { did, schemaIds, corporationAddresses, tables, blockHeight } = args;
   if (!tables.hasPermissions) return [];
 
   const query = knex("permissions")
     .select("*")
     .where((qb) => {
-      qb.where("did", did).orWhere("corporation", did);
+      qb.where("did", did);
+      if (corporationAddresses.length > 0) qb.orWhere((q) => q.whereIn("corporation", corporationAddresses));
       if (schemaIds.length > 0) qb.orWhereIn("schema_id", schemaIds);
     })
     .orderBy("id", "asc");
@@ -127,6 +134,15 @@ export async function getDidSnapshotAtHeight(args: { did: string; blockHeight: n
     .map((row: any) => Number(row.id))
     .filter((id) => Number.isInteger(id) && id >= 0);
 
+  const corporationAddresses = Array.from(
+    new Set(
+      trustRegistries
+        .map((row: any) => row.corporation)
+        .filter((corp): corp is string => typeof corp === "string" && corp.trim().length > 0)
+        .map((corp) => corp.trim())
+    )
+  );
+
   const credentialSchemas = await fetchCredentialSchemasAtHeight(trIds, blockHeight, tables);
   const schemaIds = credentialSchemas
     .map((row: any) => Number(row.id))
@@ -136,6 +152,7 @@ export async function getDidSnapshotAtHeight(args: { did: string; blockHeight: n
     did,
     blockHeight,
     schemaIds,
+    corporationAddresses,
     tables,
   });
 
@@ -168,6 +185,7 @@ export default class IndexerSnapshotService extends BaseService {
       did: { type: "string", optional: true, trim: true },
       block_height: { type: "any", optional: true },
     },
+    rest: "GET /snapshot",
   })
   public async getSnapshot(ctx: Context<{ did?: string; block_height?: unknown }>): Promise<SnapshotResponse | any> {
     try {

--- a/src/services/api/snapshot.service.ts
+++ b/src/services/api/snapshot.service.ts
@@ -104,12 +104,11 @@ async function fetchCredentialSchemasAtHeight(trIds: number[], _height: number, 
 async function fetchPermissionsAtHeight(args: {
   did: string;
   blockHeight: number;
-  schemaIds: number[];
   schemaTrIds?: number[];
   corporationAddresses: string[];
   tables: SnapshotTables;
 }): Promise<SnapshotRow[]> {
-  const { did, schemaIds, schemaTrIds = [], corporationAddresses, tables, blockHeight } = args;
+  const { did, schemaTrIds = [], corporationAddresses, tables, blockHeight } = args;
   if (!tables.hasPermissions) return [];
 
   const query = knex("permissions")
@@ -117,7 +116,6 @@ async function fetchPermissionsAtHeight(args: {
     .where((qb) => {
       qb.where("did", did);
       if (corporationAddresses.length > 0) qb.orWhere((q) => q.whereIn("corporation", corporationAddresses));
-      if (schemaIds.length > 0) qb.orWhereIn("schema_id", schemaIds);
       if (tables.hasCredentialSchemas && schemaTrIds.length > 0) {
         const schemaQuery = knex("credential_schemas")
           .select("id")
@@ -160,7 +158,6 @@ export async function getDidSnapshotAtHeight(args: { did: string; blockHeight: n
     fetchPermissionsAtHeight({
       did,
       blockHeight,
-      schemaIds: [],
       schemaTrIds: trIds,
       corporationAddresses,
       tables,

--- a/test/unit/services/api/indexer_snapshot.service.spec.ts
+++ b/test/unit/services/api/indexer_snapshot.service.spec.ts
@@ -1,0 +1,264 @@
+import { ServiceBroker } from "moleculer";
+import knex from "../../../../src/common/utils/db_connection";
+import IndexerSnapshotService, { getDidSnapshotAtHeight } from "../../../../src/services/api/snapshot.service";
+
+describe("IndexerSnapshotService snapshot endpoint", () => {
+  const runId = `${Date.now()}-${Math.floor(Math.random() * 10000)}`;
+  const baseHeight = 7_500_000 + Math.floor(Math.random() * 10_000);
+  const didA = `did:web:snapshot-a-${runId}.example`;
+  const didB = `did:web:snapshot-b-${runId}.example`;
+  const otherDid = `did:web:snapshot-other-${runId}.example`;
+
+  const createdAt = new Date("2026-01-15T10:30:00Z");
+
+  const inserted = {
+    trustRegistryIds: [] as number[],
+    credentialSchemaIds: [] as number[],
+    permissionIds: [] as number[],
+  };
+
+  const createdTables: string[] = [];
+  const columnInfoCache = new Map<string, Promise<Record<string, any>>>();
+
+  async function getColumnInfo(table: string): Promise<Record<string, any>> {
+    const cached = columnInfoCache.get(table);
+    if (cached) return cached;
+    const p = knex(table).columnInfo();
+    columnInfoCache.set(table, p);
+    return p;
+  }
+
+  async function insertRow(table: string, row: Record<string, any>): Promise<void> {
+    const info = await getColumnInfo(table);
+    const filtered: Record<string, any> = {};
+    for (const [k, v] of Object.entries(row)) {
+      if (Object.prototype.hasOwnProperty.call(info, k)) filtered[k] = v;
+    }
+    await knex(table).insert(filtered);
+  }
+
+  beforeAll(async () => {
+    const hasTr = await knex.schema.hasTable("trust_registry");
+    if (!hasTr) {
+      await knex.schema.createTable("trust_registry", (table) => {
+        table.increments("id").primary();
+        table.string("did").notNullable();
+        table.string("corporation").notNullable();
+        table.timestamp("created").notNullable();
+        table.timestamp("modified").notNullable();
+        table.timestamp("archived").nullable();
+        table.string("aka").nullable();
+        table.string("language").notNullable();
+        table.integer("active_version").nullable();
+        table.bigInteger("participants").notNullable().defaultTo(0);
+        table.bigInteger("active_schemas").notNullable().defaultTo(0);
+        table.bigInteger("archived_schemas").notNullable().defaultTo(0);
+        table.bigInteger("weight").notNullable().defaultTo(0);
+        table.bigInteger("issued").notNullable().defaultTo(0);
+        table.bigInteger("verified").notNullable().defaultTo(0);
+        table.bigInteger("ecosystem_slash_events").notNullable().defaultTo(0);
+        table.bigInteger("ecosystem_slashed_amount").notNullable().defaultTo(0);
+        table.bigInteger("ecosystem_slashed_amount_repaid").notNullable().defaultTo(0);
+        table.bigInteger("network_slash_events").notNullable().defaultTo(0);
+        table.bigInteger("network_slashed_amount").notNullable().defaultTo(0);
+        table.bigInteger("network_slashed_amount_repaid").notNullable().defaultTo(0);
+        table.bigInteger("height").notNullable().defaultTo(0);
+      });
+      createdTables.push("trust_registry");
+    }
+
+    const hasCs = await knex.schema.hasTable("credential_schemas");
+    if (!hasCs) {
+      await knex.schema.createTable("credential_schemas", (table) => {
+        table.increments("id").primary();
+        table.integer("tr_id").notNullable();
+        table.text("json_schema").nullable();
+        table.boolean("is_active").notNullable().defaultTo(true);
+      });
+      createdTables.push("credential_schemas");
+    }
+
+    const hasPerms = await knex.schema.hasTable("permissions");
+    if (!hasPerms) {
+      await knex.schema.createTable("permissions", (table) => {
+        table.increments("id").primary();
+        table.integer("schema_id").notNullable();
+        table.string("type").nullable();
+        table.string("did").nullable();
+        table.string("corporation").nullable();
+      });
+      createdTables.push("permissions");
+    }
+  });
+
+  afterAll(async () => {
+    for (const table of createdTables.reverse()) {
+      // eslint-disable-next-line no-await-in-loop
+      await knex.schema.dropTableIfExists(table);
+    }
+  });
+
+  async function insertTrustRegistry(args: { did: string; corporation: string; height: number }): Promise<number> {
+    const [idRow] = await knex("trust_registry")
+      .insert({
+      did: args.did,
+      corporation: args.corporation,
+      created: createdAt,
+      modified: createdAt,
+      archived: null,
+      aka: null,
+      language: "en",
+      active_version: null,
+      participants: 0,
+      active_schemas: 0,
+      archived_schemas: 0,
+      weight: 0,
+      issued: 0,
+      verified: 0,
+      ecosystem_slash_events: 0,
+      ecosystem_slashed_amount: 0,
+      ecosystem_slashed_amount_repaid: 0,
+      network_slash_events: 0,
+      network_slashed_amount: 0,
+      network_slashed_amount_repaid: 0,
+      height: args.height,
+    })
+      .returning("id");
+    const trId = Number(typeof idRow === "object" ? (idRow as any).id : idRow);
+    inserted.trustRegistryIds.push(trId);
+    return trId;
+  }
+
+  async function insertCredentialSchema(args: { trId: number; schemaId: number }): Promise<number> {
+    const [idRow] = await knex("credential_schemas")
+      .insert(
+        await (async () => {
+          const base = {
+            tr_id: args.trId,
+            json_schema: JSON.stringify({ $id: `schema-${args.schemaId}` }),
+            is_active: true,
+
+            issuer_grantor_validation_validity_period: 365,
+            verifier_grantor_validation_validity_period: 365,
+            issuer_validation_validity_period: 365,
+            verifier_validation_validity_period: 365,
+            holder_validation_validity_period: 365,
+
+            issuer_onboarding_mode: "OPEN",
+            verifier_onboarding_mode: "OPEN",
+            holder_onboarding_mode: "PERMISSIONLESS",
+          };
+
+          const info = await getColumnInfo("credential_schemas");
+          const filtered: Record<string, any> = {};
+          for (const [k, v] of Object.entries(base)) {
+            if (Object.prototype.hasOwnProperty.call(info, k)) filtered[k] = v;
+          }
+          return filtered;
+        })()
+      )
+      .returning("id");
+    const schemaRowId = Number(typeof idRow === "object" ? (idRow as any).id : idRow);
+    inserted.credentialSchemaIds.push(schemaRowId);
+    return schemaRowId;
+  }
+
+  async function insertPermission(args: { schemaId: number; did?: string | null; corporation: string }): Promise<number> {
+    const [idRow] = await knex("permissions")
+      .insert({
+        schema_id: args.schemaId,
+        type: "ISSUER",
+        did: args.did ?? null,
+        corporation: args.corporation,
+      })
+      .returning("id");
+    const permRowId = Number(typeof idRow === "object" ? (idRow as any).id : idRow);
+    inserted.permissionIds.push(permRowId);
+    return permRowId;
+  }
+
+  afterEach(async () => {
+    if (inserted.permissionIds.length > 0) {
+      await knex("permissions").whereIn("id", inserted.permissionIds).delete();
+      inserted.permissionIds.length = 0;
+    }
+    if (inserted.credentialSchemaIds.length > 0) {
+      await knex("credential_schemas").whereIn("id", inserted.credentialSchemaIds).delete();
+      inserted.credentialSchemaIds.length = 0;
+    }
+    if (inserted.trustRegistryIds.length > 0) {
+      await knex("trust_registry").whereIn("id", inserted.trustRegistryIds).delete();
+      inserted.trustRegistryIds.length = 0;
+    }
+  });
+
+  it("returns 400 for missing did", async () => {
+    const broker = new ServiceBroker({ logger: false });
+    const svc = new IndexerSnapshotService(broker as any);
+    (svc as any).logger = { error: () => {} };
+
+    const ctx: any = { params: { block_height: 0 }, meta: {} };
+    const res = await svc.getSnapshot(ctx);
+    expect(res).toMatchObject({ code: 400 });
+    expect(String(res.error)).toContain("Missing did");
+  });
+
+  it("returns 400 for invalid did", async () => {
+    const broker = new ServiceBroker({ logger: false });
+    const svc = new IndexerSnapshotService(broker as any);
+    (svc as any).logger = { error: () => {} };
+
+    const ctx: any = { params: { did: "not-a-did", block_height: 0 }, meta: {} };
+    const res = await svc.getSnapshot(ctx);
+    expect(res).toMatchObject({ code: 400 });
+    expect(String(res.error)).toContain("Invalid did");
+  });
+
+  it("returns 400 for missing block_height", async () => {
+    const broker = new ServiceBroker({ logger: false });
+    const svc = new IndexerSnapshotService(broker as any);
+    (svc as any).logger = { error: () => {} };
+
+    const ctx: any = { params: { did: didA }, meta: {} };
+    const res = await svc.getSnapshot(ctx);
+    expect(res).toMatchObject({ code: 400 });
+    expect(String(res.error)).toContain("Missing block_height");
+  });
+
+  it("returns 400 for invalid block_height", async () => {
+    const broker = new ServiceBroker({ logger: false });
+    const svc = new IndexerSnapshotService(broker as any);
+    (svc as any).logger = { error: () => {} };
+
+    const ctx: any = { params: { did: didA, block_height: -1 }, meta: {} };
+    const res = await svc.getSnapshot(ctx);
+    expect(res).toMatchObject({ code: 400 });
+    expect(String(res.error)).toContain("Invalid block_height");
+  });
+
+  it("returns empty arrays for unknown DID", async () => {
+    const snap = await getDidSnapshotAtHeight({ did: didA, blockHeight: baseHeight });
+    expect(snap).toMatchObject({
+      did: didA,
+      block_height: baseHeight,
+      count: { trust_registries: 0, schemas: 0, permissions: 0 },
+    });
+    expect(snap.trust_registries).toEqual([]);
+    expect(snap.schemas).toEqual([]);
+    expect(snap.permissions).toEqual([]);
+  });
+
+  it("returns DID-linked snapshot objects from current tables (did + corporation linking)", async () => {
+    const schemaIdSeed = 88000000 + Math.floor(Math.random() * 100000);
+    const trId = await insertTrustRegistry({ did: didA, corporation: "cosmos1corp", height: baseHeight });
+    const schemaRowId = await insertCredentialSchema({ schemaId: schemaIdSeed, trId });
+    await insertPermission({ schemaId: schemaRowId, did: otherDid, corporation: "cosmos1corp" });
+
+    const snap = await getDidSnapshotAtHeight({ did: didA, blockHeight: baseHeight });
+    expect(snap.count.trust_registries).toBe(1);
+    expect(snap.count.schemas).toBe(1);
+    expect(snap.count.permissions).toBe(1);
+    expect(snap.trust_registries[0]?.did).toBe(didA);
+  });
+});
+

--- a/test/unit/services/api/indexer_snapshot.service.spec.ts
+++ b/test/unit/services/api/indexer_snapshot.service.spec.ts
@@ -248,17 +248,43 @@ describe("IndexerSnapshotService snapshot endpoint", () => {
     expect(snap.permissions).toEqual([]);
   });
 
-  it("returns DID-linked snapshot objects from current tables (did + corporation linking)", async () => {
+  it("returns DID-linked snapshot objects from current tables", async () => {
     const schemaIdSeed = 88000000 + Math.floor(Math.random() * 100000);
     const trId = await insertTrustRegistry({ did: didA, corporation: "cosmos1corp", height: baseHeight });
     const schemaRowId = await insertCredentialSchema({ schemaId: schemaIdSeed, trId });
-    await insertPermission({ schemaId: schemaRowId, did: otherDid, corporation: "cosmos1corp" });
+    await insertPermission({ schemaId: schemaRowId + 100000, did: didA, corporation: "cosmos1other-corp" });
 
     const snap = await getDidSnapshotAtHeight({ did: didA, blockHeight: baseHeight });
     expect(snap.count.trust_registries).toBe(1);
     expect(snap.count.schemas).toBe(1);
     expect(snap.count.permissions).toBe(1);
     expect(snap.trust_registries[0]?.did).toBe(didA);
+    expect(snap.permissions[0]?.did).toBe(didA);
+  });
+
+  it("returns schema-linked permissions", async () => {
+    const schemaIdSeed = 88000000 + Math.floor(Math.random() * 100000);
+    const trId = await insertTrustRegistry({ did: didA, corporation: "cosmos1corp", height: baseHeight });
+    const schemaRowId = await insertCredentialSchema({ schemaId: schemaIdSeed, trId });
+    await insertPermission({ schemaId: schemaRowId, did: otherDid, corporation: "cosmos1other-corp" });
+
+    const snap = await getDidSnapshotAtHeight({ did: didA, blockHeight: baseHeight });
+    expect(snap.count.permissions).toBe(1);
+    expect(snap.permissions[0]?.schema_id).toBe(schemaRowId);
+    expect(snap.permissions[0]?.did).toBe(otherDid);
+  });
+
+  it("returns corporation-linked permissions from derived corporation addresses", async () => {
+    const schemaIdSeed = 88000000 + Math.floor(Math.random() * 100000);
+    const corporation = "cosmos1derived-corp";
+    const trId = await insertTrustRegistry({ did: didA, corporation, height: baseHeight });
+    const schemaRowId = await insertCredentialSchema({ schemaId: schemaIdSeed, trId });
+    await insertPermission({ schemaId: schemaRowId + 100000, did: null, corporation });
+
+    const snap = await getDidSnapshotAtHeight({ did: didA, blockHeight: baseHeight });
+    expect(snap.count.permissions).toBe(1);
+    expect(snap.permissions[0]?.corporation).toBe(corporation);
+    expect(snap.permissions[0]?.schema_id).not.toBe(schemaRowId);
   });
 });
 


### PR DESCRIPTION
This PR implements a **snapshot endpoint** for initial sync, addressing issue #232 and aligning with  spec §2.2.

Previously, the indexer only exposed `/events`, which required clients to reconstruct state via event replay. This is not aligned with the spec, which requires fetching a **state snapshot** at a given block height.

This PR introduces a new endpoint to return **actual DID-linked objects** directly from indexed data.


## New Endpoint

GET /verana/indexer/v1/snapshot

Query params:
- `did` (required)
- `block_height` (required)

## Behavior

- Returns all DID-linked objects at the given `block_height`
- Uses **current indexed tables** with height filtering (`height <= block_height`)
- Does **not rely on event replay**
- Supports linking via:
  - `did`
  - `corporation`
  - related schema relationships

Response structure :

```json
{
  "did": "did:example",
  "block_height": 123,
  "trust_registries": [],
  "schemas": [],
  "permissions": [],
  "count": {
    "trust_registries": 0,
    "schemas": 0,
    "permissions": 0
  }
}