### PR TITLE
ci: announce stable releases on discord

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -96,7 +96,7 @@ jobs:
           echo "- verana-indexer:${{ needs.release-please.outputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
 
   discord-notify:
-    needs: release-please
+    needs: [release-please, docker-release]
     if: needs.release-please.outputs.releases_created == 'true'
     permissions:
       contents: read

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      notify_tag:
+        description: "Release tag to (re)announce on Discord, e.g. v1.2.0"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -12,6 +18,7 @@ permissions:
 
 jobs:
   release-please:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
@@ -87,3 +94,24 @@ jobs:
           echo "Helm Charts" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- verana-indexer:${{ needs.release-please.outputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
+
+  discord-notify:
+    needs: release-please
+    if: needs.release-please.outputs.releases_created == 'true'
+    permissions:
+      contents: read
+    uses: 2060-io/organization/.github/workflows/discord-release-notify-call.yml@main
+    with:
+      tag_name: ${{ needs.release-please.outputs.tag_name }}
+    secrets:
+      DISCORD_UPDATES_WEBHOOK_URL: ${{ secrets.DISCORD_UPDATES_WEBHOOK_URL }}
+
+  discord-notify-manual:
+    if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+    uses: 2060-io/organization/.github/workflows/discord-release-notify-call.yml@main
+    with:
+      tag_name: ${{ inputs.notify_tag }}
+    secrets:
+      DISCORD_UPDATES_WEBHOOK_URL: ${{ secrets.DISCORD_UPDATES_WEBHOOK_URL }}


### PR DESCRIPTION
Wires this repo into the shared Discord release notifier so stable releases land in `#update`, same setup as `veranafoundation.org-website` and `verana-frontend`. Adds a `discord-notify` job to the release workflow, gated on the release being created, calling `2060-io/organization`'s reusable workflow with the tag and the `DISCORD_UPDATES_WEBHOOK_URL` org secret. Also adds a manual `workflow_dispatch` so we can re-announce or backfill any tag without cutting a release.

Stable only, dev pre-releases stay quiet. @mjfelis @genaris @lotharking one of you mind taking a look.
