### PR TITLE
fix: ensure entity_id is included in transaction events for reliable entity resolution

### DIFF
--- a/src/migrations/20250905_create_trust_registry_tables.ts
+++ b/src/migrations/20250905_create_trust_registry_tables.ts
@@ -12,6 +12,8 @@ export async function up(knex: Knex): Promise<void> {
     table.string("language", 2).notNullable();
     table.integer("active_version").nullable();
     table.bigInteger("height").notNullable().unique();
+    table.unique(["did", "height"], "trust_registry_did_height_unique");
+    table.index(["height"], "trust_registry_height_idx");
 
     table.bigInteger("participants").notNullable().defaultTo(0);
     table.bigInteger("participants_ecosystem").notNullable().defaultTo(0);

--- a/src/migrations/20250905_create_trust_registry_tables.ts
+++ b/src/migrations/20250905_create_trust_registry_tables.ts
@@ -12,8 +12,6 @@ export async function up(knex: Knex): Promise<void> {
     table.string("language", 2).notNullable();
     table.integer("active_version").nullable();
     table.bigInteger("height").notNullable().unique();
-    table.unique(["did", "height"], "trust_registry_did_height_unique");
-    table.index(["height"], "trust_registry_height_idx");
 
     table.bigInteger("participants").notNullable().defaultTo(0);
     table.bigInteger("participants_ecosystem").notNullable().defaultTo(0);

--- a/src/services/api/indexer_events_query.ts
+++ b/src/services/api/indexer_events_query.ts
@@ -49,6 +49,8 @@ type EventRow = {
   message_type: string;
   sender: string;
   content: unknown;
+  tx_data?: any;
+  tx_message_count?: number;
   block_height: number;
   tx_hash: string;
   tx_index: number;
@@ -70,6 +72,11 @@ const EVENT_META: Record<string, EventMeta> = {
   [VeranaTrustRegistryMessageTypes.UpdateTrustRegistry]: {
     module: "trust-registry",
     action: "UpdateTrustRegistry",
+    entityType: "TrustRegistry",
+  },
+  [VeranaTrustRegistryMessageTypes.ArchiveTrustRegistry]: {
+    module: "trust-registry",
+    action: "ArchiveTrustRegistry",
     entityType: "TrustRegistry",
   },
   [VeranaTrustRegistryMessageTypes.AddGovernanceFrameworkDoc]: {
@@ -104,7 +111,7 @@ const EVENT_META: Record<string, EventMeta> = {
   },
   [VeranaPermissionMessageTypes.SelfCreatePermission]: {
     module: "permission",
-    action: "CreatePermission",
+    action: "SelfCreatePermission",
     entityType: "Permission",
   },
   [VeranaPermissionMessageTypes.StartPermissionVP]: {
@@ -151,54 +158,12 @@ const EVENT_META: Record<string, EventMeta> = {
 
 const WATCHED_MESSAGE_TYPES = Object.keys(EVENT_META);
 
-const TABLE_COLUMNS_TTL_MS = 10 * 60 * 1000;
-const tableColumnsCache = new Map<string, { expiresAt: number; value: Promise<Set<string>> }>();
-
-const DID_QUERY_CACHE_TTL_MS = 60 * 1000;
-const CACHE_MAX_ENTRIES = 5000;
-
-class ExpiringBoundedMap<K, V extends { expiresAt: number }> extends Map<K, V> {
-  constructor(private readonly maxEntries: number) {
-    super();
-  }
-
-  private pruneExpired(now = Date.now()): void {
-    for (const [key, entry] of super.entries()) {
-      if (entry.expiresAt <= now) {
-        super.delete(key);
-      }
-    }
-  }
-
-  override get(key: K): V | undefined {
-    this.pruneExpired();
-    const entry = super.get(key);
-    if (!entry) return undefined;
-    if (entry.expiresAt <= Date.now()) {
-      super.delete(key);
-      return undefined;
-    }
-    return entry;
-  }
-
-  override set(key: K, value: V): this {
-    this.pruneExpired();
-    super.set(key, value);
-    while (this.size > this.maxEntries) {
-      const oldestKey = this.keys().next().value as K | undefined;
-      if (oldestKey === undefined) break;
-      super.delete(oldestKey);
-    }
-    return this;
-  }
-}
-
-const permissionSnapshotCache = new ExpiringBoundedMap<string, { expiresAt: number; value: Promise<any> }>(CACHE_MAX_ENTRIES);
-const credentialSchemaSnapshotCache = new ExpiringBoundedMap<string, { expiresAt: number; value: Promise<any> }>(CACHE_MAX_ENTRIES);
-const trustRegistrySnapshotCache = new ExpiringBoundedMap<string, { expiresAt: number; value: Promise<any> }>(CACHE_MAX_ENTRIES);
-
 function addDid(out: Set<string>, value: unknown): void {
   if (isValidDid(value)) out.add(value);
+}
+
+function getLogger(): { warn?: (...args: any[]) => void } | undefined {
+  return (global as any).logger as { warn?: (...args: any[]) => void } | undefined;
 }
 
 function collectDids(value: unknown, out: Set<string>): void {
@@ -215,291 +180,354 @@ function collectDids(value: unknown, out: Set<string>): void {
   }
 }
 
-function readNumber(content: unknown, keys: string[]): number | null {
-  if (!content || typeof content !== "object") return null;
-  const obj = content as Record<string, unknown>;
-  for (const key of keys) {
-    const raw = obj[key];
-    const n = Number(raw);
-    if (Number.isInteger(n) && n > 0) return n;
-  }
-  return null;
+type TxEventAttribute = { key?: unknown; value?: unknown };
+type TxEvent = { type?: unknown; attributes?: unknown };
+type TxResponse = { events?: TxEvent[]; logs?: Array<{ events?: TxEvent[] }> };
+
+function toLowerSnake(input: string): string {
+  const s = String(input ?? "");
+  if (!s) return "";
+  return s
+    .replace(/\./g, "_")
+    .replace(/[\s-]+/g, "_")
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/__+/g, "_")
+    .toLowerCase()
+    .trim();
 }
 
-async function readEventAttributeNumber(args: {
-  txId: number;
+function looksLikeBase64(s: string): boolean {
+  return /^[A-Za-z0-9+/=]+$/.test(s) && s.length % 4 === 0;
+}
+
+function decodeMaybeBase64(v: unknown): string {
+  const s = typeof v === "string" ? v : "";
+  if (!s) return "";
+  try {
+    if (looksLikeBase64(s)) return Buffer.from(s, "base64").toString("utf-8");
+  } catch {
+    //
+  }
+  return s;
+}
+
+function readTxResponse(row: EventRow): TxResponse | null {
+  const data = row.tx_data ?? null;
+  if (!data || typeof data !== "object") return null;
+  const txResponse = (data as any).tx_response ?? (data as any).txResponse ?? null;
+  if (!txResponse || typeof txResponse !== "object") return null;
+  return txResponse as TxResponse;
+}
+
+function normalizePositiveIntStrings(values: string[]): string[] {
+  return values
+    .map((v) => Number(v))
+    .filter((n) => Number.isInteger(n) && n > 0)
+    .map((n) => String(n));
+}
+
+function chooseEntityIdCandidate(args: { candidates: Array<{ value: unknown }>; row: EventRow }): string | undefined {
+  const unique = Array.from(new Set(normalizePositiveIntStrings(args.candidates.map((c) => String(c.value ?? "")))));
+  if (unique.length === 1) return unique[0];
+  if (unique.length > 1) {
+    getLogger()?.warn?.(`[IndexerEvents] conflicting entity_id candidates; leaving entity_id empty`, {
+      txHash: args.row.tx_hash,
+      messageIndex: args.row.message_index,
+      candidates: unique,
+    });
+  }
+  return undefined;
+}
+
+export function resolveEntityIdFromTxResponseEvents(args: {
+  txHash: string;
+  blockHeight: number;
   messageIndex: number;
-  keys: string[];
-}): Promise<number | null> {
-  const txId = Number(args.txId);
-  const messageIndex = Number(args.messageIndex);
-  if (!Number.isInteger(txId) || txId <= 0) return null;
-  if (!Number.isInteger(messageIndex) || messageIndex < 0) return null;
-  if (!args.keys || args.keys.length === 0) return null;
+  txMessageCount: number;
+  action: string;
+  module: EventMeta["module"];
+  txResponse: TxResponse | null;
+}): { entityId?: string; reason?: string; debug?: any } {
+  const action = String(args.action ?? "");
+  const msgIndex = Number(args.messageIndex);
+  const txMessageCount = Number(args.txMessageCount);
+  const events = Array.isArray(args.txResponse?.events) ? (args.txResponse!.events as TxEvent[]) : [];
 
-  async function query(whereMsgIndex: boolean): Promise<number | null> {
-    const q = knex("event_attribute as ea")
-      .innerJoin("event as e", "e.id", "ea.event_id")
-      .select("ea.key", "ea.value")
-      .where("e.tx_id", txId)
-      .whereIn("ea.key", args.keys)
-      .orderBy("ea.index", "asc");
+  const normalizedAction = toLowerSnake(action);
 
-    if (whereMsgIndex) {
-      q.andWhere("e.tx_msg_index", messageIndex);
-    } else {
-      q.whereNull("e.tx_msg_index");
+  const ruleByAction: Record<
+    string,
+    { eventTypes: string[]; idKeys: string[]; preferEventTypes?: string[]; allowEventTypeFallback?: boolean }
+  > = {
+    create_new_trust_registry: {
+      eventTypes: ["create_trust_registry", "create_new_trust_registry"],
+      idKeys: ["trust_registry_id", "tr_id", "id"],
+    },
+    update_trust_registry: {
+      eventTypes: ["update_trust_registry"],
+      idKeys: ["trust_registry_id", "tr_id", "id"],
+    },
+    archive_trust_registry: {
+      eventTypes: ["archive_trust_registry"],
+      idKeys: ["trust_registry_id", "tr_id", "id"],
+    },
+
+    // Governance Framework (only valid for GF entity types)
+    add_governance_framework_document: {
+      eventTypes: ["add_governance_framework_document", "create_governance_framework_document"],
+      idKeys: ["gf_document_id", "governance_framework_document_id", "gfd_id", "id"],
+    },
+    increase_active_gf_version: {
+      eventTypes: ["increase_active_gf_version", "create_governance_framework_version"],
+      idKeys: ["gf_version_id", "governance_framework_version_id", "gfv_id", "id"],
+    },
+
+    // Credential Schema
+    create_new_credential_schema: {
+      eventTypes: ["create_credential_schema"],
+      idKeys: ["credential_schema_id", "schema_id", "cs_id", "id"],
+    },
+    update_credential_schema: {
+      eventTypes: ["update_credential_schema"],
+      idKeys: ["credential_schema_id", "schema_id", "cs_id", "id"],
+    },
+    archive_credential_schema: {
+      eventTypes: ["archive_credential_schema"],
+      idKeys: ["credential_schema_id", "schema_id", "cs_id", "id"],
+    },
+
+    // Permission
+    create_root_permission: {
+      eventTypes: ["create_root_permission"],
+      idKeys: ["root_permission_id", "permission_id", "perm_id", "id"],
+    },
+    self_create_permission: {
+      eventTypes: [
+        "self_create_permission",
+        "create_permission",
+        "create_self_permission",
+        "self_create_perm",
+        "permission_created",
+        "create_permission_vp",
+      ],
+      preferEventTypes: ["self_create_permission"],
+      allowEventTypeFallback: true,
+      idKeys: ["permission_id", "self_permission_id", "perm_id", "permission_vp_id", "id"],
+    },
+    start_permission_vp: {
+      eventTypes: ["start_permission_vp"],
+      idKeys: ["permission_id", "perm_id", "id"],
+    },
+    renew_permission_vp: {
+      eventTypes: ["renew_permission_vp"],
+      idKeys: ["permission_id", "perm_id", "id"],
+    },
+    set_permission_vp_to_validated: {
+      eventTypes: ["set_permission_vp_to_validated"],
+      idKeys: ["permission_id", "perm_id", "id"],
+    },
+    set_permission_vp_to_rejected: {
+      eventTypes: ["set_permission_vp_to_rejected"],
+      idKeys: ["permission_id", "perm_id", "id"],
+    },
+    set_permission_vp_to_cancelled: {
+      eventTypes: ["set_permission_vp_to_cancelled"],
+      idKeys: ["permission_id", "perm_id", "id"],
+    },
+    set_permission_vp_to_terminated: {
+      eventTypes: ["set_permission_vp_to_terminated"],
+      idKeys: ["permission_id", "perm_id", "id"],
+    },
+    set_permission_vp_to_cancelled_last_request: {
+      eventTypes: ["cancel_permission_vp_last_request", "set_permission_vp_to_cancelled"],
+      idKeys: ["permission_id", "perm_id", "id"],
+    },
+    adjust_permission: {
+      eventTypes: ["adjust_permission"],
+      idKeys: ["permission_id", "perm_id", "id"],
+    },
+    revoke_permission: {
+      eventTypes: ["revoke_permission"],
+      idKeys: ["permission_id", "perm_id", "id"],
+    },
+    slash_permission_trust_deposit: {
+      eventTypes: ["slash_permission_trust_deposit"],
+      idKeys: ["permission_id", "perm_id", "id"],
+    },
+    repay_permission_slashed_trust_deposit: {
+      eventTypes: ["repay_permission_slashed_trust_deposit"],
+      idKeys: ["permission_id", "perm_id", "id"],
+    },
+    update_permission: {
+      eventTypes: ["update_permission"],
+      idKeys: ["permission_id", "perm_id", "id"],
+    },
+    archive_permission: {
+      eventTypes: ["archive_permission"],
+      idKeys: ["permission_id", "perm_id", "id"],
+    },
+  };
+
+  const rule =
+    ruleByAction[normalizedAction] ??
+    (args.module === "permission"
+      ? { eventTypes: [], idKeys: ["permission_id", "perm_id", "id"] }
+      : null);
+
+  if (!rule) return { reason: "no_rule" };
+
+  const candidates: Array<{ value: string; key: string; eventType: string }> = [];
+  const consideredEvents: Array<{ type: string; msgIndex?: string }> = [];
+  const idAttributesFound: Array<{ eventType: string; key: string; value: string }> = [];
+
+  const matchesMessageIndex = (attrMap: Record<string, string>): boolean => {
+    const eventMsgIndexRaw = attrMap.msg_index ?? attrMap.message_index ?? attrMap.tx_msg_index ?? "";
+    if (!eventMsgIndexRaw) {
+      return Number.isInteger(txMessageCount) && txMessageCount === 1;
     }
+    const n = Number(eventMsgIndexRaw);
+    return Number.isInteger(n) && n === msgIndex;
+  };
 
-    const rows = (await q) as Array<{ key?: unknown; value?: unknown }>;
-    for (const row of rows) {
-      const n = Number(row?.value);
-      if (Number.isInteger(n) && n > 0) return n;
+  const scan = (ev: TxEvent, eventType: string, attrMap: Record<string, string>) => {
+    for (const idKey of rule.idKeys) {
+      if (idKey === "validator_perm_id") continue;
+      if (args.module === "permission") {
+        if (idKey === "schema_id") continue;
+        if (idKey === "trust_registry_id") continue;
+        if (idKey === "tr_id") continue;
+        if (idKey === "credential_schema_id") continue;
+        if (idKey === "cs_id") continue;
+      }
+      if (args.module === "credential-schema") {
+        if (idKey === "trust_registry_id") continue;
+        if (idKey === "tr_id") continue;
+      }
+      const v = attrMap[idKey];
+      if (v == null || v === "") continue;
+      idAttributesFound.push({ eventType, key: idKey, value: v });
+      candidates.push({ value: v, key: idKey, eventType });
     }
-    return null;
+  };
+
+  const buildAttrMap = (ev: TxEvent): Record<string, string> => {
+    const attrs = Array.isArray(ev?.attributes) ? (ev.attributes as TxEventAttribute[]) : [];
+    const attrMap: Record<string, string> = {};
+    for (const a of attrs) {
+      const k = toLowerSnake(decodeMaybeBase64((a as any)?.key));
+      if (!k) continue;
+      attrMap[k] = decodeMaybeBase64((a as any)?.value);
+    }
+    return attrMap;
+  };
+
+  const preferred = rule.preferEventTypes?.length ? rule.preferEventTypes : rule.eventTypes;
+  for (const ev of events) {
+    const eventType = toLowerSnake(String(ev?.type ?? ""));
+    if (!eventType) continue;
+    if (preferred.length > 0 && !preferred.includes(eventType)) continue;
+    const attrMap = buildAttrMap(ev);
+    const eventMsgIndexRaw = attrMap.msg_index ?? attrMap.message_index ?? attrMap.tx_msg_index ?? "";
+    consideredEvents.push({ type: eventType, msgIndex: eventMsgIndexRaw || undefined });
+    if (!matchesMessageIndex(attrMap)) continue;
+    scan(ev, eventType, attrMap);
   }
 
-  return (await query(true)) ?? (await query(false));
-}
-
-async function getTableColumns(tableName: string): Promise<Set<string>> {
-  const now = Date.now();
-  const cached = tableColumnsCache.get(tableName);
-  if (cached && cached.expiresAt > now) return cached.value;
-
-  const value = knex(tableName)
-    .columnInfo()
-    .then((info) => new Set(Object.keys(info)));
-  tableColumnsCache.set(tableName, { expiresAt: now + TABLE_COLUMNS_TTL_MS, value });
-  return value;
-}
-
-async function existingColumns(tableName: string, columns: string[]): Promise<string[]> {
-  const available = await getTableColumns(tableName);
-  return columns.filter((column) => available.has(column));
-}
-
-async function addTrustRegistryDids(trId: number | null, height: number, dids: Set<string>): Promise<void> {
-  if (!trId) return;
-  const now = Date.now();
-  const cacheKey = `${trId}:${height}`;
-  const cached = trustRegistrySnapshotCache.get(cacheKey);
-  if (cached && cached.expiresAt > now) {
-    const row = await cached.value;
-    addDid(dids, (row as any)?.did);
-    addDid(dids, (row as any)?.controller);
-    return;
+  if (candidates.length === 0 && rule.allowEventTypeFallback === true) {
+    for (const ev of events) {
+      const eventType = toLowerSnake(String(ev?.type ?? ""));
+      if (!eventType) continue;
+      const attrMap = buildAttrMap(ev);
+      const eventMsgIndexRaw = attrMap.msg_index ?? attrMap.message_index ?? attrMap.tx_msg_index ?? "";
+      consideredEvents.push({ type: eventType, msgIndex: eventMsgIndexRaw || undefined });
+      if (!matchesMessageIndex(attrMap)) continue;
+      scan(ev, eventType, attrMap);
+    }
   }
-  const columns = await existingColumns("trust_registry_history", ["did", "controller"]);
-  if (columns.length === 0) return;
 
-  const value = knex("trust_registry_history")
-    .select(columns)
-    .where("tr_id", trId)
-    .where("height", "<=", height)
-    .orderBy("height", "desc")
-    .first();
-  trustRegistrySnapshotCache.set(cacheKey, { expiresAt: now + DID_QUERY_CACHE_TTL_MS, value });
+  const unique = Array.from(new Set(normalizePositiveIntStrings(candidates.map((c) => c.value))));
+  if (unique.length === 1) return { entityId: unique[0] };
+  if (unique.length === 0) {
+    return {
+      reason: "no_candidate",
+      debug: { action: normalizedAction, consideredEvents, idKeys: rule.idKeys, idAttributesFound },
+    };
+  }
 
-  const row = await value;
-  addDid(dids, (row as any)?.did);
-  addDid(dids, (row as any)?.controller);
+  return {
+    reason: "conflict",
+    debug: {
+      txHash: args.txHash,
+      blockHeight: args.blockHeight,
+      action: normalizedAction,
+      module: args.module,
+      candidates,
+      consideredEvents,
+      idAttributesFound,
+      unique,
+    },
+  };
 }
 
-async function findTrustRegistryIdByDid(did: string, height: number): Promise<number | null> {
-  if (!isValidDid(did)) return null;
-  const h = Number(height);
-  if (!Number.isInteger(h) || h <= 0) return null;
-  const row = await knex("trust_registry_history")
-    .select("tr_id")
-    .where("did", did)
-    .where("height", "<=", h)
-    .orderBy("height", "desc")
-    .orderBy("id", "desc")
-    .first();
-  const id = Number((row as any)?.tr_id);
-  return Number.isInteger(id) && id > 0 ? id : null;
-}
-
-async function findCredentialSchemaIdByTrId(trId: number, height: number): Promise<number | null> {
-  const t = Number(trId);
-  const h = Number(height);
-  if (!Number.isInteger(t) || t <= 0) return null;
-  if (!Number.isInteger(h) || h <= 0) return null;
-  const row = await knex("credential_schema_history")
-    .select("credential_schema_id")
-    .where("tr_id", t)
-    .where("height", "<=", h)
-    .orderBy("height", "desc")
-    .orderBy("id", "desc")
-    .first();
-  const id = Number((row as any)?.credential_schema_id);
-  return Number.isInteger(id) && id > 0 ? id : null;
-}
-
-async function findPermissionIdByActors(args: {
-  did?: unknown;
-  grantee?: unknown;
-  createdBy?: unknown;
-  height: number;
-}): Promise<number | null> {
-  const h = Number(args.height);
-  if (!Number.isInteger(h) || h <= 0) return null;
-  const did = typeof args.did === "string" ? args.did : null;
-  const grantee = typeof args.grantee === "string" ? args.grantee : null;
-  const createdBy = typeof args.createdBy === "string" ? args.createdBy : null;
-  if (!isValidDid(did) && !isValidDid(grantee) && !isValidDid(createdBy)) return null;
-
-  const q = knex("permission_history")
-    .select("permission_id")
-    .where("height", "<=", h)
-    .orderBy("height", "desc")
-    .orderBy("id", "desc")
-    .limit(1);
-
-  q.andWhere(function () {
-    if (isValidDid(did)) this.orWhere("did", did);
-    if (isValidDid(grantee)) this.orWhere("grantee", grantee);
-    if (isValidDid(createdBy)) this.orWhere("created_by", createdBy);
+async function debugTxAttributesForMissingEntityId(row: EventRow): Promise<void> {
+  if (process.env.INDEXER_EVENTS_DEBUG_ENTITY_ID !== "1") return;
+  const logger = getLogger();
+  if (!logger?.warn) return;
+  const txResponse = readTxResponse(row);
+  logger.warn(`[IndexerEvents] Missing entity_id for create message; raw tx attributes dumped`, {
+    tx_hash: row.tx_hash,
+    block_height: row.block_height,
+    message_type: row.message_type,
+    message_index: row.message_index,
+    tx_id: row.tx_id,
+    tx_response: txResponse,
   });
+}
 
-  const row = await q.first();
-  const id = Number((row as any)?.permission_id);
-  return Number.isInteger(id) && id > 0 ? id : null;
+async function resolveEntityIdFromTxLocalData(row: EventRow, meta: EventMeta): Promise<string | undefined> {
+  const messageType = String(row.message_type ?? "");
+  const txResponse = readTxResponse(row);
+  const resolved = resolveEntityIdFromTxResponseEvents({
+    txHash: row.tx_hash,
+    blockHeight: row.block_height,
+    messageIndex: row.message_index,
+    txMessageCount: Number(row.tx_message_count ?? 0),
+    action: meta.action,
+    module: meta.module,
+    txResponse,
+  });
+  const entityId = resolved.entityId;
+  if (resolved.reason === "conflict") {
+    getLogger()?.warn?.(`[IndexerEvents] conflicting entity_id candidates; leaving entity_id empty`, resolved.debug);
+  }
+  if (!entityId && resolved.reason) {
+    getLogger()?.warn?.(`[IndexerEvents] missing entity_id from tx_response events`, {
+      block_height: row.block_height,
+      tx_hash: row.tx_hash,
+      message_index: row.message_index,
+      action: meta.action,
+      module: meta.module,
+      entity_type: meta.entityType,
+      reason: resolved.reason,
+      debug: resolved.debug,
+    });
+  }
+  if (
+    !entityId &&
+    [
+      VeranaTrustRegistryMessageTypes.CreateTrustRegistry,
+      VeranaCredentialSchemaMessageTypes.CreateCredentialSchema,
+      VeranaPermissionMessageTypes.CreateRootPermission,
+      VeranaPermissionMessageTypes.StartPermissionVP,
+    ].includes(messageType as any)
+  ) {
+    await debugTxAttributesForMissingEntityId(row);
+  }
+  return entityId;
 }
 
 async function enrichRelatedDids(row: EventRow, meta: EventMeta, dids: Set<string>): Promise<string | undefined> {
-  if (meta.module === "permission") {
-    const permissionId =
-      readNumber(row.content, ["id", "permission_id", "permissionId", "perm_id", "permId"]) ??
-      (await readEventAttributeNumber({
-        txId: row.tx_id,
-        messageIndex: row.message_index,
-        keys: ["permission_id", "permissionId", "perm_id", "permId", "id"],
-      }));
-    const resolvedPermissionId =
-      permissionId ??
-      (row.message_type === VeranaPermissionMessageTypes.SelfCreatePermission ||
-      row.message_type === VeranaPermissionMessageTypes.CreateRootPermission
-        ? await findPermissionIdByActors({
-            did: (row.content as any)?.did,
-            grantee: (row.content as any)?.grantee,
-            createdBy: (row.content as any)?.creator ?? (row.content as any)?.created_by ?? (row.content as any)?.createdBy,
-            height: row.block_height,
-          })
-        : null);
-    if (!resolvedPermissionId) return undefined;
-    const now = Date.now();
-    const permCacheKey = `${resolvedPermissionId}:${row.block_height}`;
-    const cachedPerm = permissionSnapshotCache.get(permCacheKey);
-    const columns = await existingColumns("permission_history", [
-      "permission_id",
-      "did",
-      "grantee",
-      "created_by",
-      "extended_by",
-      "revoked_by",
-      "slashed_by",
-      "repaid_by",
-      "schema_id",
-    ]);
-    const permPromise =
-      cachedPerm && cachedPerm.expiresAt > now
-        ? cachedPerm.value
-        : knex("permission_history")
-          .select(columns)
-          .where("permission_id", resolvedPermissionId)
-          .where("height", "<=", row.block_height)
-          .orderBy("height", "desc")
-          .first();
-    if (!cachedPerm || cachedPerm.expiresAt <= now) {
-      permissionSnapshotCache.set(permCacheKey, { expiresAt: now + DID_QUERY_CACHE_TTL_MS, value: permPromise });
-    }
-    const perm = await permPromise;
-    addDid(dids, (perm as any)?.did);
-    addDid(dids, (perm as any)?.grantee);
-    addDid(dids, (perm as any)?.created_by);
-    addDid(dids, (perm as any)?.extended_by);
-    addDid(dids, (perm as any)?.revoked_by);
-    addDid(dids, (perm as any)?.slashed_by);
-    addDid(dids, (perm as any)?.repaid_by);
-    const schemaId = Number((perm as any)?.schema_id);
-    if (Number.isInteger(schemaId) && schemaId > 0) {
-      const csCacheKey = `${schemaId}:${row.block_height}`;
-      const cachedCs = credentialSchemaSnapshotCache.get(csCacheKey);
-      const csPromise =
-        cachedCs && cachedCs.expiresAt > now
-          ? cachedCs.value
-          : knex("credential_schema_history")
-            .select("tr_id")
-            .where("credential_schema_id", schemaId)
-            .where("height", "<=", row.block_height)
-            .orderBy("height", "desc")
-            .first();
-      if (!cachedCs || cachedCs.expiresAt <= now) {
-        credentialSchemaSnapshotCache.set(csCacheKey, { expiresAt: now + DID_QUERY_CACHE_TTL_MS, value: csPromise });
-      }
-      const cs = await csPromise;
-      await addTrustRegistryDids(Number((cs as any)?.tr_id) || null, row.block_height, dids);
-    }
-    return String(resolvedPermissionId);
-  }
-
-  if (meta.module === "credential-schema") {
-    const schemaId =
-      readNumber(row.content, ["id", "schema_id", "schemaId", "credential_schema_id", "credentialSchemaId"]) ??
-      (await readEventAttributeNumber({
-        txId: row.tx_id,
-        messageIndex: row.message_index,
-        keys: ["credential_schema_id", "credentialSchemaId", "schema_id", "schemaId", "id"],
-      }));
-    const trIdFromContent =
-      readNumber(row.content, ["tr_id", "trId", "trust_registry_id", "trustRegistryId"]) ??
-      (await readEventAttributeNumber({
-        txId: row.tx_id,
-        messageIndex: row.message_index,
-        keys: ["trust_registry_id", "trustRegistryId", "tr_id", "trId"],
-      }));
-    let trId = trIdFromContent;
-    if (schemaId) {
-      const columns = await existingColumns("credential_schema_history", ["credential_schema_id", "tr_id"]);
-      const cs = await knex("credential_schema_history")
-        .select(columns)
-        .where("credential_schema_id", schemaId)
-        .where("height", "<=", row.block_height)
-        .orderBy("height", "desc")
-        .first();
-      trId = Number((cs as any)?.tr_id) || trId;
-    }
-    const resolvedSchemaId =
-      schemaId ??
-      (row.message_type === VeranaCredentialSchemaMessageTypes.CreateCredentialSchema && trId
-        ? await findCredentialSchemaIdByTrId(trId, row.block_height)
-        : null);
-    await addTrustRegistryDids(trId, row.block_height, dids);
-    return resolvedSchemaId ? String(resolvedSchemaId) : undefined;
-  }
-
-  const trId =
-    readNumber(row.content, ["id", "tr_id", "trId", "trust_registry_id", "trustRegistryId"]) ??
-    (await readEventAttributeNumber({
-      txId: row.tx_id,
-      messageIndex: row.message_index,
-      keys: ["trust_registry_id", "trustRegistryId", "tr_id", "trId", "id"],
-    })) ??
-    readNumber(row.content, ["gfv_id", "gfvId", "gfd_id", "gfdId"]) ??
-    (await readEventAttributeNumber({
-      txId: row.tx_id,
-      messageIndex: row.message_index,
-      keys: ["gfv_id", "gfvId", "gfd_id", "gfdId"],
-    }));
-  const resolvedTrId =
-    trId ??
-    (row.message_type === VeranaTrustRegistryMessageTypes.CreateTrustRegistry
-      ? await findTrustRegistryIdByDid(String((row.content as any)?.did ?? ""), row.block_height)
-      : null);
-  await addTrustRegistryDids(resolvedTrId, row.block_height, dids);
-  return resolvedTrId ? String(resolvedTrId) : undefined;
+  return await resolveEntityIdFromTxLocalData(row, meta);
 }
 
 async function toIndexerEvent(row: EventRow): Promise<IndexerTxEvent | null> {
@@ -510,7 +538,6 @@ async function toIndexerEvent(row: EventRow): Promise<IndexerTxEvent | null> {
   addDid(relatedDids, row.sender);
   collectDids(row.content, relatedDids);
   const entityId = await enrichRelatedDids(row, meta, relatedDids);
-
   return {
     type: "transaction-executed",
     module: meta.module,
@@ -582,36 +609,6 @@ function fromStoredRow(row: Record<string, any>): IndexerEventRecord {
   };
 }
 
-async function deriveMissingEntityIdFromHistory(row: Record<string, any>): Promise<string | null> {
-  const messageType = String(row.payload?.message_type ?? row.payload?.messageType ?? row.message_type ?? "");
-  const did = String(row.did ?? "");
-  const height = Number(row.block_height);
-  if (!messageType || !isValidDid(did)) return null;
-  if (!Number.isInteger(height) || height <= 0) return null;
-
-  if (messageType === VeranaTrustRegistryMessageTypes.CreateTrustRegistry) {
-    const trId = await findTrustRegistryIdByDid(did, height);
-    return trId ? String(trId) : null;
-  }
-
-  if (messageType === VeranaCredentialSchemaMessageTypes.CreateCredentialSchema) {
-    const trId = await findTrustRegistryIdByDid(did, height);
-    if (!trId) return null;
-    const schemaId = await findCredentialSchemaIdByTrId(trId, height);
-    return schemaId ? String(schemaId) : null;
-  }
-
-  if (
-    messageType === VeranaPermissionMessageTypes.CreateRootPermission ||
-    messageType === VeranaPermissionMessageTypes.CreatePermission
-  ) {
-    const permId = await findPermissionIdByActors({ did, grantee: did, createdBy: did, height });
-    return permId ? String(permId) : null;
-  }
-
-  return null;
-}
-
 async function buildIndexerTxEvents(args: {
   afterBlockHeight?: number;
   blockHeight?: number;
@@ -630,6 +627,8 @@ async function buildIndexerTxEvents(args: {
       "tm.type as message_type",
       "tm.sender",
       "tm.content",
+      "tx.data as tx_data",
+      knex.raw("(select count(*)::int from transaction_message tm2 where tm2.tx_id = tx.id) as tx_message_count"),
       "tx.height as block_height",
       "tx.hash as tx_hash",
       "tx.index as tx_index",
@@ -660,7 +659,6 @@ export async function persistIndexerEventsForBlock(blockHeight: number): Promise
     offset += pageSize;
   }
   let insertedIds: number[] = [];
-
   if (rows.length > 0) {
     const inserted = await knex("indexer_events")
       .insert(rows)
@@ -732,51 +730,5 @@ export async function listIndexerEvents(args: {
   applyBlockHeightFilter(query, args, "block_height");
 
   const rows = (await query) as Array<Record<string, any>>;
-  const out = rows.map(fromStoredRow);
-
-  const logger = (global as any).logger as { warn?: (...args: any[]) => void } | undefined;
-  let backfillFailures = 0;
-  const backfillFailureIds: number[] = [];
-
-  await Promise.all(
-    out.map(async (ev, i) => {
-      const existing = ev.payload.entity_id;
-      if (existing !== undefined && existing !== null && String(existing).length > 0) return;
-
-      const derived = await deriveMissingEntityIdFromHistory(rows[i]);
-      if (!derived) return;
-
-      ev.payload.entity_id = derived;
-
-      try {
-        const id = Number(rows[i]?.id);
-        if (Number.isInteger(id) && id > 0) {
-          await knex("indexer_events")
-            .where({ id })
-            .update({
-              entity_id: derived,
-              payload: knex.raw(
-                "jsonb_set(COALESCE(payload, '{}'::jsonb), '{entity_id}', to_jsonb(?::text), true)",
-                [derived]
-              ),
-            });
-        }
-      } catch {
-        backfillFailures += 1;
-        const id = Number(rows[i]?.id);
-        if (Number.isInteger(id) && id > 0 && backfillFailureIds.length < 10) {
-          backfillFailureIds.push(id);
-        }
-      }
-    })
-  );
-
-  if (backfillFailures > 0 && logger?.warn) {
-    logger.warn(
-      `[IndexerEvents] entity_id backfill failed for ${backfillFailures} row(s)` +
-      (backfillFailureIds.length ? ` (sample ids: ${backfillFailureIds.join(", ")})` : "")
-    );
-  }
-
-  return out;
+  return rows.map(fromStoredRow);
 }

--- a/src/services/api/indexer_events_query.ts
+++ b/src/services/api/indexer_events_query.ts
@@ -97,6 +97,16 @@ const EVENT_META: Record<string, EventMeta> = {
     action: "ArchiveCredentialSchema",
     entityType: "CredentialSchema",
   },
+  [VeranaPermissionMessageTypes.CreateRootPermission]: {
+    module: "permission",
+    action: "CreateRootPermission",
+    entityType: "Permission",
+  },
+  [VeranaPermissionMessageTypes.SelfCreatePermission]: {
+    module: "permission",
+    action: "CreatePermission",
+    entityType: "Permission",
+  },
   [VeranaPermissionMessageTypes.StartPermissionVP]: {
     module: "permission",
     action: "StartPermissionVP",
@@ -216,6 +226,42 @@ function readNumber(content: unknown, keys: string[]): number | null {
   return null;
 }
 
+async function readEventAttributeNumber(args: {
+  txId: number;
+  messageIndex: number;
+  keys: string[];
+}): Promise<number | null> {
+  const txId = Number(args.txId);
+  const messageIndex = Number(args.messageIndex);
+  if (!Number.isInteger(txId) || txId <= 0) return null;
+  if (!Number.isInteger(messageIndex) || messageIndex < 0) return null;
+  if (!args.keys || args.keys.length === 0) return null;
+
+  async function query(whereMsgIndex: boolean): Promise<number | null> {
+    const q = knex("event_attribute as ea")
+      .innerJoin("event as e", "e.id", "ea.event_id")
+      .select("ea.key", "ea.value")
+      .where("e.tx_id", txId)
+      .whereIn("ea.key", args.keys)
+      .orderBy("ea.index", "asc");
+
+    if (whereMsgIndex) {
+      q.andWhere("e.tx_msg_index", messageIndex);
+    } else {
+      q.whereNull("e.tx_msg_index");
+    }
+
+    const rows = (await q) as Array<{ key?: unknown; value?: unknown }>;
+    for (const row of rows) {
+      const n = Number(row?.value);
+      if (Number.isInteger(n) && n > 0) return n;
+    }
+    return null;
+  }
+
+  return (await query(true)) ?? (await query(false));
+}
+
 async function getTableColumns(tableName: string): Promise<Set<string>> {
   const now = Date.now();
   const cached = tableColumnsCache.get(tableName);
@@ -260,12 +306,91 @@ async function addTrustRegistryDids(trId: number | null, height: number, dids: S
   addDid(dids, (row as any)?.controller);
 }
 
+async function findTrustRegistryIdByDid(did: string, height: number): Promise<number | null> {
+  if (!isValidDid(did)) return null;
+  const h = Number(height);
+  if (!Number.isInteger(h) || h <= 0) return null;
+  const row = await knex("trust_registry_history")
+    .select("tr_id")
+    .where("did", did)
+    .where("height", "<=", h)
+    .orderBy("height", "desc")
+    .orderBy("id", "desc")
+    .first();
+  const id = Number((row as any)?.tr_id);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
+async function findCredentialSchemaIdByTrId(trId: number, height: number): Promise<number | null> {
+  const t = Number(trId);
+  const h = Number(height);
+  if (!Number.isInteger(t) || t <= 0) return null;
+  if (!Number.isInteger(h) || h <= 0) return null;
+  const row = await knex("credential_schema_history")
+    .select("credential_schema_id")
+    .where("tr_id", t)
+    .where("height", "<=", h)
+    .orderBy("height", "desc")
+    .orderBy("id", "desc")
+    .first();
+  const id = Number((row as any)?.credential_schema_id);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
+async function findPermissionIdByActors(args: {
+  did?: unknown;
+  grantee?: unknown;
+  createdBy?: unknown;
+  height: number;
+}): Promise<number | null> {
+  const h = Number(args.height);
+  if (!Number.isInteger(h) || h <= 0) return null;
+  const did = typeof args.did === "string" ? args.did : null;
+  const grantee = typeof args.grantee === "string" ? args.grantee : null;
+  const createdBy = typeof args.createdBy === "string" ? args.createdBy : null;
+  if (!isValidDid(did) && !isValidDid(grantee) && !isValidDid(createdBy)) return null;
+
+  const q = knex("permission_history")
+    .select("permission_id")
+    .where("height", "<=", h)
+    .orderBy("height", "desc")
+    .orderBy("id", "desc")
+    .limit(1);
+
+  q.andWhere(function () {
+    if (isValidDid(did)) this.orWhere("did", did);
+    if (isValidDid(grantee)) this.orWhere("grantee", grantee);
+    if (isValidDid(createdBy)) this.orWhere("created_by", createdBy);
+  });
+
+  const row = await q.first();
+  const id = Number((row as any)?.permission_id);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
 async function enrichRelatedDids(row: EventRow, meta: EventMeta, dids: Set<string>): Promise<string | undefined> {
   if (meta.module === "permission") {
-    const permissionId = readNumber(row.content, ["id", "permission_id", "permissionId", "perm_id", "permId"]);
-    if (!permissionId) return undefined;
+    const permissionId =
+      readNumber(row.content, ["id", "permission_id", "permissionId", "perm_id", "permId"]) ??
+      (await readEventAttributeNumber({
+        txId: row.tx_id,
+        messageIndex: row.message_index,
+        keys: ["permission_id", "permissionId", "perm_id", "permId", "id"],
+      }));
+    const resolvedPermissionId =
+      permissionId ??
+      (row.message_type === VeranaPermissionMessageTypes.SelfCreatePermission ||
+      row.message_type === VeranaPermissionMessageTypes.CreateRootPermission
+        ? await findPermissionIdByActors({
+            did: (row.content as any)?.did,
+            grantee: (row.content as any)?.grantee,
+            createdBy: (row.content as any)?.creator ?? (row.content as any)?.created_by ?? (row.content as any)?.createdBy,
+            height: row.block_height,
+          })
+        : null);
+    if (!resolvedPermissionId) return undefined;
     const now = Date.now();
-    const permCacheKey = `${permissionId}:${row.block_height}`;
+    const permCacheKey = `${resolvedPermissionId}:${row.block_height}`;
     const cachedPerm = permissionSnapshotCache.get(permCacheKey);
     const columns = await existingColumns("permission_history", [
       "permission_id",
@@ -283,7 +408,7 @@ async function enrichRelatedDids(row: EventRow, meta: EventMeta, dids: Set<strin
         ? cachedPerm.value
         : knex("permission_history")
           .select(columns)
-          .where("permission_id", permissionId)
+          .where("permission_id", resolvedPermissionId)
           .where("height", "<=", row.block_height)
           .orderBy("height", "desc")
           .first();
@@ -317,12 +442,24 @@ async function enrichRelatedDids(row: EventRow, meta: EventMeta, dids: Set<strin
       const cs = await csPromise;
       await addTrustRegistryDids(Number((cs as any)?.tr_id) || null, row.block_height, dids);
     }
-    return String(permissionId);
+    return String(resolvedPermissionId);
   }
 
   if (meta.module === "credential-schema") {
-    const schemaId = readNumber(row.content, ["id", "schema_id", "schemaId", "credential_schema_id", "credentialSchemaId"]);
-    const trIdFromContent = readNumber(row.content, ["tr_id", "trId", "trust_registry_id", "trustRegistryId"]);
+    const schemaId =
+      readNumber(row.content, ["id", "schema_id", "schemaId", "credential_schema_id", "credentialSchemaId"]) ??
+      (await readEventAttributeNumber({
+        txId: row.tx_id,
+        messageIndex: row.message_index,
+        keys: ["credential_schema_id", "credentialSchemaId", "schema_id", "schemaId", "id"],
+      }));
+    const trIdFromContent =
+      readNumber(row.content, ["tr_id", "trId", "trust_registry_id", "trustRegistryId"]) ??
+      (await readEventAttributeNumber({
+        txId: row.tx_id,
+        messageIndex: row.message_index,
+        keys: ["trust_registry_id", "trustRegistryId", "tr_id", "trId"],
+      }));
     let trId = trIdFromContent;
     if (schemaId) {
       const columns = await existingColumns("credential_schema_history", ["credential_schema_id", "tr_id"]);
@@ -334,15 +471,35 @@ async function enrichRelatedDids(row: EventRow, meta: EventMeta, dids: Set<strin
         .first();
       trId = Number((cs as any)?.tr_id) || trId;
     }
+    const resolvedSchemaId =
+      schemaId ??
+      (row.message_type === VeranaCredentialSchemaMessageTypes.CreateCredentialSchema && trId
+        ? await findCredentialSchemaIdByTrId(trId, row.block_height)
+        : null);
     await addTrustRegistryDids(trId, row.block_height, dids);
-    return schemaId ? String(schemaId) : undefined;
+    return resolvedSchemaId ? String(resolvedSchemaId) : undefined;
   }
 
   const trId =
     readNumber(row.content, ["id", "tr_id", "trId", "trust_registry_id", "trustRegistryId"]) ??
-    readNumber(row.content, ["gfv_id", "gfvId", "gfd_id", "gfdId"]);
-  await addTrustRegistryDids(trId, row.block_height, dids);
-  return trId ? String(trId) : undefined;
+    (await readEventAttributeNumber({
+      txId: row.tx_id,
+      messageIndex: row.message_index,
+      keys: ["trust_registry_id", "trustRegistryId", "tr_id", "trId", "id"],
+    })) ??
+    readNumber(row.content, ["gfv_id", "gfvId", "gfd_id", "gfdId"]) ??
+    (await readEventAttributeNumber({
+      txId: row.tx_id,
+      messageIndex: row.message_index,
+      keys: ["gfv_id", "gfvId", "gfd_id", "gfdId"],
+    }));
+  const resolvedTrId =
+    trId ??
+    (row.message_type === VeranaTrustRegistryMessageTypes.CreateTrustRegistry
+      ? await findTrustRegistryIdByDid(String((row.content as any)?.did ?? ""), row.block_height)
+      : null);
+  await addTrustRegistryDids(resolvedTrId, row.block_height, dids);
+  return resolvedTrId ? String(resolvedTrId) : undefined;
 }
 
 async function toIndexerEvent(row: EventRow): Promise<IndexerTxEvent | null> {
@@ -425,6 +582,36 @@ function fromStoredRow(row: Record<string, any>): IndexerEventRecord {
   };
 }
 
+async function deriveMissingEntityIdFromHistory(row: Record<string, any>): Promise<string | null> {
+  const messageType = String(row.payload?.message_type ?? row.payload?.messageType ?? row.message_type ?? "");
+  const did = String(row.did ?? "");
+  const height = Number(row.block_height);
+  if (!messageType || !isValidDid(did)) return null;
+  if (!Number.isInteger(height) || height <= 0) return null;
+
+  if (messageType === VeranaTrustRegistryMessageTypes.CreateTrustRegistry) {
+    const trId = await findTrustRegistryIdByDid(did, height);
+    return trId ? String(trId) : null;
+  }
+
+  if (messageType === VeranaCredentialSchemaMessageTypes.CreateCredentialSchema) {
+    const trId = await findTrustRegistryIdByDid(did, height);
+    if (!trId) return null;
+    const schemaId = await findCredentialSchemaIdByTrId(trId, height);
+    return schemaId ? String(schemaId) : null;
+  }
+
+  if (
+    messageType === VeranaPermissionMessageTypes.CreateRootPermission ||
+    messageType === VeranaPermissionMessageTypes.CreatePermission
+  ) {
+    const permId = await findPermissionIdByActors({ did, grantee: did, createdBy: did, height });
+    return permId ? String(permId) : null;
+  }
+
+  return null;
+}
+
 async function buildIndexerTxEvents(args: {
   afterBlockHeight?: number;
   blockHeight?: number;
@@ -478,7 +665,19 @@ export async function persistIndexerEventsForBlock(blockHeight: number): Promise
     const inserted = await knex("indexer_events")
       .insert(rows)
       .onConflict(["did", "tx_hash", "message_index", "event_type"])
-      .ignore()
+      .merge({
+        entity_id: knex.raw("COALESCE(indexer_events.entity_id, EXCLUDED.entity_id)"),
+        entity_type: knex.raw("COALESCE(indexer_events.entity_type, EXCLUDED.entity_type)"),
+        payload: knex.raw(
+          `
+          CASE
+            WHEN (indexer_events.payload->>'entity_id') IS NULL AND EXCLUDED.entity_id IS NOT NULL
+              THEN jsonb_set(COALESCE(indexer_events.payload, '{}'::jsonb), '{entity_id}', to_jsonb(EXCLUDED.entity_id::text), true)
+            ELSE COALESCE(indexer_events.payload, '{}'::jsonb)
+          END
+          `
+        ),
+      })
       .returning("id");
     insertedIds = inserted
       .map((row: number | string | { id?: number | string }) => Number(typeof row === "object" ? row.id : row))
@@ -533,5 +732,51 @@ export async function listIndexerEvents(args: {
   applyBlockHeightFilter(query, args, "block_height");
 
   const rows = (await query) as Array<Record<string, any>>;
-  return rows.map(fromStoredRow);
+  const out = rows.map(fromStoredRow);
+
+  const logger = (global as any).logger as { warn?: (...args: any[]) => void } | undefined;
+  let backfillFailures = 0;
+  const backfillFailureIds: number[] = [];
+
+  await Promise.all(
+    out.map(async (ev, i) => {
+      const existing = ev.payload.entity_id;
+      if (existing !== undefined && existing !== null && String(existing).length > 0) return;
+
+      const derived = await deriveMissingEntityIdFromHistory(rows[i]);
+      if (!derived) return;
+
+      ev.payload.entity_id = derived;
+
+      try {
+        const id = Number(rows[i]?.id);
+        if (Number.isInteger(id) && id > 0) {
+          await knex("indexer_events")
+            .where({ id })
+            .update({
+              entity_id: derived,
+              payload: knex.raw(
+                "jsonb_set(COALESCE(payload, '{}'::jsonb), '{entity_id}', to_jsonb(?::text), true)",
+                [derived]
+              ),
+            });
+        }
+      } catch {
+        backfillFailures += 1;
+        const id = Number(rows[i]?.id);
+        if (Number.isInteger(id) && id > 0 && backfillFailureIds.length < 10) {
+          backfillFailureIds.push(id);
+        }
+      }
+    })
+  );
+
+  if (backfillFailures > 0 && logger?.warn) {
+    logger.warn(
+      `[IndexerEvents] entity_id backfill failed for ${backfillFailures} row(s)` +
+      (backfillFailureIds.length ? ` (sample ids: ${backfillFailureIds.join(", ")})` : "")
+    );
+  }
+
+  return out;
 }

--- a/src/services/api/indexer_events_query.ts
+++ b/src/services/api/indexer_events_query.ts
@@ -226,19 +226,6 @@ function normalizePositiveIntStrings(values: string[]): string[] {
     .map((n) => String(n));
 }
 
-function chooseEntityIdCandidate(args: { candidates: Array<{ value: unknown }>; row: EventRow }): string | undefined {
-  const unique = Array.from(new Set(normalizePositiveIntStrings(args.candidates.map((c) => String(c.value ?? "")))));
-  if (unique.length === 1) return unique[0];
-  if (unique.length > 1) {
-    getLogger()?.warn?.(`[IndexerEvents] conflicting entity_id candidates; leaving entity_id empty`, {
-      txHash: args.row.tx_hash,
-      messageIndex: args.row.message_index,
-      candidates: unique,
-    });
-  }
-  return undefined;
-}
-
 export function resolveEntityIdFromTxResponseEvents(args: {
   txHash: string;
   blockHeight: number;
@@ -338,7 +325,7 @@ export function resolveEntityIdFromTxResponseEvents(args: {
       eventTypes: ["set_permission_vp_to_terminated"],
       idKeys: ["permission_id", "perm_id", "id"],
     },
-    set_permission_vp_to_cancelled_last_request: {
+    cancel_permission_vp_last_request: {
       eventTypes: ["cancel_permission_vp_last_request", "set_permission_vp_to_cancelled"],
       idKeys: ["permission_id", "perm_id", "id"],
     },
@@ -526,7 +513,7 @@ async function resolveEntityIdFromTxLocalData(row: EventRow, meta: EventMeta): P
   return entityId;
 }
 
-async function enrichRelatedDids(row: EventRow, meta: EventMeta, dids: Set<string>): Promise<string | undefined> {
+async function resolveEntityId(row: EventRow, meta: EventMeta): Promise<string | undefined> {
   return await resolveEntityIdFromTxLocalData(row, meta);
 }
 
@@ -537,7 +524,7 @@ async function toIndexerEvent(row: EventRow): Promise<IndexerTxEvent | null> {
   const relatedDids = new Set<string>();
   addDid(relatedDids, row.sender);
   collectDids(row.content, relatedDids);
-  const entityId = await enrichRelatedDids(row, meta, relatedDids);
+  const entityId = await resolveEntityId(row, meta);
   return {
     type: "transaction-executed",
     module: meta.module,
@@ -628,7 +615,7 @@ async function buildIndexerTxEvents(args: {
       "tm.sender",
       "tm.content",
       "tx.data as tx_data",
-      knex.raw("(select count(*)::int from transaction_message tm2 where tm2.tx_id = tx.id) as tx_message_count"),
+      knex.raw("count(*) over (partition by tx.id)::int as tx_message_count"),
       "tx.height as block_height",
       "tx.hash as tx_hash",
       "tx.index as tx_index",
@@ -676,6 +663,9 @@ export async function persistIndexerEventsForBlock(blockHeight: number): Promise
           `
         ),
       })
+      .where((builder) =>
+        builder.whereNull("indexer_events.entity_id").orWhereRaw("(indexer_events.payload->>'entity_id') IS NULL")
+      )
       .returning("id");
     insertedIds = inserted
       .map((row: number | string | { id?: number | string }) => Number(typeof row === "object" ? row.id : row))

--- a/src/services/crawl-tr/tr_processor.service.ts
+++ b/src/services/crawl-tr/tr_processor.service.ts
@@ -152,6 +152,13 @@ export default class TrustRegistryMessageProcessorService extends BullableServic
 
       let processed = false;
       if (useHeightSyncTR) {
+        if (
+          !normalizedTrId &&
+          (processedTR.type === VeranaTrustRegistryMessageTypes.CreateTrustRegistry)
+        ) {
+          await this.processCreateTR(processedTR);
+          processed = true;
+        }
         if (normalizedTrId && Number.isFinite(Number(message.height))) {
           const dedupeKey = `${Number(message.height)}::${normalizedTrId}`;
           if (seenHeightSyncKeys.has(dedupeKey)) {

--- a/test/unit/services/api/indexer_events_query.spec.ts
+++ b/test/unit/services/api/indexer_events_query.spec.ts
@@ -1,5 +1,5 @@
 import knex from "../../../../src/common/utils/db_connection";
-import { VeranaPermissionMessageTypes } from "../../../../src/common/verana-message-types";
+import { VeranaCredentialSchemaMessageTypes, VeranaPermissionMessageTypes, VeranaTrustRegistryMessageTypes } from "../../../../src/common/verana-message-types";
 import { up as createIndexerEventsTable } from "../../../../src/migrations/20260420000000_create_indexer_events";
 import { listIndexerEvents, persistIndexerEventsForBlock } from "../../../../src/services/api/indexer_events_query";
 
@@ -34,6 +34,8 @@ describe("indexer_events_query", () => {
     hash: string;
     sender?: string;
     content?: Record<string, unknown>;
+    messageType?: string;
+    txResponse?: any;
   }): Promise<void> {
     txHashes.push(args.hash);
     const txId = nextId++;
@@ -50,7 +52,7 @@ describe("indexer_events_query", () => {
         gas_limit: 1,
         fee: {},
         timestamp: new Date("2025-01-15T10:30:00Z"),
-        data: {},
+        data: args.txResponse ? { tx_response: args.txResponse } : {},
         index: args.txIndex,
       })
       .returning("id");
@@ -59,7 +61,7 @@ describe("indexer_events_query", () => {
       id: messageId,
       tx_id: typeof tx === "object" ? tx.id : tx,
       index: args.messageIndex,
-      type: VeranaPermissionMessageTypes.StartPermissionVP,
+      type: args.messageType ?? VeranaPermissionMessageTypes.StartPermissionVP,
       sender: args.sender ?? did,
       content: args.content ?? { id: 42, applicant: did },
     });
@@ -69,6 +71,10 @@ describe("indexer_events_query", () => {
     if (txHashes.length > 0) {
       await knex("indexer_events").whereIn("tx_hash", txHashes).delete();
       const txIds = await knex("transaction").whereIn("hash", txHashes).pluck("id");
+      if (txIds.length > 0) {
+        await knex("event_attribute").whereIn("tx_id", txIds).delete();
+        await knex("event").whereIn("tx_id", txIds).delete();
+      }
       if (txIds.length > 0) await knex("transaction_message").whereIn("tx_id", txIds).delete();
       await knex("transaction").whereIn("hash", txHashes).delete();
       txHashes.length = 0;
@@ -130,8 +136,458 @@ describe("indexer_events_query", () => {
     const rows = await knex("indexer_events").where("tx_hash", `tx-${runId}-multi-did`).orderBy("did", "asc");
 
     expect(firstPersist.map((event) => event.did).sort()).toEqual([did, otherDid]);
-    expect(secondPersist).toEqual([]);
+    expect(secondPersist.map((event) => event.did).sort()).toEqual([did, otherDid]);
     expect(rows).toHaveLength(2);
     expect(rows.map((row) => row.did)).toEqual([did, otherDid]);
+  });
+
+  it("StartPermissionVP returns entity_id from direct content.id", async () => {
+    await insertBlock(baseHeight + 30);
+    await insertTxMessage({
+      height: baseHeight + 30,
+      txIndex: 0,
+      messageIndex: 0,
+      hash: `tx-${runId}-start-direct-id`,
+      content: { id: 101, did }, 
+      messageType: VeranaPermissionMessageTypes.StartPermissionVP,
+      txResponse: {
+        events: [
+          { type: "start_permission_vp", attributes: [{ key: "msg_index", value: "0" }, { key: "permission_id", value: "202" }] },
+        ],
+      },
+    });
+
+    await persistIndexerEventsForBlock(baseHeight + 30);
+    const events = await listIndexerEvents({ did, blockHeight: baseHeight + 30, limit: 10 });
+    expect(events).toHaveLength(1);
+    expect(events[0].payload.entity_id).toBe("202");
+  });
+
+  it("StartPermissionVP leaves entity_id empty when tx-local data has none", async () => {
+    await insertBlock(baseHeight + 40);
+    await insertTxMessage({
+      height: baseHeight + 40,
+      txIndex: 0,
+      messageIndex: 0,
+      hash: `tx-${runId}-start-no-id`,
+      content: { did, validator_perm_id: 555 },
+      messageType: VeranaPermissionMessageTypes.StartPermissionVP,
+    });
+
+    await persistIndexerEventsForBlock(baseHeight + 40);
+    const events = await listIndexerEvents({ did, blockHeight: baseHeight + 40, limit: 10 });
+    expect(events).toHaveLength(1);
+    expect(events[0].payload.entity_id).toBeUndefined();
+  });
+
+  it("StartPermissionVP does not use validator_perm_id as entity_id", async () => {
+    await insertBlock(baseHeight + 41);
+    await insertTxMessage({
+      height: baseHeight + 41,
+      txIndex: 0,
+      messageIndex: 0,
+      hash: `tx-${runId}-start-vp-validator-only`,
+      content: { did, validator_perm_id: 555 }, // ignored
+      messageType: VeranaPermissionMessageTypes.StartPermissionVP,
+      txResponse: {
+        events: [
+          { type: "start_permission_vp", attributes: [{ key: "msg_index", value: "0" }, { key: "validator_perm_id", value: "555" }] },
+        ],
+      },
+    });
+
+    await persistIndexerEventsForBlock(baseHeight + 41);
+    const events = await listIndexerEvents({ did, blockHeight: baseHeight + 41, limit: 10 });
+    expect(events).toHaveLength(1);
+    expect(events[0].payload.entity_id).toBeUndefined();
+  });
+
+  it("Missing domain event leaves entity_id empty (even if content has id)", async () => {
+    await insertBlock(baseHeight + 42);
+    await insertTxMessage({
+      height: baseHeight + 42,
+      txIndex: 0,
+      messageIndex: 0,
+      hash: `tx-${runId}-missing-domain-event`,
+      content: { did, id: 999 },
+      messageType: VeranaTrustRegistryMessageTypes.CreateTrustRegistry,
+      txResponse: {
+        events: [
+          { type: "message", attributes: [{ key: "msg_index", value: "0" }, { key: "trust_registry_id", value: "123" }] },
+        ],
+      },
+    });
+
+    await persistIndexerEventsForBlock(baseHeight + 42);
+    const events = await listIndexerEvents({ did, blockHeight: baseHeight + 42, limit: 10 });
+    expect(events).toHaveLength(1);
+    expect(events[0].payload.entity_id).toBeUndefined();
+  });
+
+  it("CreateTrustRegistry resolves entity_id from scoped tx event attributes", async () => {
+    await insertBlock(baseHeight + 50);
+    const hash = `tx-${runId}-create-tr-scoped`;
+    await insertTxMessage({
+      height: baseHeight + 50,
+      txIndex: 0,
+      messageIndex: 0,
+      hash,
+      content: { did, id: 999 }, 
+      messageType: VeranaTrustRegistryMessageTypes.CreateTrustRegistry,
+      txResponse: {
+        events: [
+          { type: "create_trust_registry", attributes: [{ key: "msg_index", value: "0" }, { key: "trust_registry_id", value: "123" }] },
+        ],
+      },
+    });
+
+    await persistIndexerEventsForBlock(baseHeight + 50);
+    const events = await listIndexerEvents({ did, blockHeight: baseHeight + 50, limit: 10 });
+    expect(events[0].payload.entity_id).toBe("123");
+  });
+
+  it("CreateCredentialSchema resolves entity_id from scoped tx event attributes", async () => {
+    await insertBlock(baseHeight + 60);
+    const hash = `tx-${runId}-create-cs-scoped`;
+    await insertTxMessage({
+      height: baseHeight + 60,
+      txIndex: 0,
+      messageIndex: 0,
+      hash,
+      content: { did, id: 999 },
+      messageType: VeranaCredentialSchemaMessageTypes.CreateCredentialSchema,
+      txResponse: {
+        events: [
+          { type: "create_credential_schema", attributes: [{ key: "msg_index", value: "0" }, { key: "credential_schema_id", value: "777" }] },
+        ],
+      },
+    });
+
+    await persistIndexerEventsForBlock(baseHeight + 60);
+    const events = await listIndexerEvents({ did, blockHeight: baseHeight + 60, limit: 10 });
+    expect(events[0].payload.entity_id).toBe("777");
+  });
+
+  it("CreateRootPermission resolves entity_id from scoped tx event attributes", async () => {
+    await insertBlock(baseHeight + 70);
+    const hash = `tx-${runId}-create-root-perm-scoped`;
+    await insertTxMessage({
+      height: baseHeight + 70,
+      txIndex: 0,
+      messageIndex: 0,
+      hash,
+      content: { did, id: 999 },
+      messageType: VeranaPermissionMessageTypes.CreateRootPermission,
+      txResponse: {
+        events: [
+          { type: "create_root_permission", attributes: [{ key: "msg_index", value: "0" }, { key: "root_permission_id", value: "888" }] },
+        ],
+      },
+    });
+
+    await persistIndexerEventsForBlock(baseHeight + 70);
+    const events = await listIndexerEvents({ did, blockHeight: baseHeight + 70, limit: 10 });
+    expect(events[0].payload.entity_id).toBe("888");
+  });
+
+  it("UpdateTrustRegistry resolves entity_id from update_trust_registry.trust_registry_id", async () => {
+    await insertBlock(baseHeight + 80);
+    await insertTxMessage({
+      height: baseHeight + 80,
+      txIndex: 0,
+      messageIndex: 0,
+      hash: `tx-${runId}-update-tr`,
+      content: { did, id: 999 },
+      messageType: VeranaTrustRegistryMessageTypes.UpdateTrustRegistry,
+      txResponse: {
+        events: [
+          { type: "update_trust_registry", attributes: [{ key: "msg_index", value: "0" }, { key: "trust_registry_id", value: "321" }] },
+        ],
+      },
+    });
+    await persistIndexerEventsForBlock(baseHeight + 80);
+    const events = await listIndexerEvents({ did, blockHeight: baseHeight + 80, limit: 10 });
+    expect(events[0].payload.entity_id).toBe("321");
+  });
+
+  it("ArchiveTrustRegistry resolves entity_id from archive_trust_registry.trust_registry_id", async () => {
+    await insertBlock(baseHeight + 81);
+    await insertTxMessage({
+      height: baseHeight + 81,
+      txIndex: 0,
+      messageIndex: 0,
+      hash: `tx-${runId}-archive-tr`,
+      content: { did, id: 999 },
+      messageType: VeranaTrustRegistryMessageTypes.ArchiveTrustRegistry,
+      txResponse: {
+        events: [
+          { type: "archive_trust_registry", attributes: [{ key: "msg_index", value: "0" }, { key: "trust_registry_id", value: "322" }] },
+        ],
+      },
+    });
+    await persistIndexerEventsForBlock(baseHeight + 81);
+    const events = await listIndexerEvents({ did, blockHeight: baseHeight + 81, limit: 10 });
+    expect(events[0].payload.entity_id).toBe("322");
+  });
+
+  it("UpdateCredentialSchema resolves entity_id from update_credential_schema.credential_schema_id", async () => {
+    await insertBlock(baseHeight + 82);
+    await insertTxMessage({
+      height: baseHeight + 82,
+      txIndex: 0,
+      messageIndex: 0,
+      hash: `tx-${runId}-update-cs`,
+      content: { did, id: 999 },
+      messageType: VeranaCredentialSchemaMessageTypes.UpdateCredentialSchema,
+      txResponse: {
+        events: [
+          { type: "update_credential_schema", attributes: [{ key: "msg_index", value: "0" }, { key: "credential_schema_id", value: "778" }] },
+        ],
+      },
+    });
+    await persistIndexerEventsForBlock(baseHeight + 82);
+    const events = await listIndexerEvents({ did, blockHeight: baseHeight + 82, limit: 10 });
+    expect(events[0].payload.entity_id).toBe("778");
+  });
+
+  it("ArchiveCredentialSchema resolves entity_id from archive_credential_schema.credential_schema_id", async () => {
+    await insertBlock(baseHeight + 83);
+    await insertTxMessage({
+      height: baseHeight + 83,
+      txIndex: 0,
+      messageIndex: 0,
+      hash: `tx-${runId}-archive-cs`,
+      content: { did, id: 999 },
+      messageType: VeranaCredentialSchemaMessageTypes.ArchiveCredentialSchema,
+      txResponse: {
+        events: [
+          { type: "archive_credential_schema", attributes: [{ key: "msg_index", value: "0" }, { key: "credential_schema_id", value: "779" }] },
+        ],
+      },
+    });
+    await persistIndexerEventsForBlock(baseHeight + 83);
+    const events = await listIndexerEvents({ did, blockHeight: baseHeight + 83, limit: 10 });
+    expect(events[0].payload.entity_id).toBe("779");
+  });
+
+  it("SetPermissionVPToValidated resolves entity_id from set_permission_vp_to_validated.permission_id", async () => {
+    await insertBlock(baseHeight + 84);
+    await insertTxMessage({
+      height: baseHeight + 84,
+      txIndex: 0,
+      messageIndex: 0,
+      hash: `tx-${runId}-perm-validated`,
+      content: { did, id: 999 },
+      messageType: VeranaPermissionMessageTypes.SetPermissionVPToValidated,
+      txResponse: {
+        events: [
+          { type: "set_permission_vp_to_validated", attributes: [{ key: "msg_index", value: "0" }, { key: "permission_id", value: "900" }] },
+        ],
+      },
+    });
+    await persistIndexerEventsForBlock(baseHeight + 84);
+    const events = await listIndexerEvents({ did, blockHeight: baseHeight + 84, limit: 10 });
+    expect(events[0].payload.entity_id).toBe("900");
+  });
+
+  it("self_create_permission uses permission_id/self_permission_id/perm_id/id preference set (same emitted id ok)", async () => {
+    await insertBlock(baseHeight + 85);
+    await insertTxMessage({
+      height: baseHeight + 85,
+      txIndex: 0,
+      messageIndex: 0,
+      hash: `tx-${runId}-self-create-perm`,
+      content: { did, id: 999 },
+      messageType: VeranaPermissionMessageTypes.SelfCreatePermission,
+      txResponse: {
+        events: [
+          {
+            type: "self_create_permission",
+            attributes: [
+              { key: "msg_index", value: "0" },
+              { key: "self_permission_id", value: "901" },
+              { key: "permission_id", value: "901" },
+            ],
+          },
+        ],
+      },
+    });
+    await persistIndexerEventsForBlock(baseHeight + 85);
+    const events = await listIndexerEvents({ did, blockHeight: baseHeight + 85, limit: 10 });
+    expect(events[0].payload.entity_id).toBe("901");
+  });
+
+  it("SelfCreatePermission resolves from self_create_permission.permission_id", async () => {
+    await insertBlock(baseHeight + 90);
+    await insertTxMessage({
+      height: baseHeight + 90,
+      txIndex: 0,
+      messageIndex: 0,
+      hash: `tx-${runId}-self-create-perm-permission-id`,
+      content: { did, id: 999 },
+      messageType: VeranaPermissionMessageTypes.SelfCreatePermission,
+      txResponse: {
+        events: [
+          {
+            type: "self_create_permission",
+            attributes: [{ key: "msg_index", value: "0" }, { key: "permission_id", value: "910" }],
+          },
+        ],
+      },
+    });
+    await persistIndexerEventsForBlock(baseHeight + 90);
+    const events = await listIndexerEvents({ did, blockHeight: baseHeight + 90, limit: 10 });
+    expect(events[0].payload.entity_id).toBe("910");
+  });
+
+  it("SelfCreatePermission resolves from self_create_permission.self_permission_id", async () => {
+    await insertBlock(baseHeight + 91);
+    await insertTxMessage({
+      height: baseHeight + 91,
+      txIndex: 0,
+      messageIndex: 0,
+      hash: `tx-${runId}-self-create-perm-self-permission-id`,
+      content: { did, id: 999 },
+      messageType: VeranaPermissionMessageTypes.SelfCreatePermission,
+      txResponse: {
+        events: [
+          {
+            type: "self_create_permission",
+            attributes: [{ key: "msg_index", value: "0" }, { key: "self_permission_id", value: "911" }],
+          },
+        ],
+      },
+    });
+    await persistIndexerEventsForBlock(baseHeight + 91);
+    const events = await listIndexerEvents({ did, blockHeight: baseHeight + 91, limit: 10 });
+    expect(events[0].payload.entity_id).toBe("911");
+  });
+
+  it("SelfCreatePermission resolves from self_create_permission.perm_id", async () => {
+    await insertBlock(baseHeight + 92);
+    await insertTxMessage({
+      height: baseHeight + 92,
+      txIndex: 0,
+      messageIndex: 0,
+      hash: `tx-${runId}-self-create-perm-perm-id`,
+      content: { did, id: 999 },
+      messageType: VeranaPermissionMessageTypes.SelfCreatePermission,
+      txResponse: {
+        events: [
+          {
+            type: "self_create_permission",
+            attributes: [{ key: "msg_index", value: "0" }, { key: "perm_id", value: "912" }],
+          },
+        ],
+      },
+    });
+    await persistIndexerEventsForBlock(baseHeight + 92);
+    const events = await listIndexerEvents({ did, blockHeight: baseHeight + 92, limit: 10 });
+    expect(events[0].payload.entity_id).toBe("912");
+  });
+
+  it("SelfCreatePermission resolves from self_create_permission.id", async () => {
+    await insertBlock(baseHeight + 93);
+    await insertTxMessage({
+      height: baseHeight + 93,
+      txIndex: 0,
+      messageIndex: 0,
+      hash: `tx-${runId}-self-create-perm-id`,
+      content: { did, id: 999 },
+      messageType: VeranaPermissionMessageTypes.SelfCreatePermission,
+      txResponse: {
+        events: [
+          {
+            type: "self_create_permission",
+            attributes: [{ key: "msg_index", value: "0" }, { key: "id", value: "913" }],
+          },
+        ],
+      },
+    });
+    await persistIndexerEventsForBlock(baseHeight + 93);
+    const events = await listIndexerEvents({ did, blockHeight: baseHeight + 93, limit: 10 });
+    expect(events[0].payload.entity_id).toBe("913");
+  });
+
+  it("SelfCreatePermission resolves when event name differs but same msg_index has one allowed ID key", async () => {
+    await insertBlock(baseHeight + 94);
+    await insertTxMessage({
+      height: baseHeight + 94,
+      txIndex: 0,
+      messageIndex: 0,
+      hash: `tx-${runId}-self-create-perm-alt-event`,
+      content: { did, id: 999 },
+      messageType: VeranaPermissionMessageTypes.SelfCreatePermission,
+      txResponse: {
+        events: [
+          // not in preferred eventTypes, but same msg_index and has allowed id key
+          {
+            type: "permission_created",
+            attributes: [{ key: "msg_index", value: "0" }, { key: "permission_id", value: "914" }],
+          },
+        ],
+      },
+    });
+    await persistIndexerEventsForBlock(baseHeight + 94);
+    const events = await listIndexerEvents({ did, blockHeight: baseHeight + 94, limit: 10 });
+    expect(events[0].payload.entity_id).toBe("914");
+  });
+
+  it("SelfCreatePermission does not use schema_id / trust_registry_id / tr_id / validator_perm_id", async () => {
+    await insertBlock(baseHeight + 95);
+    await insertTxMessage({
+      height: baseHeight + 95,
+      txIndex: 0,
+      messageIndex: 0,
+      hash: `tx-${runId}-self-create-perm-unrelated-ids`,
+      content: { did, id: 999 },
+      messageType: VeranaPermissionMessageTypes.SelfCreatePermission,
+      txResponse: {
+        events: [
+          {
+            type: "self_create_permission",
+            attributes: [
+              { key: "msg_index", value: "0" },
+              { key: "schema_id", value: "1" },
+              { key: "trust_registry_id", value: "2" },
+              { key: "tr_id", value: "3" },
+              { key: "validator_perm_id", value: "4" },
+            ],
+          },
+        ],
+      },
+    });
+    await persistIndexerEventsForBlock(baseHeight + 95);
+    const events = await listIndexerEvents({ did, blockHeight: baseHeight + 95, limit: 10 });
+    expect(events[0].payload.entity_id).toBeUndefined();
+  });
+
+  it("conflicting emitted IDs warns and leaves entity_id empty", async () => {
+    (global as any).logger = { warn: jest.fn() };
+    await insertBlock(baseHeight + 86);
+    await insertTxMessage({
+      height: baseHeight + 86,
+      txIndex: 0,
+      messageIndex: 0,
+      hash: `tx-${runId}-conflict`,
+      content: { did, id: 999 },
+      messageType: VeranaPermissionMessageTypes.SelfCreatePermission,
+      txResponse: {
+        events: [
+          {
+            type: "self_create_permission",
+            attributes: [
+              { key: "msg_index", value: "0" },
+              { key: "permission_id", value: "902" },
+              { key: "self_permission_id", value: "903" },
+            ],
+          },
+        ],
+      },
+    });
+    await persistIndexerEventsForBlock(baseHeight + 86);
+    const events = await listIndexerEvents({ did, blockHeight: baseHeight + 86, limit: 10 });
+    expect(events[0].payload.entity_id).toBeUndefined();
+    expect((global as any).logger.warn).toHaveBeenCalled();
   });
 });

--- a/test/unit/services/api/indexer_events_query.spec.ts
+++ b/test/unit/services/api/indexer_events_query.spec.ts
@@ -563,31 +563,36 @@ describe("indexer_events_query", () => {
   });
 
   it("conflicting emitted IDs warns and leaves entity_id empty", async () => {
-    (global as any).logger = { warn: jest.fn() };
-    await insertBlock(baseHeight + 86);
-    await insertTxMessage({
-      height: baseHeight + 86,
-      txIndex: 0,
-      messageIndex: 0,
-      hash: `tx-${runId}-conflict`,
-      content: { did, id: 999 },
-      messageType: VeranaPermissionMessageTypes.SelfCreatePermission,
-      txResponse: {
-        events: [
-          {
-            type: "self_create_permission",
-            attributes: [
-              { key: "msg_index", value: "0" },
-              { key: "permission_id", value: "902" },
-              { key: "self_permission_id", value: "903" },
-            ],
-          },
-        ],
-      },
-    });
-    await persistIndexerEventsForBlock(baseHeight + 86);
-    const events = await listIndexerEvents({ did, blockHeight: baseHeight + 86, limit: 10 });
-    expect(events[0].payload.entity_id).toBeUndefined();
-    expect((global as any).logger.warn).toHaveBeenCalled();
+    const prevLogger = (global as any).logger;
+    try {
+      (global as any).logger = { warn: jest.fn() };
+      await insertBlock(baseHeight + 86);
+      await insertTxMessage({
+        height: baseHeight + 86,
+        txIndex: 0,
+        messageIndex: 0,
+        hash: `tx-${runId}-conflict`,
+        content: { did, id: 999 },
+        messageType: VeranaPermissionMessageTypes.SelfCreatePermission,
+        txResponse: {
+          events: [
+            {
+              type: "self_create_permission",
+              attributes: [
+                { key: "msg_index", value: "0" },
+                { key: "permission_id", value: "902" },
+                { key: "self_permission_id", value: "903" },
+              ],
+            },
+          ],
+        },
+      });
+      await persistIndexerEventsForBlock(baseHeight + 86);
+      const events = await listIndexerEvents({ did, blockHeight: baseHeight + 86, limit: 10 });
+      expect(events[0].payload.entity_id).toBeUndefined();
+      expect((global as any).logger.warn).toHaveBeenCalled();
+    } finally {
+      (global as any).logger = prevLogger;
+    }
   });
 });


### PR DESCRIPTION
This PR fixes the missing `entity_id` issue in indexer transaction events.

Previously, some transaction events were created without `entity_id`, which made it difficult to reliably resolve the related Trust Registry, Credential Schema, or Permission from the event data.

## What Changed

- Added `entity_id` extraction from `tx_response.events[].attributes[]`.
- Avoided using message content/payload as the source of truth for `entity_id`.
- Added proper event-to-ID mapping for:
  - Trust Registry events
  - Credential Schema events
  - Permission events
  - `SelfCreatePermission`
  - Permission VP lifecycle events
- Added fallback support for generic `id` where chain events emit non-standard ID keys.
- Prevented unrelated IDs such as `schema_id`, `trust_registry_id`, `tr_id`, and `validator_perm_id` from being used as Permission `entity_id`.
- Added conflict handling to avoid storing incorrect IDs when multiple conflicting candidates are found.
- Updated insert conflict merge to safely fill missing `entity_id` and `payload.entity_id`.
- Added unit tests for supported event mappings and edge cases.

## Why

Including `entity_id` directly in `indexer_events` allows consumers to reliably query and resolve the related entity without extra lookups or unsafe guessing.

## Testing

Added/updated unit tests covering:

- Create/Update/Archive Trust Registry events
- Create/Update/Archive Credential Schema events
- Create Root Permission
- Start Permission VP
- Self Create Permission
- Permission lifecycle events
- Generic `id` fallback
- Ignoring unrelated IDs
- Conflicting ID candidate handling