### PR TITLE
fix: improve event replay for pre-existing DIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ A list of services is shown below:
 
 You can view detail database schema [here](./docs/database_schema.md)
 
-
 ## Setup
 
 This setup guide is for **local development** and connecting to the **Verana testnet**. For production deployments or other networks, adjust the configuration accordingly.

--- a/src/migrations/20260420000000_create_indexer_events.ts
+++ b/src/migrations/20260420000000_create_indexer_events.ts
@@ -25,6 +25,16 @@ export async function up(knex: Knex): Promise<void> {
     table.index(["block_height", "tx_index", "message_index", "id"], "idx_events_replay_order");
     table.index(["event_type"], "idx_events_event_type");
   });
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS idx_events_payload_related_dids_gin
+    ON indexer_events USING GIN ((payload -> 'related_dids'))
+  `);
+
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS idx_events_payload_related_dids_camel_gin
+    ON indexer_events USING GIN ((payload -> 'relatedDids'))
+  `);
 }
 
 export async function down(knex: Knex): Promise<void> {

--- a/src/migrations/20260420000000_create_indexer_events.ts
+++ b/src/migrations/20260420000000_create_indexer_events.ts
@@ -20,11 +20,25 @@ export async function up(knex: Knex): Promise<void> {
     table.jsonb("payload").notNullable().defaultTo("{}");
     table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
 
-    table.unique(["did", "tx_hash", "message_index", "event_type"], "idx_events_did_tx_msg_type_unique");
     table.index(["did", "block_height", "tx_index", "message_index", "id"], "idx_events_did_replay_order");
     table.index(["block_height", "tx_index", "message_index", "id"], "idx_events_replay_order");
+    table.index(["block_height"], "idx_events_block_height");
+    table.index(["did"], "idx_events_did");
+    table.index(["tx_hash"], "idx_events_tx_hash");
     table.index(["event_type"], "idx_events_event_type");
   });
+
+  await knex.raw(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_events_tx_msg_entity_unique
+    ON indexer_events (
+      tx_hash,
+      tx_index,
+      message_index,
+      event_type,
+      entity_type,
+      COALESCE(entity_id, '')
+    )
+  `);
 
   await knex.raw(`
     CREATE INDEX IF NOT EXISTS idx_events_payload_related_dids_gin

--- a/src/migrations/20260421000000_harden_indexer_events_replay.ts
+++ b/src/migrations/20260421000000_harden_indexer_events_replay.ts
@@ -1,0 +1,54 @@
+import { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  const exists = await knex.schema.hasTable("indexer_events");
+  if (!exists) return;
+
+  await knex.raw(`ALTER TABLE indexer_events DROP CONSTRAINT IF EXISTS idx_events_did_tx_msg_type_unique`);
+  await knex.raw(`ALTER TABLE indexer_events DROP CONSTRAINT IF EXISTS indexer_events_did_tx_hash_message_index_event_type_unique`);
+  await knex.raw(`DROP INDEX IF EXISTS idx_events_did_tx_msg_type_unique`);
+  await knex.raw(`DROP INDEX IF EXISTS indexer_events_did_tx_hash_message_index_event_type_unique`);
+
+  await knex.raw(`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_events_tx_msg_entity_unique
+    ON indexer_events (
+      tx_hash,
+      tx_index,
+      message_index,
+      event_type,
+      entity_type,
+      COALESCE(entity_id, '')
+    )
+  `);
+
+  await knex.raw(`CREATE INDEX IF NOT EXISTS idx_events_block_height ON indexer_events (block_height)`);
+  await knex.raw(`CREATE INDEX IF NOT EXISTS idx_events_did ON indexer_events (did)`);
+  await knex.raw(`CREATE INDEX IF NOT EXISTS idx_events_tx_hash ON indexer_events (tx_hash)`);
+  await knex.raw(`CREATE INDEX IF NOT EXISTS idx_events_event_type ON indexer_events (event_type)`);
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS idx_events_replay_order
+    ON indexer_events (block_height, tx_index, message_index, id)
+  `);
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS idx_events_did_replay_order
+    ON indexer_events (did, block_height, tx_index, message_index, id)
+  `);
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS idx_events_payload_related_dids_gin
+    ON indexer_events USING GIN ((payload -> 'related_dids'))
+  `);
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS idx_events_payload_related_dids_camel_gin
+    ON indexer_events USING GIN ((payload -> 'relatedDids'))
+  `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const exists = await knex.schema.hasTable("indexer_events");
+  if (!exists) return;
+
+  await knex.raw(`DROP INDEX IF EXISTS idx_events_tx_msg_entity_unique`);
+  await knex.raw(`DROP INDEX IF EXISTS idx_events_block_height`);
+  await knex.raw(`DROP INDEX IF EXISTS idx_events_did`);
+  await knex.raw(`DROP INDEX IF EXISTS idx_events_tx_hash`);
+}

--- a/src/services/api/events_broadcaster.ts
+++ b/src/services/api/events_broadcaster.ts
@@ -4,6 +4,7 @@ import { indexerStatusManager } from "../manager/indexer_status.manager";
 import type { IndexerEventRecord } from "./indexer_events_query";
 import { createLogger, isUnknownMessageError, isValidDid, toIsoSeconds, type LoggerLike } from "./api_shared";
 import type { IndexerStatusEvent } from "../manager/indexer_status.events";
+import { normalizeDid, uniqueNormalizedDids } from "./indexer_event_utils";
 
 type ClientDidParseResult = {
   did?: string;
@@ -30,9 +31,10 @@ export class EventsBroadcaster {
   private parseClientDid(req: IncomingMessage): ClientDidParseResult {
     const host = req.headers.host || "localhost";
     const url = new URL(req.url || "/verana/indexer/v1/events", `http://${host}`);
-    const did = (url.searchParams.get("did") || "").trim();
-    if (!did) return {};
-    return isValidDid(did) ? { did } : { invalidDid: did };
+    const rawDid = (url.searchParams.get("did") || "").trim();
+    if (!rawDid) return {};
+    const did = normalizeDid(rawDid);
+    return did && isValidDid(did) ? { did } : { invalidDid: rawDid };
   }
 
   private addToRoom(ws: WebSocket, did: string): void {
@@ -224,7 +226,15 @@ export class EventsBroadcaster {
   }
 
   broadcastIndexerEvent(event: IndexerEventRecord): void {
-    this.broadcastToDid(event.did, event as unknown as Record<string, unknown>);
+    const rooms = uniqueNormalizedDids([event.did, ...(event.payload?.related_dids ?? [])]);
+    if (rooms.length === 0) {
+      this.logger.warn(`[EventsBroadcaster] No DID found for indexer event ${event.event_type} tx=${event.tx_hash}`);
+      return;
+    }
+
+    rooms.forEach((did) => {
+      this.broadcastToDid(did, event as unknown as Record<string, unknown>);
+    });
   }
 
   broadcastBlockProcessed(height: number, timestamp: Date | string): void {

--- a/src/services/api/indexer_event_utils.ts
+++ b/src/services/api/indexer_event_utils.ts
@@ -1,0 +1,69 @@
+const DID_PATTERN = /^did:[a-z0-9]+:.+/i;
+
+export function normalizeDid(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  let decoded = trimmed;
+  try {
+    decoded = decodeURIComponent(trimmed).trim();
+  } catch {
+    decoded = trimmed;
+  }
+  return DID_PATTERN.test(decoded) ? decoded : undefined;
+}
+
+export function uniqueNormalizedDids(values: Iterable<unknown>): string[] {
+  const dids = new Set<string>();
+  for (const value of values) {
+    const did = normalizeDid(value);
+    if (did) dids.add(did);
+  }
+  return Array.from(dids).sort();
+}
+
+export function collectDidsDeep(value: unknown, out: Set<string> = new Set<string>()): Set<string> {
+  const did = normalizeDid(value);
+  if (did) {
+    out.add(did);
+    return out;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectDidsDeep(item, out));
+    return out;
+  }
+
+  if (value && typeof value === "object") {
+    Object.values(value as Record<string, unknown>).forEach((item) => collectDidsDeep(item, out));
+  }
+
+  return out;
+}
+
+export function firstNormalizedDid(values: Iterable<unknown>): string | undefined {
+  for (const value of values) {
+    const did = normalizeDid(value);
+    if (did) return did;
+  }
+  return undefined;
+}
+
+export function readPositiveInteger(value: unknown): number | null {
+  const n = Number(value);
+  return Number.isInteger(n) && n > 0 ? n : null;
+}
+
+export function readFirstPositiveInteger(source: unknown, keys: string[]): number | null {
+  if (!source || typeof source !== "object") return null;
+  const obj = source as Record<string, unknown>;
+  for (const key of keys) {
+    const value = key.split(".").reduce<unknown>((acc, part) => {
+      if (!acc || typeof acc !== "object") return undefined;
+      return (acc as Record<string, unknown>)[part];
+    }, obj);
+    const n = readPositiveInteger(value);
+    if (n) return n;
+  }
+  return null;
+}

--- a/src/services/api/indexer_events_query.ts
+++ b/src/services/api/indexer_events_query.ts
@@ -141,52 +141,6 @@ const EVENT_META: Record<string, EventMeta> = {
 
 const WATCHED_MESSAGE_TYPES = Object.keys(EVENT_META);
 
-const TABLE_COLUMNS_TTL_MS = 10 * 60 * 1000;
-const tableColumnsCache = new Map<string, { expiresAt: number; value: Promise<Set<string>> }>();
-
-const DID_QUERY_CACHE_TTL_MS = 60 * 1000;
-const CACHE_MAX_ENTRIES = 5000;
-
-class ExpiringBoundedMap<K, V extends { expiresAt: number }> extends Map<K, V> {
-  constructor(private readonly maxEntries: number) {
-    super();
-  }
-
-  private pruneExpired(now = Date.now()): void {
-    for (const [key, entry] of super.entries()) {
-      if (entry.expiresAt <= now) {
-        super.delete(key);
-      }
-    }
-  }
-
-  override get(key: K): V | undefined {
-    this.pruneExpired();
-    const entry = super.get(key);
-    if (!entry) return undefined;
-    if (entry.expiresAt <= Date.now()) {
-      super.delete(key);
-      return undefined;
-    }
-    return entry;
-  }
-
-  override set(key: K, value: V): this {
-    this.pruneExpired();
-    super.set(key, value);
-    while (this.size > this.maxEntries) {
-      const oldestKey = this.keys().next().value as K | undefined;
-      if (oldestKey === undefined) break;
-      super.delete(oldestKey);
-    }
-    return this;
-  }
-}
-
-const permissionSnapshotCache = new ExpiringBoundedMap<string, { expiresAt: number; value: Promise<any> }>(CACHE_MAX_ENTRIES);
-const credentialSchemaSnapshotCache = new ExpiringBoundedMap<string, { expiresAt: number; value: Promise<any> }>(CACHE_MAX_ENTRIES);
-const trustRegistrySnapshotCache = new ExpiringBoundedMap<string, { expiresAt: number; value: Promise<any> }>(CACHE_MAX_ENTRIES);
-
 function addDid(out: Set<string>, value: unknown): void {
   if (isValidDid(value)) out.add(value);
 }
@@ -216,133 +170,32 @@ function readNumber(content: unknown, keys: string[]): number | null {
   return null;
 }
 
-async function getTableColumns(tableName: string): Promise<Set<string>> {
-  const now = Date.now();
-  const cached = tableColumnsCache.get(tableName);
-  if (cached && cached.expiresAt > now) return cached.value;
-
-  const value = knex(tableName)
-    .columnInfo()
-    .then((info) => new Set(Object.keys(info)));
-  tableColumnsCache.set(tableName, { expiresAt: now + TABLE_COLUMNS_TTL_MS, value });
-  return value;
-}
-
-async function existingColumns(tableName: string, columns: string[]): Promise<string[]> {
-  const available = await getTableColumns(tableName);
-  return columns.filter((column) => available.has(column));
-}
-
-async function addTrustRegistryDids(trId: number | null, height: number, dids: Set<string>): Promise<void> {
-  if (!trId) return;
-  const now = Date.now();
-  const cacheKey = `${trId}:${height}`;
-  const cached = trustRegistrySnapshotCache.get(cacheKey);
-  if (cached && cached.expiresAt > now) {
-    const row = await cached.value;
-    addDid(dids, (row as any)?.did);
-    addDid(dids, (row as any)?.controller);
-    return;
-  }
-  const columns = await existingColumns("trust_registry_history", ["did", "controller"]);
-  if (columns.length === 0) return;
-
-  const value = knex("trust_registry_history")
-    .select(columns)
-    .where("tr_id", trId)
-    .where("height", "<=", height)
-    .orderBy("height", "desc")
-    .first();
-  trustRegistrySnapshotCache.set(cacheKey, { expiresAt: now + DID_QUERY_CACHE_TTL_MS, value });
-
-  const row = await value;
-  addDid(dids, (row as any)?.did);
-  addDid(dids, (row as any)?.controller);
-}
-
-async function enrichRelatedDids(row: EventRow, meta: EventMeta, dids: Set<string>): Promise<string | undefined> {
+function getEntityId(row: EventRow, meta: EventMeta): string | undefined {
   if (meta.module === "permission") {
     const permissionId = readNumber(row.content, ["id", "permission_id", "permissionId", "perm_id", "permId"]);
-    if (!permissionId) return undefined;
-    const now = Date.now();
-    const permCacheKey = `${permissionId}:${row.block_height}`;
-    const cachedPerm = permissionSnapshotCache.get(permCacheKey);
-    const columns = await existingColumns("permission_history", [
-      "permission_id",
-      "did",
-      "grantee",
-      "created_by",
-      "extended_by",
-      "revoked_by",
-      "slashed_by",
-      "repaid_by",
-      "schema_id",
-    ]);
-    const permPromise =
-      cachedPerm && cachedPerm.expiresAt > now
-        ? cachedPerm.value
-        : knex("permission_history")
-          .select(columns)
-          .where("permission_id", permissionId)
-          .where("height", "<=", row.block_height)
-          .orderBy("height", "desc")
-          .first();
-    if (!cachedPerm || cachedPerm.expiresAt <= now) {
-      permissionSnapshotCache.set(permCacheKey, { expiresAt: now + DID_QUERY_CACHE_TTL_MS, value: permPromise });
-    }
-    const perm = await permPromise;
-    addDid(dids, (perm as any)?.did);
-    addDid(dids, (perm as any)?.grantee);
-    addDid(dids, (perm as any)?.created_by);
-    addDid(dids, (perm as any)?.extended_by);
-    addDid(dids, (perm as any)?.revoked_by);
-    addDid(dids, (perm as any)?.slashed_by);
-    addDid(dids, (perm as any)?.repaid_by);
-    const schemaId = Number((perm as any)?.schema_id);
-    if (Number.isInteger(schemaId) && schemaId > 0) {
-      const csCacheKey = `${schemaId}:${row.block_height}`;
-      const cachedCs = credentialSchemaSnapshotCache.get(csCacheKey);
-      const csPromise =
-        cachedCs && cachedCs.expiresAt > now
-          ? cachedCs.value
-          : knex("credential_schema_history")
-            .select("tr_id")
-            .where("credential_schema_id", schemaId)
-            .where("height", "<=", row.block_height)
-            .orderBy("height", "desc")
-            .first();
-      if (!cachedCs || cachedCs.expiresAt <= now) {
-        credentialSchemaSnapshotCache.set(csCacheKey, { expiresAt: now + DID_QUERY_CACHE_TTL_MS, value: csPromise });
-      }
-      const cs = await csPromise;
-      await addTrustRegistryDids(Number((cs as any)?.tr_id) || null, row.block_height, dids);
-    }
-    return String(permissionId);
+    return permissionId ? String(permissionId) : undefined;
   }
 
   if (meta.module === "credential-schema") {
     const schemaId = readNumber(row.content, ["id", "schema_id", "schemaId", "credential_schema_id", "credentialSchemaId"]);
-    const trIdFromContent = readNumber(row.content, ["tr_id", "trId", "trust_registry_id", "trustRegistryId"]);
-    let trId = trIdFromContent;
-    if (schemaId) {
-      const columns = await existingColumns("credential_schema_history", ["credential_schema_id", "tr_id"]);
-      const cs = await knex("credential_schema_history")
-        .select(columns)
-        .where("credential_schema_id", schemaId)
-        .where("height", "<=", row.block_height)
-        .orderBy("height", "desc")
-        .first();
-      trId = Number((cs as any)?.tr_id) || trId;
-    }
-    await addTrustRegistryDids(trId, row.block_height, dids);
     return schemaId ? String(schemaId) : undefined;
   }
 
   const trId =
     readNumber(row.content, ["id", "tr_id", "trId", "trust_registry_id", "trustRegistryId"]) ??
     readNumber(row.content, ["gfv_id", "gfvId", "gfd_id", "gfdId"]);
-  await addTrustRegistryDids(trId, row.block_height, dids);
   return trId ? String(trId) : undefined;
+}
+
+function normalizeRequestedDid(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  try {
+    return decodeURIComponent(trimmed).trim();
+  } catch {
+    return trimmed;
+  }
 }
 
 async function toIndexerEvent(row: EventRow): Promise<IndexerTxEvent | null> {
@@ -352,7 +205,7 @@ async function toIndexerEvent(row: EventRow): Promise<IndexerTxEvent | null> {
   const relatedDids = new Set<string>();
   addDid(relatedDids, row.sender);
   collectDids(row.content, relatedDids);
-  const entityId = await enrichRelatedDids(row, meta, relatedDids);
+  const entityId = getEntityId(row, meta);
 
   return {
     type: "transaction-executed",
@@ -505,32 +358,40 @@ export async function listIndexerEvents(args: {
   limit?: number;
 }): Promise<IndexerEventRecord[]> {
   const limit = Math.max(1, Math.min(500, Math.floor(Number(args.limit ?? 100))));
-  const query = knex("indexer_events")
+  const normalizedDid = normalizeRequestedDid(args.did);
+  const query = knex("indexer_events as ie")
     .select(
-      "id",
-      "event_type",
-      "did",
-      "block_height",
-      "tx_hash",
-      "tx_index",
-      "message_index",
-      "message_type",
-      "module",
-      "entity_type",
-      "entity_id",
-      "timestamp",
-      "payload"
+      "ie.id",
+      "ie.event_type",
+      "ie.did",
+      "ie.block_height",
+      "ie.tx_hash",
+      "ie.tx_index",
+      "ie.message_index",
+      "ie.message_type",
+      "ie.module",
+      "ie.entity_type",
+      "ie.entity_id",
+      "ie.timestamp",
+      "ie.payload"
     )
-    .orderBy("block_height", "asc")
-    .orderBy("tx_index", "asc")
-    .orderBy("message_index", "asc")
-    .orderBy("did", "asc")
-    .orderBy("id", "asc")
+    .orderBy("ie.block_height", "asc")
+    .orderBy("ie.tx_index", "asc")
+    .orderBy("ie.message_index", "asc")
+    .orderBy("ie.id", "asc")
     .limit(limit);
 
-  if (args.ids) query.whereIn("id", args.ids);
-  if (args.did) query.where("did", args.did);
-  applyBlockHeightFilter(query, args, "block_height");
+  if (args.ids) query.whereIn("ie.id", args.ids);
+  if (args.did && !normalizedDid) return [];
+  if (normalizedDid && !args.ids) {
+    query.andWhere((builder) => {
+      builder
+        .where("ie.did", normalizedDid)
+        .orWhereRaw("(ie.payload -> 'related_dids') \\? ?", [normalizedDid])
+        .orWhereRaw("(ie.payload -> 'relatedDids') \\? ?", [normalizedDid]);
+    });
+  }
+  applyBlockHeightFilter(query, args, "ie.block_height");
 
   const rows = (await query) as Array<Record<string, any>>;
   return rows.map(fromStoredRow);

--- a/src/services/api/indexer_events_query.ts
+++ b/src/services/api/indexer_events_query.ts
@@ -1,14 +1,23 @@
 import knex from "../../common/utils/db_connection";
 import {
   VeranaCredentialSchemaMessageTypes,
+  VeranaDelegationMessageTypes,
+  VeranaDiMessageTypes,
   VeranaPermissionMessageTypes,
   VeranaTrustRegistryMessageTypes,
 } from "../../common/verana-message-types";
-import { applyBlockHeightFilter, isValidDid, toIsoSeconds } from "./api_shared";
+import { applyBlockHeightFilter, toIsoSeconds } from "./api_shared";
+import {
+  collectDidsDeep,
+  firstNormalizedDid,
+  normalizeDid,
+  readFirstPositiveInteger,
+  uniqueNormalizedDids,
+} from "./indexer_event_utils";
 
 export type IndexerTxEvent = {
   type: "transaction-executed";
-  module: "trust-registry" | "credential-schema" | "permission";
+  module: "trust-registry" | "credential-schema" | "permission" | "digital-identity" | "delegation";
   action: string;
   messageType: string;
   blockHeight: number;
@@ -16,9 +25,13 @@ export type IndexerTxEvent = {
   txIndex: number;
   messageIndex: number;
   sender: string;
+  did: string;
   relatedDids: string[];
   entityType?: string;
   entityId?: string;
+  trId?: string;
+  schemaId?: string;
+  permissionId?: string;
   timestamp: string;
 };
 
@@ -39,6 +52,9 @@ export type IndexerEventRecord = {
     related_dids: string[];
     entity_type?: string;
     entity_id?: string;
+    tr_id?: string;
+    schema_id?: string;
+    permission_id?: string;
   };
 };
 
@@ -72,6 +88,11 @@ const EVENT_META: Record<string, EventMeta> = {
     action: "UpdateTrustRegistry",
     entityType: "TrustRegistry",
   },
+  [VeranaTrustRegistryMessageTypes.ArchiveTrustRegistry]: {
+    module: "trust-registry",
+    action: "ArchiveTrustRegistry",
+    entityType: "TrustRegistry",
+  },
   [VeranaTrustRegistryMessageTypes.AddGovernanceFrameworkDoc]: {
     module: "trust-registry",
     action: "AddGovernanceFrameworkDocument",
@@ -100,6 +121,16 @@ const EVENT_META: Record<string, EventMeta> = {
   [VeranaPermissionMessageTypes.StartPermissionVP]: {
     module: "permission",
     action: "StartPermissionVP",
+    entityType: "Permission",
+  },
+  [VeranaPermissionMessageTypes.CreateRootPermission]: {
+    module: "permission",
+    action: "CreateRootPermission",
+    entityType: "Permission",
+  },
+  [VeranaPermissionMessageTypes.SelfCreatePermission]: {
+    module: "permission",
+    action: "SelfCreatePermission",
     entityType: "Permission",
   },
   [VeranaPermissionMessageTypes.RenewPermissionVP]: {
@@ -137,37 +168,32 @@ const EVENT_META: Record<string, EventMeta> = {
     action: "CancelPermissionVPLastRequest",
     entityType: "Permission",
   },
+  [VeranaPermissionMessageTypes.CreateOrUpdatePermissionSession]: {
+    module: "permission",
+    action: "CreateOrUpdatePermissionSession",
+    entityType: "PermissionSession",
+  },
+  [VeranaDiMessageTypes.StoreDigest]: {
+    module: "digital-identity",
+    action: "StoreDigest",
+    entityType: "DigitalIdentityDigest",
+  },
+  [VeranaDelegationMessageTypes.GrantOperatorAuthorization]: {
+    module: "delegation",
+    action: "GrantOperatorAuthorization",
+    entityType: "OperatorAuthorization",
+  },
+  [VeranaDelegationMessageTypes.RevokeOperatorAuthorization]: {
+    module: "delegation",
+    action: "RevokeOperatorAuthorization",
+    entityType: "OperatorAuthorization",
+  },
 };
 
 const WATCHED_MESSAGE_TYPES = Object.keys(EVENT_META);
 
-function addDid(out: Set<string>, value: unknown): void {
-  if (isValidDid(value)) out.add(value);
-}
-
-function collectDids(value: unknown, out: Set<string>): void {
-  if (isValidDid(value)) {
-    out.add(value);
-    return;
-  }
-  if (Array.isArray(value)) {
-    value.forEach((item) => collectDids(item, out));
-    return;
-  }
-  if (value && typeof value === "object") {
-    Object.values(value as Record<string, unknown>).forEach((item) => collectDids(item, out));
-  }
-}
-
 function readNumber(content: unknown, keys: string[]): number | null {
-  if (!content || typeof content !== "object") return null;
-  const obj = content as Record<string, unknown>;
-  for (const key of keys) {
-    const raw = obj[key];
-    const n = Number(raw);
-    if (Number.isInteger(n) && n > 0) return n;
-  }
-  return null;
+  return readFirstPositiveInteger(content, keys);
 }
 
 function getEntityId(row: EventRow, meta: EventMeta): string | undefined {
@@ -188,24 +214,138 @@ function getEntityId(row: EventRow, meta: EventMeta): string | undefined {
 }
 
 function normalizeRequestedDid(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined;
-  const trimmed = value.trim();
-  if (!trimmed) return undefined;
-  try {
-    return decodeURIComponent(trimmed).trim();
-  } catch {
-    return trimmed;
-  }
+  return normalizeDid(value);
+}
+
+async function loadTrustRegistryDid(trId: number | null | undefined): Promise<string | undefined> {
+  if (!trId) return undefined;
+  const row = await knex("trust_registry").select("did").where({ id: trId }).first();
+  return normalizeDid(row?.did);
+}
+
+async function loadSchemaRelation(schemaId: number | null | undefined): Promise<{
+  schemaId?: string;
+  trId?: string;
+  trDid?: string;
+}> {
+  if (!schemaId) return {};
+  const schema = await knex("credential_schemas as cs")
+    .leftJoin("trust_registry as tr", "tr.id", "cs.tr_id")
+    .where("cs.id", schemaId)
+    .select("cs.id as schema_id", "cs.tr_id", "tr.did as tr_did")
+    .first();
+  if (!schema) return { schemaId: String(schemaId) };
+  return {
+    schemaId: String(schema.schema_id ?? schemaId),
+    trId: schema.tr_id != null ? String(schema.tr_id) : undefined,
+    trDid: normalizeDid(schema.tr_did),
+  };
+}
+
+async function loadPermissionRelation(permissionId: number | null | undefined): Promise<{
+  permissionId?: string;
+  permissionDid?: string;
+  schemaId?: string;
+  trId?: string;
+  trDid?: string;
+  validatorPermissionDid?: string;
+}> {
+  if (!permissionId) return {};
+  const perm = await knex("permissions as p")
+    .leftJoin("credential_schemas as cs", "cs.id", "p.schema_id")
+    .leftJoin("trust_registry as tr", "tr.id", "cs.tr_id")
+    .leftJoin("permissions as validator", "validator.id", "p.validator_perm_id")
+    .where("p.id", permissionId)
+    .select(
+      "p.id as permission_id",
+      "p.did as permission_did",
+      "p.schema_id",
+      "cs.tr_id",
+      "tr.did as tr_did",
+      "validator.did as validator_permission_did"
+    )
+    .first();
+  if (!perm) return { permissionId: String(permissionId) };
+  return {
+    permissionId: String(perm.permission_id ?? permissionId),
+    permissionDid: normalizeDid(perm.permission_did),
+    schemaId: perm.schema_id != null ? String(perm.schema_id) : undefined,
+    trId: perm.tr_id != null ? String(perm.tr_id) : undefined,
+    trDid: normalizeDid(perm.tr_did),
+    validatorPermissionDid: normalizeDid(perm.validator_permission_did),
+  };
 }
 
 async function toIndexerEvent(row: EventRow): Promise<IndexerTxEvent | null> {
   const meta = EVENT_META[row.message_type];
   if (!meta) return null;
 
-  const relatedDids = new Set<string>();
-  addDid(relatedDids, row.sender);
-  collectDids(row.content, relatedDids);
   const entityId = getEntityId(row, meta);
+  const content = row.content && typeof row.content === "object" ? (row.content as Record<string, unknown>) : {};
+  const collected = collectDidsDeep([row.sender, row.content]);
+  let trId: string | undefined;
+  let schemaId: string | undefined;
+  let permissionId: string | undefined;
+  const explicitPrimaryDid = firstNormalizedDid([
+    content.did,
+    content.trust_registry_did,
+    content.trustRegistryDid,
+    content.permission_did,
+    content.permissionDid,
+    content.participant_did,
+    content.participantDid,
+    content.sender,
+    row.sender,
+  ]);
+
+  if (meta.module === "trust-registry") {
+    const rawTrId = readNumber(row.content, ["trust_registry_id", "trustRegistryId", "tr_id", "trId", "id"]);
+    trId = rawTrId ? String(rawTrId) : entityId;
+    const trDid = await loadTrustRegistryDid(rawTrId);
+    if (trDid) collected.add(trDid);
+  }
+
+  if (meta.module === "credential-schema") {
+    const rawSchemaId = readNumber(row.content, ["schema_id", "schemaId", "credential_schema_id", "credentialSchemaId", "id"]);
+    const rawTrId = readNumber(row.content, ["trust_registry_id", "trustRegistryId", "tr_id", "trId"]);
+    const relation = await loadSchemaRelation(rawSchemaId);
+    schemaId = relation.schemaId ?? (rawSchemaId ? String(rawSchemaId) : entityId);
+    trId = relation.trId ?? (rawTrId ? String(rawTrId) : undefined);
+    const trDid = relation.trDid ?? (await loadTrustRegistryDid(rawTrId));
+    if (trDid) collected.add(trDid);
+  }
+
+  if (meta.module === "permission") {
+    const rawPermissionId = readNumber(row.content, ["permission_id", "permissionId", "perm_id", "permId", "id"]);
+    const rawSchemaId = readNumber(row.content, ["schema_id", "schemaId", "credential_schema_id", "credentialSchemaId"]);
+    const rawValidatorPermId = readNumber(row.content, ["validator_perm_id", "validatorPermId"]);
+    const relation = await loadPermissionRelation(rawPermissionId);
+    permissionId = relation.permissionId ?? (rawPermissionId ? String(rawPermissionId) : entityId);
+    schemaId = relation.schemaId ?? (rawSchemaId ? String(rawSchemaId) : undefined);
+    trId = relation.trId;
+    [relation.permissionDid, relation.trDid, relation.validatorPermissionDid].forEach((did) => {
+      if (did) collected.add(did);
+    });
+    if (rawSchemaId && !relation.trDid) {
+      const schemaRelation = await loadSchemaRelation(rawSchemaId);
+      schemaId = schemaId ?? schemaRelation.schemaId;
+      trId = trId ?? schemaRelation.trId;
+      if (schemaRelation.trDid) collected.add(schemaRelation.trDid);
+    }
+    if (rawValidatorPermId) {
+      const validatorRelation = await loadPermissionRelation(rawValidatorPermId);
+      [validatorRelation.permissionDid, validatorRelation.trDid].forEach((did) => {
+        if (did) collected.add(did);
+      });
+    }
+  }
+
+  const relatedDids = uniqueNormalizedDids(collected);
+  const primaryDid =
+    explicitPrimaryDid ??
+    (meta.module === "permission" ? firstNormalizedDid(relatedDids) : undefined) ??
+    firstNormalizedDid(relatedDids);
+  if (!primaryDid) return null;
 
   return {
     type: "transaction-executed",
@@ -217,17 +357,21 @@ async function toIndexerEvent(row: EventRow): Promise<IndexerTxEvent | null> {
     txIndex: Number(row.tx_index),
     messageIndex: Number(row.message_index),
     sender: row.sender,
-    relatedDids: Array.from(relatedDids).sort(),
+    did: primaryDid,
+    relatedDids,
     entityType: meta.entityType,
     entityId,
+    trId,
+    schemaId,
+    permissionId,
     timestamp: toIsoSeconds(row.timestamp),
   };
 }
 
-function toEventRows(event: IndexerTxEvent): Array<Record<string, unknown>> {
-  return event.relatedDids.map((did) => ({
+function toEventRow(event: IndexerTxEvent): Record<string, unknown> {
+  return {
     event_type: event.action,
-    did,
+    did: event.did,
     block_height: event.blockHeight,
     tx_hash: event.txHash,
     tx_index: event.txIndex,
@@ -247,8 +391,11 @@ function toEventRows(event: IndexerTxEvent): Array<Record<string, unknown>> {
       related_dids: event.relatedDids,
       entity_type: event.entityType,
       entity_id: event.entityId,
+      tr_id: event.trId,
+      schema_id: event.schemaId,
+      permission_id: event.permissionId,
     },
-  }));
+  };
 }
 
 function fromStoredRow(row: Record<string, any>): IndexerEventRecord {
@@ -274,6 +421,9 @@ function fromStoredRow(row: Record<string, any>): IndexerEventRecord {
           : [String(row.did)],
       entity_type: row.payload?.entity_type ?? row.payload?.entityType ?? row.entity_type ?? undefined,
       entity_id: row.payload?.entity_id ?? row.payload?.entityId ?? row.entity_id ?? undefined,
+      tr_id: row.payload?.tr_id ?? row.payload?.trId ?? undefined,
+      schema_id: row.payload?.schema_id ?? row.payload?.schemaId ?? undefined,
+      permission_id: row.payload?.permission_id ?? row.payload?.permissionId ?? undefined,
     },
   };
 }
@@ -321,7 +471,7 @@ export async function persistIndexerEventsForBlock(blockHeight: number): Promise
   let offset = 0;
   while (true) {
     const txEvents = await buildIndexerTxEvents({ blockHeight, limit: pageSize, offset });
-    rows.push(...txEvents.flatMap(toEventRows));
+    rows.push(...txEvents.map(toEventRow));
     if (txEvents.length < pageSize) break;
     offset += pageSize;
   }
@@ -330,12 +480,19 @@ export async function persistIndexerEventsForBlock(blockHeight: number): Promise
   if (rows.length > 0) {
     const inserted = await knex("indexer_events")
       .insert(rows)
-      .onConflict(["did", "tx_hash", "message_index", "event_type"])
+      .onConflict(knex.raw("(tx_hash, tx_index, message_index, event_type, entity_type, COALESCE(entity_id, ''))"))
       .ignore()
       .returning("id");
     insertedIds = inserted
       .map((row: number | string | { id?: number | string }) => Number(typeof row === "object" ? row.id : row))
       .filter((id): id is number => Number.isInteger(id));
+    if (insertedIds.length === 0) {
+      console.info(`[IndexerEvents] skipped duplicate event batch for block_height=${blockHeight}, candidates=${rows.length}`);
+    } else {
+      console.info(`[IndexerEvents] saved ${insertedIds.length}/${rows.length} event(s) for block_height=${blockHeight}`);
+    }
+  } else {
+    console.info(`[IndexerEvents] no DID found or no watched messages for block_height=${blockHeight}`);
   }
 
   if (insertedIds.length === 0) return [];
@@ -384,8 +541,8 @@ export async function listIndexerEvents(args: {
   if (args.ids) query.whereIn("ie.id", args.ids);
   if (args.did && !normalizedDid) return [];
   if (normalizedDid && !args.ids) {
-    query.andWhere((builder) => {
-      builder
+    query.andWhere(function () {
+      this
         .where("ie.did", normalizedDid)
         .orWhereRaw("(ie.payload -> 'related_dids') \\? ?", [normalizedDid])
         .orWhereRaw("(ie.payload -> 'relatedDids') \\? ?", [normalizedDid]);

--- a/test/unit/services/api/events_broadcaster.spec.ts
+++ b/test/unit/services/api/events_broadcaster.spec.ts
@@ -367,21 +367,36 @@ describe("EventsBroadcaster", () => {
     const eventA = makeEvent(didA, {
       payload: { ...makeEvent(didA).payload, related_dids: [didA, didB] },
     });
-    const eventB = makeEvent(didB, {
-      tx_hash: eventA.tx_hash,
-      payload: { ...eventA.payload, related_dids: [didA, didB] },
-    });
-
     const messageA = waitForMessage(wsA, (msg) => msg.type === "indexer-event");
     const messageB = waitForMessage(wsB, (msg) => msg.type === "indexer-event");
     broadcaster.broadcastIndexerEvent(eventA);
-    broadcaster.broadcastIndexerEvent(eventB);
 
     await expect(messageA).resolves.toMatchObject({ did: didA, payload: { related_dids: [didA, didB] } });
-    await expect(messageB).resolves.toMatchObject({ did: didB, payload: { related_dids: [didA, didB] } });
+    await expect(messageB).resolves.toMatchObject({ did: didA, payload: { related_dids: [didA, didB] } });
 
     closeSocket(wsA);
     closeSocket(wsB);
+  });
+
+  it("does not emit duplicate DID room events when did is also related", async () => {
+    const didA = "did:web:agent-duplicate.example";
+    const wsA = new WebSocket(`${WS_URL}?did=${encodeURIComponent(didA)}`);
+    await waitForOpen(wsA);
+    await waitForMessage(wsA, (msg) => msg.type === "connected");
+
+    let received = 0;
+    wsA.on("message", (data) => {
+      const message = JSON.parse(data.toString());
+      if (message.type === "indexer-event") received++;
+    });
+
+    broadcaster.broadcastIndexerEvent(makeEvent(didA, {
+      payload: { ...makeEvent(didA).payload, related_dids: [didA, didA] },
+    }));
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    expect(received).toBe(1);
+    closeSocket(wsA);
   });
 
   it("broadcasts legacy block-indexed events to global subscribers only", async () => {

--- a/test/unit/services/api/indexer_events_query.spec.ts
+++ b/test/unit/services/api/indexer_events_query.spec.ts
@@ -1,6 +1,7 @@
 import knex from "../../../../src/common/utils/db_connection";
 import { VeranaPermissionMessageTypes } from "../../../../src/common/verana-message-types";
 import { up as createIndexerEventsTable } from "../../../../src/migrations/20260420000000_create_indexer_events";
+import { up as hardenIndexerEventsTable } from "../../../../src/migrations/20260421000000_harden_indexer_events_replay";
 import { listIndexerEvents, persistIndexerEventsForBlock } from "../../../../src/services/api/indexer_events_query";
 
 describe("indexer_events_query", () => {
@@ -11,10 +12,88 @@ describe("indexer_events_query", () => {
   const otherDid = `did:web:indexer-events-other-${runId}.example`;
   const txHashes: string[] = [];
   const heights: number[] = [];
+  const createdTables: string[] = [];
 
   beforeAll(async () => {
+    await ensureBaseTables();
     await createIndexerEventsTable(knex);
+    await hardenIndexerEventsTable(knex);
   });
+
+  afterAll(async () => {
+    for (const table of createdTables.reverse()) {
+      await knex.schema.dropTableIfExists(table);
+    }
+  });
+
+  async function ensureBaseTables(): Promise<void> {
+    if (!(await knex.schema.hasTable("block"))) {
+      await knex.schema.createTable("block", (table) => {
+        table.bigInteger("height").primary();
+        table.text("hash").notNullable();
+        table.timestamp("time").notNullable();
+        table.text("proposer_address").nullable();
+        table.jsonb("data").nullable();
+      });
+      createdTables.push("block");
+    }
+
+    if (!(await knex.schema.hasTable("transaction"))) {
+      await knex.schema.createTable("transaction", (table) => {
+        table.bigInteger("id").primary();
+        table.bigInteger("height").notNullable();
+        table.text("hash").notNullable();
+        table.text("codespace").nullable();
+        table.integer("code").notNullable().defaultTo(0);
+        table.bigInteger("gas_used").nullable();
+        table.bigInteger("gas_wanted").nullable();
+        table.bigInteger("gas_limit").nullable();
+        table.jsonb("fee").nullable();
+        table.timestamp("timestamp").notNullable();
+        table.jsonb("data").nullable();
+        table.integer("index").notNullable().defaultTo(0);
+      });
+      createdTables.push("transaction");
+    }
+
+    if (!(await knex.schema.hasTable("transaction_message"))) {
+      await knex.schema.createTable("transaction_message", (table) => {
+        table.bigInteger("id").primary();
+        table.bigInteger("tx_id").notNullable();
+        table.integer("index").notNullable().defaultTo(0);
+        table.text("type").notNullable();
+        table.text("sender").nullable();
+        table.jsonb("content").nullable();
+      });
+      createdTables.push("transaction_message");
+    }
+
+    if (!(await knex.schema.hasTable("trust_registry"))) {
+      await knex.schema.createTable("trust_registry", (table) => {
+        table.bigInteger("id").primary();
+        table.text("did").notNullable();
+      });
+      createdTables.push("trust_registry");
+    }
+
+    if (!(await knex.schema.hasTable("credential_schemas"))) {
+      await knex.schema.createTable("credential_schemas", (table) => {
+        table.bigInteger("id").primary();
+        table.bigInteger("tr_id").notNullable();
+      });
+      createdTables.push("credential_schemas");
+    }
+
+    if (!(await knex.schema.hasTable("permissions"))) {
+      await knex.schema.createTable("permissions", (table) => {
+        table.bigInteger("id").primary();
+        table.bigInteger("schema_id").nullable();
+        table.text("did").nullable();
+        table.bigInteger("validator_perm_id").nullable();
+      });
+      createdTables.push("permissions");
+    }
+  }
 
   async function insertBlock(height: number): Promise<void> {
     heights.push(height);
@@ -150,7 +229,7 @@ describe("indexer_events_query", () => {
     ]);
   });
 
-  it("persists one row per affected DID and protects duplicate inserts", async () => {
+  it("persists one event with all affected DIDs and protects duplicate inserts", async () => {
     await insertBlock(baseHeight + 20);
     await insertTxMessage({
       height: baseHeight + 20,
@@ -164,10 +243,12 @@ describe("indexer_events_query", () => {
     const secondPersist = await persistIndexerEventsForBlock(baseHeight + 20);
     const rows = await knex("indexer_events").where("tx_hash", `tx-${runId}-multi-did`).orderBy("did", "asc");
 
-    expect(firstPersist.map((event) => event.did).sort()).toEqual([did, otherDid]);
+    expect(firstPersist).toHaveLength(1);
+    expect(firstPersist[0].did).toBe(did);
+    expect(firstPersist[0].payload.related_dids).toEqual([did, otherDid]);
     expect(secondPersist).toEqual([]);
-    expect(rows).toHaveLength(2);
-    expect(rows.map((row) => row.did)).toEqual([did, otherDid]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].did).toBe(did);
   });
 
   it("matches persisted events by event.did", async () => {
@@ -293,5 +374,32 @@ describe("indexer_events_query", () => {
     const events = await listIndexerEvents({ did: unpersistedDid, afterBlockHeight: height - 1, limit: 10 });
 
     expect(events).toEqual([]);
+  });
+
+  it("does not leak unrelated rows when after_block_height is combined with related_dids matching", async () => {
+    const height = baseHeight + 100;
+    const relatedDid = `did:web:indexer-events-grouping-${runId}.example`;
+    await insertStoredIndexerEvent({
+      did: otherDid,
+      relatedDids: [relatedDid],
+      height,
+      txHash: `tx-${runId}-grouping-match`,
+    });
+    await insertStoredIndexerEvent({
+      did: otherDid,
+      relatedDids: [relatedDid],
+      height: height - 50,
+      txHash: `tx-${runId}-grouping-too-old`,
+    });
+    await insertStoredIndexerEvent({
+      did: otherDid,
+      relatedDids: [`did:web:indexer-events-unrelated-${runId}.example`],
+      height: height + 1,
+      txHash: `tx-${runId}-grouping-unrelated`,
+    });
+
+    const events = await listIndexerEvents({ did: relatedDid, afterBlockHeight: height - 1, limit: 10 });
+
+    expect(events.map((event) => event.tx_hash)).toEqual([`tx-${runId}-grouping-match`]);
   });
 });

--- a/test/unit/services/api/indexer_events_query.spec.ts
+++ b/test/unit/services/api/indexer_events_query.spec.ts
@@ -65,6 +65,41 @@ describe("indexer_events_query", () => {
     });
   }
 
+  async function insertStoredIndexerEvent(args: {
+    did: string;
+    relatedDids: string[];
+    height: number;
+    txHash: string;
+    txIndex?: number;
+    messageIndex?: number;
+  }): Promise<void> {
+    txHashes.push(args.txHash);
+    await knex("indexer_events").insert({
+      event_type: "StartPermissionVP",
+      did: args.did,
+      block_height: args.height,
+      tx_hash: args.txHash,
+      tx_index: args.txIndex ?? 0,
+      message_index: args.messageIndex ?? 0,
+      message_type: VeranaPermissionMessageTypes.StartPermissionVP,
+      module: "permission",
+      entity_type: "Permission",
+      entity_id: "42",
+      timestamp: new Date("2025-01-15T10:30:00Z"),
+      payload: {
+        module: "permission",
+        action: "StartPermissionVP",
+        message_type: VeranaPermissionMessageTypes.StartPermissionVP,
+        tx_index: args.txIndex ?? 0,
+        message_index: args.messageIndex ?? 0,
+        sender: otherDid,
+        related_dids: args.relatedDids,
+        entity_type: "Permission",
+        entity_id: "42",
+      },
+    });
+  }
+
   afterEach(async () => {
     if (txHashes.length > 0) {
       await knex("indexer_events").whereIn("tx_hash", txHashes).delete();
@@ -133,5 +168,130 @@ describe("indexer_events_query", () => {
     expect(secondPersist).toEqual([]);
     expect(rows).toHaveLength(2);
     expect(rows.map((row) => row.did)).toEqual([did, otherDid]);
+  });
+
+  it("matches persisted events by event.did", async () => {
+    const height = baseHeight + 30;
+    await insertStoredIndexerEvent({
+      did,
+      relatedDids: [did],
+      height,
+      txHash: `tx-${runId}-match-did`,
+    });
+
+    const events = await listIndexerEvents({ did, afterBlockHeight: height - 1, limit: 10 });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ did, tx_hash: `tx-${runId}-match-did` });
+  });
+
+  it("matches persisted events by payload.related_dids", async () => {
+    const height = baseHeight + 40;
+    const relatedDid = `did:web:indexer-events-related-${runId}.example`;
+    await insertStoredIndexerEvent({
+      did: otherDid,
+      relatedDids: [relatedDid],
+      height,
+      txHash: `tx-${runId}-related-dids`,
+    });
+
+    const events = await listIndexerEvents({ did: relatedDid, afterBlockHeight: height - 1, limit: 10 });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].did).toBe(otherDid);
+    expect(events[0].payload.related_dids).toContain(relatedDid);
+  });
+
+  it("normalizes URL-encoded DID input before matching", async () => {
+    const height = baseHeight + 50;
+    await insertStoredIndexerEvent({
+      did,
+      relatedDids: [did],
+      height,
+      txHash: `tx-${runId}-encoded-did`,
+    });
+
+    const events = await listIndexerEvents({
+      did: encodeURIComponent(` ${did} `),
+      afterBlockHeight: 0,
+      limit: 10,
+    });
+
+    expect(events.map((event) => event.tx_hash)).toContain(`tx-${runId}-encoded-did`);
+  });
+
+  it("after_block_height excludes old events", async () => {
+    await insertStoredIndexerEvent({
+      did,
+      relatedDids: [did],
+      height: baseHeight + 60,
+      txHash: `tx-${runId}-old-height`,
+    });
+    await insertStoredIndexerEvent({
+      did,
+      relatedDids: [did],
+      height: baseHeight + 61,
+      txHash: `tx-${runId}-new-height`,
+    });
+
+    const events = await listIndexerEvents({ did, afterBlockHeight: baseHeight + 60, limit: 10 });
+
+    expect(events.map((event) => event.tx_hash)).toEqual([`tx-${runId}-new-height`]);
+  });
+
+  it("applies limit after deterministic ordering", async () => {
+    await insertStoredIndexerEvent({
+      did,
+      relatedDids: [did],
+      height: baseHeight + 70,
+      txHash: `tx-${runId}-limit-1`,
+      txIndex: 0,
+    });
+    await insertStoredIndexerEvent({
+      did,
+      relatedDids: [did],
+      height: baseHeight + 70,
+      txHash: `tx-${runId}-limit-2`,
+      txIndex: 1,
+    });
+
+    const events = await listIndexerEvents({ did, afterBlockHeight: baseHeight + 69, limit: 1 });
+
+    expect(events.map((event) => event.tx_hash)).toEqual([`tx-${runId}-limit-1`]);
+  });
+
+  it("returns an empty array for an unknown DID", async () => {
+    await insertStoredIndexerEvent({
+      did,
+      relatedDids: [did],
+      height: baseHeight + 80,
+      txHash: `tx-${runId}-unknown-did-control`,
+    });
+
+    const events = await listIndexerEvents({
+      did: `did:web:indexer-events-missing-${runId}.example`,
+      afterBlockHeight: 0,
+      limit: 10,
+    });
+
+    expect(events).toEqual([]);
+  });
+
+  it("does not reconstruct unpersisted historical transaction events in the request path", async () => {
+    const height = baseHeight + 90;
+    const unpersistedDid = `did:web:indexer-events-unpersisted-${runId}.example`;
+    await insertBlock(height);
+    await insertTxMessage({
+      height,
+      txIndex: 0,
+      messageIndex: 0,
+      hash: `tx-${runId}-unpersisted-history`,
+      sender: otherDid,
+      content: { id: 42, applicant: unpersistedDid },
+    });
+
+    const events = await listIndexerEvents({ did: unpersistedDid, afterBlockHeight: height - 1, limit: 10 });
+
+    expect(events).toEqual([]);
   });
 });


### PR DESCRIPTION
This PR fixes event replay and socket broadcasting for pre-existing and related DIDs.

Previously, `/verana/indexer/v1/events` could return incomplete results because replay mainly matched direct `event.did` values. In cases where a DID was related through Trust Registry, Credential Schema, or Permission state, the snapshot endpoint could show related data while the events endpoint only returned a limited set of events.

## Changes

- Replay events only from persisted `indexer_events`
- Match queried DID by:
  - `indexer_events.did`
  - `payload.related_dids`
  - legacy `payload.relatedDids`
- Normalize DID query input before matching
- Preserve `after_block_height`, `limit`, and response format
- Apply deterministic ordering by `block_height`, `tx_index`, `message_index`, and `id`
- Fix grouped query conditions so related DID matching does not bypass block-height filters
- Add shared DID/event utility helpers
- Store affected DIDs in `payload.related_dids`
- Broadcast indexer events to both the primary DID room and all related DID rooms
- Prevent duplicate socket emissions to the same DID room
- Harden database indexes and uniqueness rules for replay/idempotency
- Add tests for replay matching, URL-encoded DIDs, filtering, limit behavior, no request-time reconstruction, and socket broadcasting

## Result

Agents can now replay persisted events for pre-existing DIDs, receive events where their DID appears as a related DID, and get future live socket events for all affected DID rooms.
