### PR TITLE
fix: return null when no next indexer change exists

### DIFF
--- a/src/services/manager/indexer_meta.service.ts
+++ b/src/services/manager/indexer_meta.service.ts
@@ -121,6 +121,14 @@ export default class IndexerMetaService extends BaseService {
   }
 
   private async getNextChangeAt(blockHeight: number): Promise<number | null> {
+    const checkpoint = await knex("block_checkpoint")
+      .select("height")
+      .where("job_name", BULL_JOB_NAME.HANDLE_TRANSACTION)
+      .first();
+    const maxHeight = Number(checkpoint?.height);
+    if (!Number.isFinite(maxHeight) || maxHeight <= 0) return null;
+    if (!Number.isFinite(blockHeight) || blockHeight >= maxHeight) return null;
+
     // Query each history table with index-friendly pattern: WHERE height > ? ORDER BY height ASC LIMIT 1.
     const tables = [
       "trust_registry_history",
@@ -139,6 +147,7 @@ export default class IndexerMetaService extends BaseService {
           const row = await knex(tableName)
             .select("height")
             .where("height", ">", blockHeight)
+            .andWhere("height", "<=", maxHeight)
             .orderBy("height", "asc")
             .limit(1)
             .first();

--- a/test/unit/services/manager/indexer_meta.spec.ts
+++ b/test/unit/services/manager/indexer_meta.spec.ts
@@ -144,5 +144,21 @@ describe("IndexerMetaService next_change_at", () => {
       tableHeights.block_checkpoint = prevCheckpoint;
     }
   });
+
+  it("returns null when checkpoint exists but no next change is within (block_height, checkpoint]", async () => {
+    const next = await service.getNextChangeAt(150);
+    expect(next).toBeNull();
+  });
+
+  it("returns null when no checkpoint row exists", async () => {
+    const prevCheckpoint = tableHeights.block_checkpoint;
+    try {
+      tableHeights.block_checkpoint = [];
+      const next = await service.getNextChangeAt(105);
+      expect(next).toBeNull();
+    } finally {
+      tableHeights.block_checkpoint = prevCheckpoint;
+    }
+  });
 });
 

--- a/test/unit/services/manager/indexer_meta.spec.ts
+++ b/test/unit/services/manager/indexer_meta.spec.ts
@@ -1,12 +1,17 @@
 import { ServiceBroker } from "moleculer";
 import IndexerMetaService from "../../../../src/services/manager/indexer_meta.service";
 import knex from "../../../../src/common/utils/db_connection";
+import { BULL_JOB_NAME } from "../../../../src/common/constant";
 
 type QueryState = {
   table: string;
   whereCol?: string;
   whereOp?: string;
   whereVal?: number;
+  whereStrVal?: string;
+  andWhereCol?: string;
+  andWhereOp?: string;
+  andWhereVal?: number;
   orderCol?: string;
   orderDir?: string;
   limitVal?: number;
@@ -21,6 +26,7 @@ const tableHeights: Record<string, number[]> = {
   permission_session_history: [],
   trust_deposit_history: [],
   module_params_history: [],
+  block_checkpoint: [200],
 };
 
 const queryStates: QueryState[] = [];
@@ -32,10 +38,21 @@ jest.mock("../../../../src/common/utils/db_connection", () => {
 
     const qb: any = {};
     qb.select = jest.fn(() => qb);
-    qb.where = jest.fn((col: string, op: string, val: number) => {
+    qb.where = jest.fn((col: string, opOrVal: any, maybeVal?: any) => {
       state.whereCol = col;
-      state.whereOp = op;
-      state.whereVal = Number(val);
+      if (maybeVal === undefined) {
+        state.whereOp = "=";
+        state.whereStrVal = String(opOrVal);
+      } else {
+        state.whereOp = String(opOrVal);
+        state.whereVal = Number(maybeVal);
+      }
+      return qb;
+    });
+    qb.andWhere = jest.fn((col: string, op: string, val: number) => {
+      state.andWhereCol = col;
+      state.andWhereOp = op;
+      state.andWhereVal = Number(val);
       return qb;
     });
     qb.orderBy = jest.fn((col: string, dir: string) => {
@@ -49,9 +66,21 @@ jest.mock("../../../../src/common/utils/db_connection", () => {
     });
     qb.first = jest.fn(async () => {
       const rows = tableHeights[tableName] ?? [];
+      if (tableName === "block_checkpoint") {
+        const matchesHandleTransactionCheckpoint =
+          state.whereCol === "job_name" &&
+          state.whereOp === "=" &&
+          state.whereStrVal === BULL_JOB_NAME.HANDLE_TRANSACTION;
+        if (!matchesHandleTransactionCheckpoint) {
+          return undefined;
+        }
+        const first = rows[0];
+        return first !== undefined ? { height: first } : undefined;
+      }
       const threshold = state.whereVal ?? Number.NEGATIVE_INFINITY;
+      const max = state.andWhereVal ?? Number.POSITIVE_INFINITY;
       const next = rows
-        .filter((h) => h > threshold)
+        .filter((h) => h > threshold && h <= max)
         .sort((a, b) => a - b)[0];
       return next !== undefined ? { height: next } : undefined;
     });
@@ -85,9 +114,13 @@ describe("IndexerMetaService next_change_at", () => {
 
     expect(queryStates.length).toBeGreaterThan(0);
     for (const q of queryStates) {
+      if (q.table === "block_checkpoint") continue;
       expect(q.whereCol).toBe("height");
       expect(q.whereOp).toBe(">");
       expect(q.whereVal).toBe(105);
+      expect(q.andWhereCol).toBe("height");
+      expect(q.andWhereOp).toBe("<=");
+      expect(q.andWhereVal).toBe(200);
       expect((q.orderDir || "").toLowerCase()).toBe("asc");
       expect(q.limitVal).toBe(1);
     }
@@ -96,6 +129,20 @@ describe("IndexerMetaService next_change_at", () => {
   it("returns null when no higher height exists", async () => {
     const next = await service.getNextChangeAt(1000);
     expect(next).toBeNull();
+  });
+
+  it("returns null when the next height is above current indexed checkpoint (reindex safety)", async () => {
+    const prevTrustRegistry = tableHeights.trust_registry_history;
+    const prevCheckpoint = tableHeights.block_checkpoint;
+    try {
+      tableHeights.trust_registry_history = [9999];
+      tableHeights.block_checkpoint = [200];
+      const next = await service.getNextChangeAt(105);
+      expect(next).toBeNull();
+    } finally {
+      tableHeights.trust_registry_history = prevTrustRegistry;
+      tableHeights.block_checkpoint = prevCheckpoint;
+    }
   });
 });
 


### PR DESCRIPTION
This PR fixes the `nextChangeAt` behavior in the indexer changes API.

Previously, `/verana/indexer/v1/changes/{block_height}` could return a stale/future change height even when that block was beyond the currently indexed checkpoint. This caused polling clients to see inconsistent behavior during reindexing, where `nextChangeAt` could jump forward and then later move back again.

## What Changed

- Added checkpoint-aware validation in `getNextChangeAt`.
- Uses the current `HANDLE_TRANSACTION` block checkpoint as the upper bound for valid next changes.
- Returns `null` when:
  - no checkpoint exists,
  - the requested block height is already at/after the indexed checkpoint,
  - or the next detected change is above the current indexed checkpoint.
- Updated next-change table queries to only consider heights within the indexed range.
- Added unit tests for checkpoint filtering and reindex safety.

## Why

During reindexing, history tables may contain data ahead of the currently processed checkpoint. The changes API should only return changes that are actually available within the indexed range. If no valid next change exists, it should return `null` instead of a stale or misleading block height.

## Testing

Added/updated unit tests covering:

- next change lookup bounded by current checkpoint
- returning `null` when block height is at/after checkpoint
- ignoring future history rows above the indexed checkpoint
- preserving index-friendly `height > blockHeight AND height <= checkpoint` query behavior