### PR TITLE
feat: corporation id model

### DIFF
--- a/docker/verana-test-flow.sh
+++ b/docker/verana-test-flow.sh
@@ -93,7 +93,7 @@ last_prop()   { v query group proposals-by-group-policy "$1" -o json | jq -r '.p
 last_eco()    { v query ec list-ecosystems   -o json | jq -r '.ecosystems  | max_by(.id|tonumber) | .id'; }
 last_schema() { v query cs list-schemas      -o json | jq -r '(.schemas // []) | max_by(.id|tonumber) | .id'; }
 # dev.13: pp returns `.participants[]` with a `.role` (not `.permissions[]`/`.type`).
-last_perm()   { v query pp list-permissions  -o json | jq -r --arg t "$1" '[(.participants // [])[]|select(.role==$t)] | max_by(.id|tonumber) | .id'; }
+last_perm()   { v query pp list-participants  -o json | jq -r --arg t "$1" '[(.participants // [])[]|select(.role==$t)] | max_by(.id|tonumber) | .id'; }
 
 # ---- Preflight ----------------------------------------------------
 if ! docker ps --format '{{.Names}}' 2>/dev/null | grep -qx "$CONTAINER"; then
@@ -226,7 +226,7 @@ submit "Self-create an ISSUER participant under root ${ROOT_PERM_ID}" \
   tx pp self-create-participant issuer "$ROOT_PERM_ID" "$ISSUER_DID" \
      --corporation "$CORP" --effective-from "$EFFECTIVE_FROM" --from "$KEY"
 ISSUER_PERM_ID="$(last_perm ISSUER)"; echo "   ISSUER participant ID = ${ISSUER_PERM_ID}"
-v query pp get-perm "$ISSUER_PERM_ID" -o json | jq '(.participant // .) | {id, schema_id, role, did, validator_participant_id, grantee}'
+v query pp get-participant "$ISSUER_PERM_ID" -o json | jq '(.participant // .) | {id, schema_id, role, did, validator_participant_id, grantee}'
 # Revocation requires the participant to be active. Validation uses the chain's block
 # time (which can lag wall-clock), so poll latest_block_time until it passes effective_from.
 EFF_EPOCH="$(date -u -d "$EFFECTIVE_FROM" +%s)"
@@ -248,6 +248,6 @@ v query ec get-ecosystem "$ECO_ID" -o json | jq '(.ecosystem // .) | {id, did, a
 echo "Credential Schema ${SCHEMA_ID}:"
 v query cs get-schema "$SCHEMA_ID" -o json | jq '(.schema // .) | {id, ecosystem_id, archived}'
 echo "Participants for schema ${SCHEMA_ID}:"
-v query pp list-permissions -o json | jq --argjson s "$SCHEMA_ID" '(.participants // [])[] | select((.schema_id|tonumber)==$s) | {id, role, did}'
+v query pp list-participants -o json | jq --argjson s "$SCHEMA_ID" '(.participants // [])[] | select((.schema_id|tonumber)==$s) | {id, role, did}'
 echo
 echo "All steps completed."

--- a/src/common/utils/installed_table_columns.ts
+++ b/src/common/utils/installed_table_columns.ts
@@ -20,14 +20,15 @@ export function finalizeEcosystemHistoryInsert(
     }
   }
 
-  if (historyColumns.has("corporation")) {
+  if (historyColumns.has("corporation_id")) {
     const v =
-      (ecosystemRow.corporation as string | undefined) ??
-      (nextPayload.corporation as string | undefined) ??
-      null;
-    if (v != null) nextPayload.corporation = v;
+      (ecosystemRow.corporation_id as number | undefined) ??
+      (nextPayload.corporation_id as number | undefined) ??
+      0;
+    nextPayload.corporation_id = Number(v ?? 0) || 0;
   }
   delete nextPayload.controller;
+  delete nextPayload.corporation;
 
   if (historyColumns.has("deposit")) {
     const dep = nextPayload.deposit ?? ecosystemRow.deposit ?? 0;
@@ -53,26 +54,26 @@ async function tableColumnNames(db: KnexWithTable, table: string): Promise<Set<s
 
 export async function resolveEcosystemParticipantColumn(
   _db: KnexWithTable
-): Promise<"corporation"> {
-  return "corporation";
+): Promise<"corporation_id"> {
+  return "corporation_id";
 }
 
 export async function resolveEcosystemHistoryParticipantColumn(
   _db: KnexWithTable
-): Promise<"corporation"> {
-  return "corporation";
+): Promise<"corporation_id"> {
+  return "corporation_id";
 }
 
 export async function resolveParticipantsParticipantColumn(
   _db: KnexWithTable
-): Promise<"corporation"> {
-  return "corporation";
+): Promise<"corporation_id"> {
+  return "corporation_id";
 }
 
 export async function resolveParticipantHistoryParticipantColumn(
   _db: KnexWithTable
-): Promise<"corporation"> {
-  return "corporation";
+): Promise<"corporation_id"> {
+  return "corporation_id";
 }
 
 export async function resolveTrustDepositTableOwnerColumn(
@@ -104,22 +105,6 @@ export async function ensureDepositDefaultIfColumnExists(
   Object.assign(row, { deposit });
 }
 
-function firstNonEmptyString(
-  sources: Array<Record<string, unknown> | undefined>,
-  keys: string[]
-): string | undefined {
-  for (const src of sources) {
-    if (!src) continue;
-    for (const k of keys) {
-      const v = src[k];
-      if (v === null || v === undefined) continue;
-      const s = String(v).trim();
-      if (s !== "") return s;
-    }
-  }
-  return undefined;
-}
-
 export async function prepareEcosystemSnapshotRowForInsert(
   db: KnexWithTable,
   row: Record<string, unknown>,
@@ -128,16 +113,12 @@ export async function prepareEcosystemSnapshotRowForInsert(
   const next: Record<string, unknown> = { ...row };
   const info = await db("ecosystem_snapshot").columnInfo();
   const cols = new Set(Object.keys(info || {}));
-  if (!cols.has("corporation") && (await db.schema.hasColumn("ecosystem_snapshot", "corporation"))) {
-    cols.add("corporation");
-  }
-  const { ecosystemRow, rawLedger } = opts;
-  const raw = rawLedger as Record<string, unknown> | undefined;
-  const participant = firstNonEmptyString([ecosystemRow, raw], ["corporation"]);
-  const didStr = String(ecosystemRow.did ?? "").trim();
-  const pStr = participant ?? didStr;
+  const { ecosystemRow } = opts;
 
-  if (cols.has("corporation")) next.corporation = pStr;
+  if (cols.has("corporation_id")) {
+    next.corporation_id = Number(ecosystemRow.corporation_id ?? 0) || 0;
+  }
+  delete next.corporation;
 
   await ensureDepositDefaultIfColumnExists(db, "ecosystem_snapshot", next, ecosystemRow.deposit);
 

--- a/src/common/vpr-v4-mapping.ts
+++ b/src/common/vpr-v4-mapping.ts
@@ -65,7 +65,8 @@ export function mapEcosystemApiFields(
   row: Record<string, unknown>
 ): Record<string, unknown> {
   const out: Record<string, unknown> = { ...row };
-  out.corporation = out.corporation ?? null;
+  out.corporation_id = Number(out.corporation_id ?? 0) || 0;
+  delete out.corporation;
   delete out.controller;
   return out;
 }
@@ -95,7 +96,8 @@ export function mapParticipantApiFields(
   row: Record<string, unknown>
 ): Record<string, unknown> {
   const out: Record<string, unknown> = { ...row };
-  out.corporation = out.corporation ?? null;
+  out.corporation_id = Number(out.corporation_id ?? 0) || 0;
+  delete out.corporation;
   for (const k of PARTICIPANT_V3_STRIP) {
     delete out[k];
   }

--- a/src/migrations/20260605000000_normalize_corporation_ownership_on_ec_pp.ts
+++ b/src/migrations/20260605000000_normalize_corporation_ownership_on_ec_pp.ts
@@ -1,0 +1,63 @@
+import { Knex } from "knex";
+
+// Corporation model normalization on the indexer (single migration for this PR).
+//
+// VPR v4 models Ecosystem/Participant ownership exclusively by the uint64 `corporation_id`
+// (FK to Corporation.id), provided directly by the chain. The embedded account address was
+// removed on-chain (Participant `reserved 5`, Ecosystem never had it); the account now lives
+// only in Corporation.policy_address and is resolved on demand (see corporation_resolve).
+//
+// This migration, in order:
+//   1. Adds the canonical `corporation_id` (+ index) to the Ecosystem/Participant family of
+//      tables that don't already have it.
+//   2. Drops the legacy `corporation` (address) column from all of them. Postgres drops any
+//      index depending on the dropped column automatically (incl. the composite
+//      idx_ec_corporation_archived_modified_id and the participant corporation indexes).
+//
+// Out of scope (kept): corporation/corporation_history (the address is the source of truth)
+// and trust_deposits/trust_deposit_history (the TD proto is still address-based).
+//
+// Runs after the dev.13 rename (20260604000003), so it targets the current table names.
+// Idempotent. No backfill — corporation_id is populated by the ingest on (re)indexing.
+
+const TABLES = [
+  "ecosystem",
+  "ecosystem_history",
+  "ecosystem_snapshot",
+  "participants",
+  "participant_history",
+  "participant_sessions",
+  "participant_session_history",
+] as const;
+
+export async function up(knex: Knex): Promise<void> {
+  for (const table of TABLES) {
+    if (!(await knex.schema.hasTable(table))) continue;
+    if (!(await knex.schema.hasColumn(table, "corporation_id"))) {
+      await knex.raw(
+        `ALTER TABLE "${table}" ADD COLUMN "corporation_id" bigint NOT NULL DEFAULT 0`
+      );
+      await knex.raw(
+        `CREATE INDEX IF NOT EXISTS "idx_${table}_corporation_id" ON "${table}" ("corporation_id")`
+      );
+    }
+    if (await knex.schema.hasColumn(table, "corporation")) {
+      await knex.raw(`ALTER TABLE "${table}" DROP COLUMN IF EXISTS "corporation"`);
+    }
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  for (const table of TABLES) {
+    if (!(await knex.schema.hasTable(table))) continue;
+    // Re-create the legacy column as nullable (the original was NOT NULL, but the addresses
+    // cannot be reconstructed here; ingest/backfill would repopulate it).
+    if (!(await knex.schema.hasColumn(table, "corporation"))) {
+      await knex.raw(`ALTER TABLE "${table}" ADD COLUMN "corporation" varchar(255)`);
+    }
+    if (await knex.schema.hasColumn(table, "corporation_id")) {
+      await knex.raw(`DROP INDEX IF EXISTS "idx_${table}_corporation_id"`);
+      await knex.raw(`ALTER TABLE "${table}" DROP COLUMN IF EXISTS "corporation_id"`);
+    }
+  }
+}

--- a/src/models/ecosystem.ts
+++ b/src/models/ecosystem.ts
@@ -7,7 +7,7 @@ export class Ecosystem extends BaseModel {
 
   id!: number;
   did!: string;
-  corporation!: string;
+  corporation_id!: number;
   created!: Date;
   modified!: Date;
   archived?: string | null;

--- a/src/models/ecosystem_history.ts
+++ b/src/models/ecosystem_history.ts
@@ -8,7 +8,7 @@ export class EcosystemHistory extends BaseModel {
   id!: number;
   ecosystem_id!: number;
   did!: string;
-  corporation!: string;
+  corporation_id!: number;
   created!: Date;
   modified!: Date;
   archived?: Date | null;

--- a/src/models/participant.ts
+++ b/src/models/participant.ts
@@ -26,7 +26,7 @@ export default class Participant extends BaseModel {
     schema_id!: number;
     role!: ParticipantType;
     did?: string;
-    corporation!: string;
+    corporation_id!: number;
     created!: Date;
     slashed?: Date | null;
     repaid?: Date | null;
@@ -78,7 +78,7 @@ export default class Participant extends BaseModel {
     static get jsonSchema() {
         return {
             type: 'object',
-            required: ['id', 'schema_id', 'role', 'corporation', 'created', 'modified'],
+            required: ['id', 'schema_id', 'role', 'corporation_id', 'created', 'modified'],
             additionalProperties: false,
             properties: {
                 id: { type: 'integer' },
@@ -88,7 +88,7 @@ export default class Participant extends BaseModel {
                     enum: ['UNSPECIFIED', 'ECOSYSTEM', 'ISSUER_GRANTOR', 'VERIFIER_GRANTOR', 'ISSUER', 'VERIFIER', 'HOLDER']
                 },
                 did: { type: 'string', maxLength: 255 },
-                corporation: { type: 'string', maxLength: 255 },
+                corporation_id: { type: 'integer' },
                 validation_fees: { type: 'integer' },
                 issuance_fees: { type: 'integer' },
                 verification_fees: { type: 'integer' },

--- a/src/models/participant_session.ts
+++ b/src/models/participant_session.ts
@@ -13,7 +13,7 @@ export default class ParticipantSession extends BaseModel {
   static tableName = "participant_sessions";
 
   id!: string;
-  corporation!: string;
+  corporation_id!: number;
   vs_operator?: string | null;
   agent_participant_id!: number;
   wallet_agent_participant_id!: number;
@@ -26,14 +26,14 @@ export default class ParticipantSession extends BaseModel {
       type: "object",
       required: [
         "id",
-        "corporation",
+        "corporation_id",
         "agent_participant_id",
         "wallet_agent_participant_id",
         "session_records",
       ],
       properties: {
         id: { type: "string" },
-        corporation: { type: "string", maxLength: 255 },
+        corporation_id: { type: "integer" },
         vs_operator: { type: ["string", "null"] },
         agent_participant_id: { type: "integer" },
         wallet_agent_participant_id: { type: "integer" },

--- a/src/modules/ec-height-sync/ec_height_sync_helpers.ts
+++ b/src/modules/ec-height-sync/ec_height_sync_helpers.ts
@@ -29,7 +29,7 @@ export interface LedgerEcosystem {
   id?: number | string;
   ecosystem_id?: number | string;
   did?: string;
-  controller?: string;
+  corporation_id?: number;
   created?: string;
   modified?: string;
   archived?: string | null;
@@ -97,8 +97,7 @@ export function mapEcosystemToLedgerEcosystem(
   return {
     id: eco.id,
     did: eco.did,
-    corporation: eco.corporationId ?? null,
-    corporation_id: eco.corporationId ?? null,
+    corporation_id: Number(eco.corporationId ?? 0) || 0,
     created: dateToIsoOrNull(eco.created) ?? undefined,
     modified: dateToIsoOrNull(eco.modified) ?? undefined,
     archived: eco.archived ? (dateToIsoOrNull(eco.modified) ?? new Date().toISOString()) : null,

--- a/src/scripts/reindex-modules.ts
+++ b/src/scripts/reindex-modules.ts
@@ -61,6 +61,11 @@ const TABLES_TO_DROP = [
   "entity_participant_changes",
   "trust_results",
   "indexer_events",
+  "co_governance_framework_document",
+  "co_governance_framework_version",
+  "corporation_member",
+  "corporation_history",
+  "corporation",
 ];
 
 const SEQUENCES_TO_RESET = [
@@ -89,6 +94,11 @@ const SEQUENCES_TO_RESET = [
   "account_id_seq",
   "stats_id_seq",
   "indexer_events_id_seq",
+  "corporation_id_seq",
+  "corporation_member_id_seq",
+  "corporation_history_id_seq",
+  "co_governance_framework_version_id_seq",
+  "co_governance_framework_document_id_seq",
 ];
 
 async function waitForDatabase(config: Knex.Config, maxRetries = 30, delayMs = 2000): Promise<void> {

--- a/src/services/api/snapshot.service.ts
+++ b/src/services/api/snapshot.service.ts
@@ -105,17 +105,17 @@ async function fetchParticipantsAtHeight(args: {
   did: string;
   blockHeight: number;
   schemaEcosystemIds?: number[];
-  corporationAddresses: string[];
+  corporationIds: number[];
   tables: SnapshotTables;
 }): Promise<SnapshotRow[]> {
-  const { did, schemaEcosystemIds = [], corporationAddresses, tables, blockHeight } = args;
+  const { did, schemaEcosystemIds = [], corporationIds, tables, blockHeight } = args;
   if (!tables.hasParticipants) return [];
 
   const query = knex("participants")
     .select("*")
     .where((qb) => {
       qb.where("did", did);
-      if (corporationAddresses.length > 0) qb.orWhere((q) => q.whereIn("corporation", corporationAddresses));
+      if (corporationIds.length > 0) qb.orWhere((q) => q.whereIn("corporation_id", corporationIds));
       if (tables.hasCredentialSchemas && schemaEcosystemIds.length > 0) {
         const schemaQuery = knex("credential_schemas")
           .select("id")
@@ -144,12 +144,11 @@ export async function getDidSnapshotAtHeight(args: { did: string; blockHeight: n
     .map((row) => Number(row.id))
     .filter((id) => Number.isInteger(id) && id >= 0);
 
-  const corporationAddresses = Array.from(
+  const corporationIds = Array.from(
     new Set(
       ecosystems
-        .map((row) => row.corporation)
-        .filter((corp): corp is string => typeof corp === "string" && corp.trim().length > 0)
-        .map((corp) => corp.trim())
+        .map((row) => Number((row as { corporation_id?: unknown }).corporation_id ?? 0))
+        .filter((id) => Number.isInteger(id) && id > 0)
     )
   );
 
@@ -159,7 +158,7 @@ export async function getDidSnapshotAtHeight(args: { did: string; blockHeight: n
       did,
       blockHeight,
       schemaEcosystemIds: ecosystemIds,
-      corporationAddresses,
+      corporationIds,
       tables,
     }),
   ]);

--- a/src/services/crawl-co/co_processor.service.ts
+++ b/src/services/crawl-co/co_processor.service.ts
@@ -49,6 +49,43 @@ interface DecodedCoMessage {
   ecosystemId?: number | string;
   version?: number | string;
   content?: Record<string, unknown>;
+  txEvents?: CoTxEvent[];
+}
+
+interface CoTxEvent {
+  type?: string;
+  attributes?: Array<{ key?: string; value?: string }>;
+}
+
+function extractCreateCorporationEvent(txEvents: CoTxEvent[] | undefined): {
+  corporationId?: number;
+  policyAddress?: string;
+  did?: string;
+} {
+  if (!Array.isArray(txEvents)) return {};
+  const decode = (raw: string | undefined): string => {
+    if (!raw) return "";
+    if (/^[A-Za-z0-9+/=]+$/.test(raw) && raw.length % 4 === 0 && !raw.startsWith("verana")) {
+      try {
+        return Buffer.from(raw, "base64").toString("utf-8");
+      } catch {
+        return raw;
+      }
+    }
+    return raw;
+  };
+  for (const ev of txEvents) {
+    if ((ev.type ?? "") !== "create_corporation") continue;
+    const attrs = new Map<string, string>();
+    for (const a of ev.attributes ?? []) attrs.set(decode(a.key), decode(a.value).replace(/^"|"$/g, ""));
+    const idNum = Number(attrs.get("corporation_id"));
+    return {
+      corporationId: Number.isInteger(idNum) && idNum > 0 ? idNum : undefined,
+      policyAddress: attrs.get("policy_address") || undefined,
+      did: attrs.get("did") || undefined,
+    };
+  }
+  return {};
 }
 
 interface CorporationRow {
@@ -234,14 +271,20 @@ export default class CorporationMessageProcessorService extends BullableService 
       ? message.members
       : [];
 
+    const event = extractCreateCorporationEvent(message.txEvents);
+    const chainCorporationId = event.corporationId;
+    const policyAddress = event.policyAddress ?? message.corporation ?? null;
+
     await this.withTransaction(`CreateCorporation for did=${did}`, async (trx) => {
-      const existing = (await trx("corporation").where({ did }).first()) as
+      const existing = ((chainCorporationId
+        ? await trx("corporation").where({ id: chainCorporationId }).first()
+        : undefined) ?? (await trx("corporation").where({ did }).first())) as
         | CorporationRow
         | undefined;
 
       const row = {
         did,
-        corporation: message.corporation ?? null,
+        corporation: policyAddress,
         creator: message.signer ?? message.creator ?? null,
         language: message.language ?? null,
         group_metadata: message.group_metadata ?? message.groupMetadata ?? null,
@@ -263,8 +306,11 @@ export default class CorporationMessageProcessorService extends BullableService 
           .update(row)
           .returning("*")) as CorporationRow[];
       } else {
+        const insertRow = chainCorporationId
+          ? { id: chainCorporationId, ...row, created: timestamp }
+          : { ...row, created: timestamp };
         [corporation] = (await trx("corporation")
-          .insert({ ...row, created: timestamp })
+          .insert(insertRow)
           .returning("*")) as CorporationRow[];
       }
 

--- a/src/services/crawl-co/corporation_resolve.ts
+++ b/src/services/crawl-co/corporation_resolve.ts
@@ -1,0 +1,59 @@
+import type { Knex } from "knex";
+import knexDefault from "../../common/utils/db_connection";
+import { extractController } from "../../common/utils/extract_controller";
+
+export async function resolveCorporationIdByAddress(
+  address: string | null | undefined,
+  db: Knex | Knex.Transaction = knexDefault
+): Promise<number | null> {
+  if (!address || typeof address !== "string" || !address.trim()) return null;
+  const row = await db("corporation").select("id").where({ corporation: address.trim() }).first();
+  const id = Number(row?.id);
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
+
+export async function resolveAddressByCorporationId(
+  corporationId: number | null | undefined,
+  db: Knex | Knex.Transaction = knexDefault
+): Promise<string | null> {
+  if (!corporationId || !Number.isInteger(corporationId) || corporationId <= 0) return null;
+  const row = await db("corporation").select("corporation").where({ id: corporationId }).first();
+  const addr = row?.corporation;
+  return typeof addr === "string" && addr.trim() ? addr : null;
+}
+
+export async function resolveCorporationIdForMessage(
+  message: Record<string, any> | null | undefined,
+  db: Knex | Knex.Transaction = knexDefault
+): Promise<number> {
+  const direct = Number(message?.corporation_id ?? message?.corporationId ?? 0) || 0;
+  if (direct > 0) return direct;
+  const controller = extractController(message ?? {});
+  if (controller) {
+    const id = await resolveCorporationIdByAddress(controller, db);
+    if (id) return id;
+  }
+  return 0;
+}
+
+export async function resolveAddressesByCorporationIds(
+  corporationIds: Array<number | null | undefined>,
+  db: Knex | Knex.Transaction = knexDefault
+): Promise<Map<number, string>> {
+  const ids = Array.from(
+    new Set(
+      corporationIds
+        .map((v) => Number(v))
+        .filter((v) => Number.isInteger(v) && v > 0)
+    )
+  );
+  const map = new Map<number, string>();
+  if (ids.length === 0) return map;
+  const rows = await db("corporation").select("id", "corporation").whereIn("id", ids);
+  for (const r of rows as Array<{ id: number; corporation: string | null }>) {
+    if (typeof r.corporation === "string" && r.corporation.trim()) {
+      map.set(Number(r.id), r.corporation);
+    }
+  }
+  return map;
+}

--- a/src/services/crawl-cs/cs_database.service.ts
+++ b/src/services/crawl-cs/cs_database.service.ts
@@ -341,7 +341,7 @@ export async function syncEcosystemStatsAndHistoryFromSchemaChange(
     {
       ecosystem_id: ecosystemId,
       did: updatedTr.did,
-      corporation: updatedTr.corporation,
+      corporation_id: Number(updatedTr.corporation_id ?? 0) || 0,
       created: updatedTr.created,
       modified: updatedTr.modified,
       archived: updatedTr.archived ?? null,

--- a/src/services/crawl-cs/cs_stats.ts
+++ b/src/services/crawl-cs/cs_stats.ts
@@ -4,10 +4,8 @@ import { calculateParticipantState } from "../crawl-pp/pp_state_utils";
 
 function participantFromTrRow(row: Record<string, unknown> | null | undefined): string | null {
     if (!row) return null;
-    const v = row.corporation;
-    if (v === null || v === undefined) return null;
-    const s = String(v).trim();
-    return s === "" ? null : s;
+    const n = Number(row.corporation_id ?? 0) || 0;
+    return n > 0 ? String(n) : null;
 }
 
 const IS_PG_CLIENT = String((knex as any)?.client?.config?.client || "").includes("pg");
@@ -427,9 +425,8 @@ export async function calculateCredentialSchemaStatsBatch(
         );
 
         const participantRow = participant as Record<string, unknown>;
-        const corpRaw = participantRow.corporation;
-        const corp =
-            corpRaw === null || corpRaw === undefined ? "" : String(corpRaw).trim();
+        const corpId = Number(participantRow.corporation_id ?? 0) || 0;
+        const corp = corpId > 0 ? String(corpId) : "";
         if (participantState === "ACTIVE" && corp) {
             activeParticipantsBySchema.get(schemaId)?.add(corp);
             if (participant.role === "ECOSYSTEM") activeParticipantsEcosystemBySchema.get(schemaId)?.add(corp);

--- a/src/services/crawl-ec/ec_database.service.ts
+++ b/src/services/crawl-ec/ec_database.service.ts
@@ -13,6 +13,7 @@ import { applyOrdering, validateSortParameter, sortByStandardAttributes, parseSo
 import { calculateEcosystemStats, TR_STATS_FIELDS } from "./ec_stats";
 import { mapEcosystemApiFields } from "../../common/vpr-v4-mapping";
 import { enrichTrustDataDeep, parseTrustDataMode } from "../resolver/trust-data-enrichment";
+import { resolveCorporationIdByAddress } from "../crawl-co/corporation_resolve";
 import {
     ensureDepositDefaultIfColumnExists,
     finalizeEcosystemHistoryInsert,
@@ -34,7 +35,6 @@ function ledgerHasKey(obj: unknown, key: string): boolean {
 export default class EcosystemDatabaseService extends BaseService {
     private ecosystemHistoryColumnExistsCache = new Map<string, boolean>();
     private ecosystemHistoryColumnsCache: Set<string> | null = null;
-    private ecosystemParticipantColumn: "corporation" | null = null;
     private static readonly SQL_SORTABLE_TR_ATTRIBUTES = new Set<string>([
         "id",
         "modified",
@@ -58,13 +58,6 @@ export default class EcosystemDatabaseService extends BaseService {
 
     public constructor(public broker: ServiceBroker) {
         super(broker);
-    }
-
-    private async getEcosystemParticipantColumn(db: Knex | Knex.Transaction): Promise<"corporation"> {
-        if (this.ecosystemParticipantColumn) return this.ecosystemParticipantColumn;
-        const col = await resolveEcosystemParticipantColumn(db);
-        this.ecosystemParticipantColumn = col;
-        return col;
     }
 
     private valuesEquivalent(left: unknown, right: unknown): boolean {
@@ -127,19 +120,19 @@ export default class EcosystemDatabaseService extends BaseService {
             await knex.transaction(async (trx) => {
                 const existingTr = await trx("ecosystem").where({ id: ecosystemId }).first();
                 const rawObj = raw as Record<string, unknown>;
-                const participantCol = await this.getEcosystemParticipantColumn(trx);
 
                 const activeVersionFromLedger =
                     ledgerHasKey(rawObj, "active_version") || ledgerHasKey(rawObj, "activeVersion")
                         ? Number((raw as any).active_version ?? (raw as any).activeVersion ?? 0) || 0
                         : Number(existingTr?.active_version ?? 0) || 0;
 
-                const corporationValue =
-                    ledgerHasKey(rawObj, "corporation")
-                        ? ((raw as any).corporation ?? null)
-                        : ((existingTr as any)?.corporation ?? null);
+                const corporationIdValue =
+                    ledgerHasKey(rawObj, "corporation_id")
+                        ? (Number((raw as any).corporation_id ?? 0) || 0)
+                        : (Number((existingTr as any)?.corporation_id ?? 0) || 0);
 
                 const basePayload: Record<string, unknown> = {
+                    corporation_id: corporationIdValue,
                     did: ledgerHasKey(rawObj, "did") ? ((raw as any).did ?? null) : (existingTr?.did ?? null),
                     created: ledgerHasKey(rawObj, "created")
                         ? ((raw as any).created ?? null)
@@ -157,7 +150,6 @@ export default class EcosystemDatabaseService extends BaseService {
                     active_version: activeVersionFromLedger,
                     height: blockHeightNum,
                 };
-                basePayload[participantCol] = corporationValue;
 
                 // skip changing height (avoids 23505). Do NOT use try/catch — Postgres aborts the txn on error (25P02).
                 if (existingTr) {
@@ -550,7 +542,7 @@ export default class EcosystemDatabaseService extends BaseService {
                             {
                                 ecosystem_id: ecosystemId,
                                 did: updatedTr.did,
-                                corporation: updatedTr.corporation,
+                                corporation_id: updatedTr.corporation_id,
                                 created: updatedTr.created,
                                 modified: updatedTr.modified,
                                 archived: updatedTr.archived ?? null,
@@ -1171,7 +1163,7 @@ export default class EcosystemDatabaseService extends BaseService {
                     const ecosystem = {
                         id: snapshot.ecosystem_id,
                         did: snapshot.did,
-                        corporation: snapshot.corporation,
+                        corporation_id: snapshot.corporation_id,
                         created: snapshot.created,
                         modified: snapshot.modified,
                         archived: snapshot.archived,
@@ -1254,7 +1246,7 @@ export default class EcosystemDatabaseService extends BaseService {
                     ecosystem: mapEcosystemApiFields({
                         id: ec.id,
                         did: ec.did,
-                        corporation: ec.corporation,
+                        corporation_id: ec.corporation_id,
                         created: ec.created,
                         modified: ec.modified,
                         archived: ec.archived,
@@ -1319,7 +1311,7 @@ export default class EcosystemDatabaseService extends BaseService {
                             ecosystem: mapEcosystemApiFields({
                                 id: s.ecosystem_id,
                                 did: s.did,
-                                corporation: s.corporation,
+                                corporation_id: s.corporation_id,
                                 created: s.created,
                                 modified: s.modified,
                                 archived: s.archived,
@@ -1372,7 +1364,7 @@ export default class EcosystemDatabaseService extends BaseService {
                 const ecosystem = {
                     id: ecosystemHistory.ecosystem_id,
                     did: ecosystemHistory.did,
-                    corporation: ecosystemHistory.corporation,
+                    corporation_id: ecosystemHistory.corporation_id,
                     created: ecosystemHistory.created,
                     modified: ecosystemHistory.modified,
                     archived: ecosystemHistory.archived,
@@ -1607,6 +1599,13 @@ export default class EcosystemDatabaseService extends BaseService {
                 return ApiResponder.error(ctx, corporationValidation.error, 400);
             }
             const corporationAccount = corporationValidation.value;
+            let corporationId: number | null = null;
+            if (corporationAccount) {
+                corporationId = await resolveCorporationIdByAddress(corporationAccount);
+                if (corporationId === null) {
+                    return ApiResponder.success(ctx, { ecosystems: [] }, 200);
+                }
+            }
 
             try {
                 validateSortParameter(sort);
@@ -1676,7 +1675,7 @@ export default class EcosystemDatabaseService extends BaseService {
                     }
                     let snapshotBase = knex("ecosystem_snapshot")
                         .where("height", "<=", blockHeight);
-                    if (corporationAccount) snapshotBase = snapshotBase.where("corporation", corporationAccount);
+                    if (corporationId !== null) snapshotBase = snapshotBase.where("corporation_id", corporationId);
                     if (participantEcosystemIds !== undefined) snapshotBase = snapshotBase.whereIn("ecosystem_id", participantEcosystemIds);
                     if (modifiedAfter) {
                         const ts = new Date(modifiedAfter);
@@ -1712,7 +1711,7 @@ export default class EcosystemDatabaseService extends BaseService {
                         return {
                             id: row.ecosystem_id,
                             did: row.did,
-                            corporation: row.corporation,
+                            corporation_id: row.corporation_id,
                             created: row.created,
                             modified: row.modified,
                             archived: row.archived,
@@ -1766,8 +1765,8 @@ export default class EcosystemDatabaseService extends BaseService {
                     .select("*")
                     .where("height", "<=", blockHeight);
 
-                if (corporationAccount) {
-                    filteredSubquery = filteredSubquery.where("corporation", corporationAccount);
+                if (corporationId !== null) {
+                    filteredSubquery = filteredSubquery.where("corporation_id", corporationId);
                 }
                 if (participantEcosystemIds !== undefined) {
                     filteredSubquery = filteredSubquery.whereIn("ecosystem_id", participantEcosystemIds);
@@ -1820,7 +1819,7 @@ export default class EcosystemDatabaseService extends BaseService {
                         return {
                             id: ecosystemHistory.ecosystem_id,
                             did: ecosystemHistory.did,
-                            corporation: ecosystemHistory.corporation,
+                            corporation_id: ecosystemHistory.corporation_id,
                             created: ecosystemHistory.created,
                             modified: ecosystemHistory.modified,
                             archived: ecosystemHistory.archived,
@@ -1883,7 +1882,7 @@ export default class EcosystemDatabaseService extends BaseService {
                     }
                     batchQuery = batchQuery.whereIn("id", participantEcosystemIds);
                 }
-                if (corporationAccount) batchQuery = batchQuery.where("corporation", corporationAccount);
+                if (corporationId !== null) batchQuery = batchQuery.where("corporation_id", corporationId);
                 batchQuery = this.applyRangeToQuery(batchQuery, "participants", minParticipants, maxParticipants);
                 batchQuery = this.applyRangeToQuery(batchQuery, "participants_ecosystem", minParticipantsEcosystem, maxParticipantsEcosystem);
                 batchQuery = this.applyRangeToQuery(batchQuery, "participants_issuer_grantor", minParticipantsIssuerGrantor, maxParticipantsIssuerGrantor);
@@ -1959,7 +1958,7 @@ export default class EcosystemDatabaseService extends BaseService {
                     return {
                         id: ec.id,
                         did: ec.did,
-                        corporation: ec.corporation,
+                        corporation_id: ec.corporation_id,
                         created: ec.created,
                         modified: ec.modified,
                         archived: ec.archived,
@@ -2010,8 +2009,8 @@ export default class EcosystemDatabaseService extends BaseService {
                 }
                 query = query.where("id", "in", participantEcosystemIds) as any;
             }
-            if (corporationAccount) {
-                query = query.where("corporation", corporationAccount);
+            if (corporationId !== null) {
+                query = query.where("corporation_id", corporationId);
             }
 
             query = query.withGraphFetched("governanceFrameworkVersions.documents") as any;
@@ -2130,15 +2129,17 @@ export default class EcosystemDatabaseService extends BaseService {
 
 
     private async getEcosystemIdsForParticipant(account: string): Promise<number[]> {
+        const corporationId = await resolveCorporationIdByAddress(account);
+        if (corporationId === null) return [];
         const trPart = await resolveEcosystemParticipantColumn(knex);
         const controllerRows = await knex("ecosystem")
-            .where(trPart, account)
+            .where(trPart, corporationId)
             .select("id");
         const controllerIds = controllerRows.map((r: { id: number }) => r.id);
 
         const participantPart = await resolveParticipantsParticipantColumn(knex);
         const corpSchemaIds = await knex("participants")
-            .where(participantPart, account)
+            .where(participantPart, corporationId)
             .distinct("schema_id");
         const schemaIds = corpSchemaIds
             .map((r: { schema_id: string }) => {
@@ -2159,17 +2160,19 @@ export default class EcosystemDatabaseService extends BaseService {
 
 
     private async getEcosystemIdsForParticipantAtHeight(account: string, blockHeight: number): Promise<number[]> {
+        const corporationId = await resolveCorporationIdByAddress(account);
+        if (corporationId === null) return [];
         const trHistPart = await resolveEcosystemHistoryParticipantColumn(knex);
         const ecosystemHistoryRows = await knex("ecosystem_history")
             .where("height", "<=", blockHeight)
-            .where(trHistPart, account)
+            .where(trHistPart, corporationId)
             .select("ecosystem_id");
         const controllerEcosystemIds = [...new Set(ecosystemHistoryRows.map((r: { ecosystem_id: number }) => r.ecosystem_id))];
 
         const participantHistPart = await resolveParticipantHistoryParticipantColumn(knex);
         const corpParticipantRows = await knex("participant_history")
             .where("height", "<=", blockHeight)
-            .where(participantHistPart, account)
+            .where(participantHistPart, corporationId)
             .distinct("schema_id");
         const schemaIds = corpParticipantRows.map((r: { schema_id: number }) => r.schema_id).filter((id): id is number => id != null);
         if (schemaIds.length === 0) {

--- a/src/services/crawl-ec/ec_history.service.ts
+++ b/src/services/crawl-ec/ec_history.service.ts
@@ -248,7 +248,7 @@ export default class EcosystemHistoryService extends BaseService {
 
     const rows = await query.select(
       "id", "ecosystem_id", "height", "event_type", "created_at",
-      "did", "corporation", "created", "modified", "archived", "aka", "language", "active_version",
+      "did", "corporation_id", "created", "modified", "archived", "aka", "language", "active_version",
       "participants", "participants_ecosystem", "participants_issuer_grantor", "participants_issuer",
       "participants_verifier_grantor", "participants_verifier", "participants_holder",
       "active_schemas", "archived_schemas", "weight", "issued", "verified",
@@ -299,7 +299,7 @@ export default class EcosystemHistoryService extends BaseService {
 
       const changes: Record<string, unknown> = {
         did: row.did,
-        corporation: row.corporation,
+        corporation_id: Number(row.corporation_id ?? 0) || 0,
         created: row.created != null ? (row.created instanceof Date ? row.created.toISOString() : new Date(row.created).toISOString()) : null,
         modified: row.modified != null ? (row.modified instanceof Date ? row.modified.toISOString() : new Date(row.modified).toISOString()) : null,
         archived: row.archived != null ? (row.archived instanceof Date ? row.archived.toISOString() : new Date(row.archived).toISOString()) : null,

--- a/src/services/crawl-ec/ec_processor.service.ts
+++ b/src/services/crawl-ec/ec_processor.service.ts
@@ -11,7 +11,7 @@ import {
 import { VeranaEcosystemMessageTypes } from "../../common/verana-message-types";
 import { formatTimestamp } from "../../common/utils/date_utils";
 import knex from "../../common/utils/db_connection";
-import { requireController } from "../../common/utils/extract_controller";
+import { resolveCorporationIdForMessage } from "../crawl-co/corporation_resolve";
 import { MessageProcessorBase } from "../../common/utils/message_processor_base";
 import { detectStartMode } from "../../common/utils/start_mode_detector";
 import { calculateEcosystemStats, TR_STATS_FIELDS } from "./ec_stats";
@@ -408,7 +408,7 @@ export default class EcosystemMessageProcessorService extends BullableService {
     const historyPayload: any = {
       ecosystem_id: ecosystemId,
       did: newData.did,
-      corporation: newData.corporation,
+      corporation_id: Number(newData.corporation_id ?? 0) || 0,
       created: newData.created,
       modified: newData.modified,
       archived: newData.archived ?? null,
@@ -772,7 +772,7 @@ export default class EcosystemMessageProcessorService extends BullableService {
         .first();
 
       let ec;
-      const corporation = requireController(message, `EC ${message.did}`);
+      const corporationId = await resolveCorporationIdForMessage(message, trx);
       const isReindexing = !!existingTR;
 
       if (isReindexing) {
@@ -781,11 +781,11 @@ export default class EcosystemMessageProcessorService extends BullableService {
           .where({ id: existingTR.id })
           .update({
             did: message.did,
-            corporation,
+            corporation_id: corporationId,
             modified: timestamp,
             aka: message.aka,
             language: message.language,
-            height: blockHeight, 
+            height: blockHeight,
           })
           .returning("*");
       } else {
@@ -793,7 +793,7 @@ export default class EcosystemMessageProcessorService extends BullableService {
         [ec] = await trx("ecosystem")
           .insert({
             did: message.did,
-            corporation,
+            corporation_id: corporationId,
             created: timestamp,
             modified: timestamp,
             aka: message.aka,

--- a/src/services/crawl-ec/ec_stats.ts
+++ b/src/services/crawl-ec/ec_stats.ts
@@ -1,5 +1,6 @@
 import knex from "../../common/utils/db_connection";
 import { Ecosystem } from "../../models/ecosystem";
+import { resolveAddressByCorporationId } from "../crawl-co/corporation_resolve";
 import { TR_STATS_FIELDS } from "../../common/utils/stats_fields";
 import { calculateCredentialSchemaStatsBatch, getParticipantSessionCounters } from "../crawl-cs/cs_stats";
 
@@ -64,10 +65,10 @@ export async function getEcosystemController(ecosystemId: number, blockHeight?: 
             .orderBy("height", "desc")
             .orderBy("created_at", "desc")
             .first();
-        return ecosystemHistory?.corporation || null;
+        return resolveAddressByCorporationId(Number(ecosystemHistory?.corporation_id ?? 0) || 0);
     }
     const ec = await Ecosystem.query().findById(ecosystemId);
-    return ec?.corporation || null;
+    return resolveAddressByCorporationId(Number(ec?.corporation_id ?? 0) || 0);
 }
 
 export async function getParticipantsForSchema(schemaId: number, blockHeight?: number): Promise<any[]> {

--- a/src/services/crawl-pp/pp_apis.service.ts
+++ b/src/services/crawl-pp/pp_apis.service.ts
@@ -16,6 +16,7 @@ import { buildActivityTimeline } from "../../common/utils/activity_timeline_help
 import { mapParticipantApiFields } from "../../common/vpr-v4-mapping";
 import { mapParticipantType, normalizeParticipantEmptyStringsToNull } from "../../common/utils/utils";
 import { enrichTrustDataDeep, parseTrustDataMode, type TrustDataMode } from "../resolver/trust-data-enrichment";
+import { resolveCorporationIdByAddress } from "../crawl-co/corporation_resolve";
 import {
   calculateParticipantState,
   calculateCorporationAvailableActions,
@@ -168,7 +169,7 @@ export default class ParticipantAPIService extends BullableService {
 
     return {
       id: row.id ?? row.session_id,
-      corporation: row.corporation ?? null,
+      corporation_id: Number(row.corporation_id ?? 0) || 0,
       vs_operator: row.vs_operator ?? null,
       agent_participant_id: Number(row.agent_participant_id ?? 0) || 0,
       wallet_agent_participant_id: Number(row.wallet_agent_participant_id ?? 0) || 0,
@@ -244,7 +245,7 @@ export default class ParticipantAPIService extends BullableService {
     if (limit > 32) return false;
 
     const disallowedKeys = [
-      "corporation",
+      "corporation_id",
       "participant_id",
       "validator_participant_id",
       "participant_state",
@@ -313,7 +314,7 @@ export default class ParticipantAPIService extends BullableService {
   private applyBaseListFiltersToQuery(
     query: any,
     params: any,
-    corporationFilter: string | undefined,
+    corporationIdFilter: number | undefined,
     modifiedAfterIso: string | undefined,
     whenIso: string | undefined,
     onlyValid: boolean,
@@ -326,7 +327,7 @@ export default class ParticipantAPIService extends BullableService {
     const col = (name: string) => (tablePrefix ? `${tablePrefix}.${name}` : name);
 
     if (params.schema_id !== undefined) query.where(col("schema_id"), Number(params.schema_id));
-    if (corporationFilter) query.where(col("corporation"), corporationFilter);
+    if (corporationIdFilter !== undefined) query.where(col("corporation_id"), corporationIdFilter);
     if (params.did) query.where(col("did"), params.did);
     if (params.participant_id !== undefined) query.where(col(participantIdColumn), Number(params.participant_id));
     if (params.validator_participant_id !== undefined) {
@@ -948,7 +949,7 @@ export default class ParticipantAPIService extends BullableService {
           .select([
             "ph.participant_id as id",
             "ph.schema_id",
-            "ph.corporation",
+            "ph.corporation_id",
             "ph.did",
             "ph.validator_participant_id",
             "ph.role",
@@ -1009,7 +1010,7 @@ export default class ParticipantAPIService extends BullableService {
           .select([
             "ph.participant_id as id",
             "ph.schema_id",
-            "ph.corporation",
+            "ph.corporation_id",
             "ph.did",
             "ph.validator_participant_id",
             "ph.role",
@@ -1078,7 +1079,7 @@ export default class ParticipantAPIService extends BullableService {
       .select([
         "id",
         "schema_id",
-        "corporation",
+        "corporation_id",
         "did",
         "validator_participant_id",
         "role",
@@ -1395,6 +1396,15 @@ export default class ParticipantAPIService extends BullableService {
         return ApiResponder.error(ctx, corporationValidation.error, 400);
       }
       const corporationFilter = corporationValidation.value;
+      // VPR v4: resolve the account-address filter to the canonical corporation_id.
+      let corporationIdFilter: number | undefined;
+      if (corporationFilter) {
+        const resolvedCorpId = await resolveCorporationIdByAddress(corporationFilter);
+        if (resolvedCorpId === null) {
+          return ApiResponder.success(ctx, { participants: [] }, 200);
+        }
+        corporationIdFilter = resolvedCorpId;
+      }
 
       const typeOpValidation = this.normalizeAndValidateTypeAndOpState(p);
       if (!typeOpValidation.ok) {
@@ -1485,7 +1495,7 @@ export default class ParticipantAPIService extends BullableService {
         const historyColumns: any[] = [
           "ph.participant_id as id",
           "ph.schema_id",
-          "ph.corporation",
+          "ph.corporation_id",
           "ph.did",
           "ph.validator_participant_id",
           "ph.role",
@@ -1555,7 +1565,7 @@ export default class ParticipantAPIService extends BullableService {
               this.applyBaseListFiltersToQuery(
                 qb,
                 normalizedParams,
-                corporationFilter,
+                corporationIdFilter,
                 modifiedAfterIso,
                 whenIso,
                 onlyValid,
@@ -1602,7 +1612,7 @@ export default class ParticipantAPIService extends BullableService {
               this.applyBaseListFiltersToQuery(
                 qb,
                 normalizedParams,
-                corporationFilter,
+                corporationIdFilter,
                 modifiedAfterIso,
                 whenIso,
                 onlyValid,
@@ -1667,7 +1677,7 @@ export default class ParticipantAPIService extends BullableService {
           const participant: any = {
             id: Number(historyRecord.id),
             schema_id: Number(historyRecord.schema_id),
-            corporation: historyRecord.corporation,
+            corporation_id: Number(historyRecord.corporation_id ?? 0) || 0,
             did: historyRecord.did,
             validator_participant_id: historyRecord.validator_participant_id ? Number(historyRecord.validator_participant_id) : null,
             role: historyRecord.role !== undefined && historyRecord.role !== null ? mapParticipantType(historyRecord.role) : historyRecord.role,
@@ -1790,7 +1800,7 @@ export default class ParticipantAPIService extends BullableService {
         "schema_id",
         "role",
         "did",
-        "corporation",
+        "corporation_id",
         "created",
         "modified",
         "slashed",
@@ -1876,7 +1886,7 @@ export default class ParticipantAPIService extends BullableService {
       this.applyBaseListFiltersToQuery(
         query,
         normalizedParams,
-        corporationFilter,
+        corporationIdFilter,
         modifiedAfterIso,
         whenIso,
         onlyValid,
@@ -2045,7 +2055,7 @@ export default class ParticipantAPIService extends BullableService {
         const selectColumns: any[] = [
           "participant_id",
           "schema_id",
-          "corporation",
+          "corporation_id",
           "did",
           "validator_participant_id",
           "role",
@@ -2110,7 +2120,7 @@ export default class ParticipantAPIService extends BullableService {
         const historicalParticipant: any = {
           id: Number(historyRecord.participant_id),
           schema_id: Number(historyRecord.schema_id),
-          corporation: historyRecord.corporation,
+          corporation_id: Number(historyRecord.corporation_id ?? 0) || 0,
           did: historyRecord.did,
           validator_participant_id: historyRecord.validator_participant_id ? Number(historyRecord.validator_participant_id) : null,
           role: historyRecord.role !== undefined && historyRecord.role !== null ? mapParticipantType(historyRecord.role) : historyRecord.role,
@@ -2530,7 +2540,7 @@ export default class ParticipantAPIService extends BullableService {
             .distinctOn("psh.session_id")
             .select(
               "psh.session_id as id",
-              "psh.corporation",
+              "psh.corporation_id",
               "psh.vs_operator",
               "psh.agent_participant_id",
               "psh.session_records",
@@ -2548,7 +2558,7 @@ export default class ParticipantAPIService extends BullableService {
           const ranked = knex("participant_session_history as psh")
             .select(
               "psh.session_id as id",
-              "psh.corporation",
+              "psh.corporation_id",
               "psh.vs_operator",
               "psh.agent_participant_id",
               "psh.session_records",
@@ -2623,6 +2633,11 @@ export default class ParticipantAPIService extends BullableService {
         return ApiResponder.error(ctx, accountValidation.error, 400);
       }
       const account = accountValidation.value;
+      // VPR v4: validator ownership is corporation-based; resolve the account once.
+      const accountCorpId = await resolveCorporationIdByAddress(account);
+      if (accountCorpId === null) {
+        return ApiResponder.success(ctx, { ecosystems: [] }, 200);
+      }
 
       const sortParam = p.sort ?? "-modified";
       try {
@@ -2652,7 +2667,7 @@ export default class ParticipantAPIService extends BullableService {
             )
           )
           .whereRaw("height <= ?", [Number(blockHeight)])
-          .andWhere("corporation", account)
+          .andWhere("corporation_id", accountCorpId)
           .whereIn("role", validatorParentTypeList)
           .as("ranked_parent");
 
@@ -2669,7 +2684,7 @@ export default class ParticipantAPIService extends BullableService {
 
       const validatorParentIdsSubquery = knex("participants")
         .select("id")
-        .where("corporation", account)
+        .where("corporation_id", accountCorpId)
         .whereIn("role", validatorParentTypeList);
 
       if (!useHistory) {
@@ -2684,7 +2699,7 @@ export default class ParticipantAPIService extends BullableService {
         "schema_id",
         "role",
         "did",
-        "corporation",
+        "corporation_id",
         "created",
         "modified",
         "slashed",
@@ -2728,7 +2743,7 @@ export default class ParticipantAPIService extends BullableService {
           )
           .whereRaw("height <= ?", [Number(blockHeight)])
           .where((qb) => {
-            qb.where("corporation", account);
+            qb.where("corporation_id", accountCorpId);
             qb.orWhereIn("validator_participant_id", parentIdsAtHeightSubquery!.clone());
           })
           .as("ranked");
@@ -2743,7 +2758,7 @@ export default class ParticipantAPIService extends BullableService {
           .select(
             "ph.participant_id",
             "ph.schema_id",
-            "ph.corporation",
+            "ph.corporation_id",
             "ph.did",
             "ph.validator_participant_id",
             "ph.role",
@@ -2796,7 +2811,7 @@ export default class ParticipantAPIService extends BullableService {
         const rows = await knex("participants")
           .select(baseColumns)
           .where((qb) => {
-            qb.where("corporation", account);
+            qb.where("corporation_id", accountCorpId);
             qb.orWhereIn("validator_participant_id", validatorParentIdsSubquery.clone());
           })
           .limit(fetchLimit);
@@ -2812,7 +2827,7 @@ export default class ParticipantAPIService extends BullableService {
 
       const enriched = await this.batchEnrichParticipants(participantsAtHeight, useHistory ? blockHeight : undefined, now, 50);
       const filtered = enriched.filter((participant: any) => {
-        if (participant.corporation === account) {
+        if (Number(participant.corporation_id ?? 0) === accountCorpId) {
           if (pendingFlatMatchesOpPendingWithEligibleParticipantState(participant)) return true;
           if (participant.participant_state === "SLASHED") return true;
           if (participant.participant_state === "ACTIVE" && participant.expire_soon === true) return true;

--- a/src/services/crawl-pp/pp_database.service.ts
+++ b/src/services/crawl-pp/pp_database.service.ts
@@ -7,6 +7,11 @@ import { SERVICE, ModulesParamsNamesTypes } from "../../common";
 import getGlobalVariables from "../../common/utils/global_variables";
 import { mapParticipantType } from "../../common/utils/utils";
 import { extractController, requireController } from "../../common/utils/extract_controller";
+import {
+  resolveCorporationIdByAddress,
+  resolveCorporationIdForMessage,
+  resolveAddressByCorporationId,
+} from "../crawl-co/corporation_resolve";
 import { calculateParticipantState } from "./pp_state_utils";
 import { CS_STATS_FIELDS, statsToUpdateObject } from "../../common/utils/stats_fields";
 import { calculateCredentialSchemaStats } from "../crawl-cs/cs_stats";
@@ -32,7 +37,7 @@ const PARTICIPANT_HISTORY_FIELDS = [
   "schema_id",
   "role",
   "did",
-  "corporation",
+  "corporation_id",
   "created",
   "modified",
   "slashed",
@@ -92,7 +97,7 @@ const PARTICIPANT_ROLE_HISTORY_FIELDS = [
 ] as const;
 
 const PARTICIPANT_SESSION_HISTORY_FIELDS = [
-  "corporation",
+  "corporation_id",
   "vs_operator",
   "agent_participant_id",
   "wallet_agent_participant_id",
@@ -110,6 +115,17 @@ const PARTICIPANT_HISTORY_V4_FIELDS = [
   "vs_operator_authz_fee_spend_limit",
   "vs_operator_authz_spend_period",
 ] as const;
+
+async function callerOwnsCorporation(
+  corporationId: number | null | undefined,
+  callerAddress: string | null | undefined,
+  db: Knex | Knex.Transaction = knex
+): Promise<boolean> {
+  const corpId = Number(corporationId ?? 0) || 0;
+  if (corpId <= 0 || !callerAddress) return false;
+  const callerCorpId = await resolveCorporationIdByAddress(callerAddress, db);
+  return callerCorpId !== null && callerCorpId === corpId;
+}
 
 function normalizeValue(value: any) {
   if (value === undefined) return null;
@@ -702,8 +718,10 @@ export default class ParticipantIngestService extends Service {
           params: { schema_id: "number", corporation: "string", role: "string" },
           handler: async (ctx) => {
             const { schema_id: schemaId, corporation, role } = ctx.params;
+            const corporationId = await resolveCorporationIdByAddress(corporation);
+            if (corporationId === null) return undefined;
             return await knex("participants")
-              .where({ schema_id: schemaId, corporation, role })
+              .where({ schema_id: schemaId, corporation_id: corporationId, role })
               .first();
           },
         },
@@ -717,8 +735,11 @@ export default class ParticipantIngestService extends Service {
             let query = knex("participants");
             if (ctx.params.schema_id)
               query = query.where("schema_id", ctx.params.schema_id);
-            if (ctx.params.corporation)
-              query = query.where("corporation", ctx.params.corporation);
+            if (ctx.params.corporation) {
+              const corporationId = await resolveCorporationIdByAddress(ctx.params.corporation);
+              if (corporationId === null) return [];
+              query = query.where("corporation_id", corporationId);
+            }
             if (ctx.params.role) query = query.where("role", ctx.params.role);
             return await query;
           },
@@ -804,14 +825,15 @@ export default class ParticipantIngestService extends Service {
     const schemaId = Number(ledgerParticipant.schema_id ?? ledgerParticipant.schemaId);
     const nowIso = new Date().toISOString();
 
-    const corporation = String(ledgerParticipant.corporation ?? "").trim();
+    const corporationId =
+      Number(ledgerParticipant.corporation_id ?? ledgerParticipant.corporationId ?? 0) || 0;
 
     return {
       id,
       schema_id: schemaId,
       role: normalizeParticipantType(ledgerParticipant.role),
       did: ledgerParticipant.did ?? null,
-      corporation,
+      corporation_id: corporationId,
       created: toIsoOrNull(ledgerParticipant.created) ?? nowIso,
       modified: toIsoOrNull(ledgerParticipant.modified) ?? nowIso,
       slashed: toIsoOrNull(ledgerParticipant.slashed),
@@ -867,6 +889,7 @@ export default class ParticipantIngestService extends Service {
 
     await db.raw(`
       ALTER TABLE IF EXISTS participants
+        ADD COLUMN IF NOT EXISTS corporation_id bigint NOT NULL DEFAULT 0,
         ADD COLUMN IF NOT EXISTS vs_operator text,
         ADD COLUMN IF NOT EXISTS adjusted timestamptz,
         ADD COLUMN IF NOT EXISTS vs_operator_authz_enabled boolean NOT NULL DEFAULT false,
@@ -1157,7 +1180,7 @@ export default class ParticipantIngestService extends Service {
             if (schema?.ecosystem_id) {
               const ec = await trx("ecosystem").where({ id: schema.ecosystem_id }).first();
               const slashedBy = ledgerParticipant.slashed_by;
-              if (ec?.corporation && slashedBy === ec.corporation) {
+              if (await callerOwnsCorporation(ec?.corporation_id, slashedBy, trx)) {
                 isEcosystemSlash = true;
               } else {
                 isNetworkSlash = true;
@@ -1265,7 +1288,8 @@ export default class ParticipantIngestService extends Service {
 
       const mappedSession: any = {
         id,
-        corporation: ledgerSession?.corporation ?? null,
+        corporation_id:
+          Number(ledgerSession?.corporation_id ?? ledgerSession?.corporationId ?? 0) || 0,
         vs_operator: ledgerSession?.vs_operator ?? ledgerSession?.vsOperator ?? null,
         agent_participant_id: Number(ledgerSession?.agent_participant_id ?? ledgerSession?.agentParticipantId ?? 0) || 0,
         wallet_agent_participant_id: Number(ledgerSession?.wallet_agent_participant_id ?? ledgerSession?.walletAgentParticipantId ?? 0) || 0,
@@ -1545,7 +1569,7 @@ export default class ParticipantIngestService extends Service {
       schema_id: Number(record.schema_id ?? record.schemaId ?? 0) || 0,
       role: normalizeParticipantType(record.role),
       did: record.did ?? null,
-      corporation: record.corporation ?? null,
+      corporation_id: Number(record.corporation_id ?? record.corporationId ?? 0) || 0,
       created: this.normalizeComparableTimestamp(record.created),
       modified: this.normalizeComparableTimestamp(record.modified),
       adjusted: this.normalizeComparableTimestamp(record.adjusted),
@@ -1592,7 +1616,7 @@ export default class ParticipantIngestService extends Service {
 
     return {
       id: String(record.id ?? record.session_id ?? ""),
-      corporation: record.corporation ?? null,
+      corporation_id: Number(record.corporation_id ?? record.corporationId ?? 0) || 0,
       vs_operator: record.vs_operator ?? record.vsOperator ?? null,
       agent_participant_id: Number(record.agent_participant_id ?? record.agentParticipantId ?? 0) || 0,
       wallet_agent_participant_id: Number(record.wallet_agent_participant_id ?? record.walletAgentParticipantId ?? 0) || 0,
@@ -1705,7 +1729,7 @@ export default class ParticipantIngestService extends Service {
 
       }
 
-      const creator = requireController(msg, `PP CREATE_ROOT ${schemaId}`);
+      const corporationId = await resolveCorporationIdForMessage(msg);
       const timestamp = msg?.timestamp ? formatTimestamp(msg.timestamp) : null;
       const effectiveFromRaw = pickMessageValue(msg as any, "effective_from", "effectiveFrom");
       const effectiveUntilRaw = pickMessageValue(msg as any, "effective_until", "effectiveUntil");
@@ -1737,7 +1761,7 @@ export default class ParticipantIngestService extends Service {
         role: participantType,
         op_state: "VALIDATION_STATE_UNSPECIFIED",
         did: msg.did,
-        corporation: creator,
+        corporation_id: corporationId,
         effective_from: effectiveFrom,
         effective_until: effectiveUntil,
         validation_fees: Number(pickMessageValue(msg as any, "validation_fees", "validationFees") ?? 0),
@@ -1875,7 +1899,7 @@ export default class ParticipantIngestService extends Service {
         );
       }
 
-      const creator = requireController(msg, `PP CREATE ${schemaId}`);
+      const corporationId = await resolveCorporationIdForMessage(msg);
       const timestamp = msg?.timestamp ? formatTimestamp(msg.timestamp) : null;
       const effectiveFromRaw = pickMessageValue(msg as any, "effective_from", "effectiveFrom");
       const effectiveUntilRaw = pickMessageValue(msg as any, "effective_until", "effectiveUntil");
@@ -1906,7 +1930,7 @@ export default class ParticipantIngestService extends Service {
         role,
         op_state: "VALIDATION_STATE_UNSPECIFIED",
         did: msg.did,
-        corporation: creator,
+        corporation_id: corporationId,
         effective_from: effectiveFrom,
         effective_until: effectiveUntil,
         verification_fees: Number(pickMessageValue(msg as any, "verification_fees", "verificationFees") ?? 0),
@@ -2039,16 +2063,18 @@ export default class ParticipantIngestService extends Service {
       }
 
       const caller = extractController(msg as unknown as Record<string, unknown>);
+      // VPR v4: ownership compares by corporation_id; resolve the caller account once.
+      const callerCorpId = await resolveCorporationIdByAddress(caller ?? null);
 
       let authorized = false;
-      if (applicantParticipant.validator_participant_id) {
+      if (callerCorpId !== null && applicantParticipant.validator_participant_id) {
         let validatorParticipantId = applicantParticipant.validator_participant_id;
         while (validatorParticipantId) {
           const validatorParticipant = await knex("participants")
             .where({ id: validatorParticipantId })
             .first();
           if (!validatorParticipant) break;
-          if (validatorParticipant.corporation === caller) {
+          if (Number(validatorParticipant.corporation_id ?? 0) === callerCorpId) {
             authorized = true;
             break;
           }
@@ -2056,7 +2082,7 @@ export default class ParticipantIngestService extends Service {
         }
       }
 
-      if (!authorized) {
+      if (!authorized && callerCorpId !== null) {
         const cs = await knex("credential_schemas")
           .where({ id: applicantParticipant.schema_id })
           .first();
@@ -2064,14 +2090,14 @@ export default class ParticipantIngestService extends Service {
           const ec = await knex("ecosystem")
             .where({ id: cs.ecosystem_id })
             .first();
-          if (ec?.corporation === caller) {
+          if (Number(ec?.corporation_id ?? 0) === callerCorpId) {
             authorized = true;
           }
         }
       }
 
-      if (!authorized) {
-        if (applicantParticipant.corporation === caller) {
+      if (!authorized && callerCorpId !== null) {
+        if (Number(applicantParticipant.corporation_id ?? 0) === callerCorpId) {
           authorized = true;
         }
       }
@@ -2189,7 +2215,7 @@ export default class ParticipantIngestService extends Service {
             : 0;
       }
 
-      const creator = requireController(msg, `PP START_OP ${validatorParticipantId}`);
+      const corporationId = await resolveCorporationIdForMessage(msg);
       const effectiveFromRaw = pickMessageValue(msg as any, "effective_from", "effectiveFrom");
       const effectiveUntilRaw = pickMessageValue(msg as any, "effective_until", "effectiveUntil");
       const effectiveFrom = effectiveFromRaw ? formatTimestamp(effectiveFromRaw) : null;
@@ -2216,7 +2242,7 @@ export default class ParticipantIngestService extends Service {
         schema_id: participant?.schema_id,
         role: typeStr,
         did: msg.did,
-        corporation: creator,
+        corporation_id: corporationId,
         effective_from: effectiveFrom,
         effective_until: effectiveUntil,
         verification_fees: Number(pickMessageValue(msg as any, "verification_fees", "verificationFees") ?? 0),
@@ -2631,11 +2657,9 @@ export default class ParticipantIngestService extends Service {
       }
 
       const caller = extractController(msg as unknown as Record<string, unknown>);
-      if (
-        caller &&
-        applicantParticipant.corporation &&
-        caller !== applicantParticipant.corporation
-      ) {
+      const callerCorpId = await resolveCorporationIdByAddress(caller ?? null);
+      const applicantCorpId = Number(applicantParticipant.corporation_id ?? 0) || 0;
+      if (caller && applicantCorpId > 0 && callerCorpId !== applicantCorpId) {
         this.logger.warn(`Caller ${caller} is not the participant corporation`);
         return { success: false, reason: "Caller is not corporation" };
       }
@@ -2768,7 +2792,9 @@ export default class ParticipantIngestService extends Service {
       }
 
       const caller = extractController(msg as unknown as Record<string, unknown>);
-      if (caller && participant.corporation && caller !== participant.corporation) {
+      const callerCorpId = await resolveCorporationIdByAddress(caller ?? null);
+      const participantCorpId = Number(participant.corporation_id ?? 0) || 0;
+      if (caller && participantCorpId > 0 && callerCorpId !== participantCorpId) {
         this.logger.warn(`Creator ${caller} is not participant corporation`);
         return { success: false, reason: "Creator is not corporation" };
       }
@@ -2887,19 +2913,20 @@ export default class ParticipantIngestService extends Service {
 
       let isAuthorized = false;
       const caller = extractController(msg as unknown as Record<string, unknown>);
+      const callerCorpId = await resolveCorporationIdByAddress(caller ?? null);
 
       let validatorParticipant = participant;
-      while (validatorParticipant && validatorParticipant.validator_participant_id) {
+      while (callerCorpId !== null && validatorParticipant && validatorParticipant.validator_participant_id) {
         validatorParticipant = await knex("participants")
           .where({ id: validatorParticipant.validator_participant_id })
           .first();
-        if (validatorParticipant && validatorParticipant.corporation === caller) {
+        if (validatorParticipant && Number(validatorParticipant.corporation_id ?? 0) === callerCorpId) {
           isAuthorized = true;
           break;
         }
       }
 
-      if (!isAuthorized && participant.schema_id) {
+      if (!isAuthorized && callerCorpId !== null && participant.schema_id) {
         const schema = await knex("credential_schemas")
           .where({ id: participant.schema_id })
           .first();
@@ -2907,7 +2934,7 @@ export default class ParticipantIngestService extends Service {
           const ec = await knex("ecosystem")
             .where({ id: schema.ecosystem_id })
             .first();
-          if (ec && ec.corporation === caller) {
+          if (ec && Number(ec.corporation_id ?? 0) === callerCorpId) {
             isAuthorized = true;
           }
         }
@@ -2954,17 +2981,18 @@ export default class ParticipantIngestService extends Service {
             classificationReason = `EC ${schema.ecosystem_id} not found`;
             trController = null;
           } else {
-            trController = ec.corporation || null;
-            if (!trController) {
-              this.logger.warn(`[Slash] Participant ${msg.id} EC ${schema.ecosystem_id} exists but has no corporation field`);
-              classificationReason = `EC ${schema.ecosystem_id} has no corporation`;
-            } else if (ec.corporation === caller) {
+            const ecCorpId = Number(ec.corporation_id ?? 0) || 0;
+            trController = ecCorpId > 0 ? String(ecCorpId) : null;
+            if (!ecCorpId) {
+              this.logger.warn(`[Slash] Participant ${msg.id} EC ${schema.ecosystem_id} exists but has no corporation_id`);
+              classificationReason = `EC ${schema.ecosystem_id} has no corporation_id`;
+            } else if (callerCorpId !== null && ecCorpId === callerCorpId) {
               isEcosystemSlash = true;
-              classificationReason = `Slashed by EC corporation ${caller}`;
-              this.logger.info(`[Slash] Participant ${msg.id} slashed by EC corporation ${caller} - marking as ecosystem slash`);
+              classificationReason = `Slashed by EC corporation_id ${ecCorpId}`;
+              this.logger.info(`[Slash] Participant ${msg.id} slashed by EC corporation_id ${ecCorpId} - marking as ecosystem slash`);
             } else {
-              this.logger.warn(`[Slash] Participant ${msg.id} slashed by ${caller} but EC corporation is ${ec.corporation} - no slash type determined`);
-              classificationReason = `Caller ${caller} != EC corporation ${ec.corporation}`;
+              this.logger.warn(`[Slash] Participant ${msg.id} slashed by ${caller} (corporation_id ${callerCorpId ?? "none"}) but EC corporation_id is ${ecCorpId} - no slash type determined`);
+              classificationReason = `Caller corporation_id ${callerCorpId ?? "none"} != EC corporation_id ${ecCorpId}`;
             }
           }
         }
@@ -3064,8 +3092,11 @@ export default class ParticipantIngestService extends Service {
       });
 
       try {
-        const schema = await knex("participants").where({ id: msg.id }).first();
-        const corporation = schema?.corporation;
+        const slashed = await knex("participants").where({ id: msg.id }).first();
+        // TrustDeposit is still address-based: resolve the owner's policy address.
+        const corporation = await resolveAddressByCorporationId(
+          Number(slashed?.corporation_id ?? 0) || 0
+        );
         if (corporation) {
           await (this as any).broker.call(
             `${SERVICE.V1.TrustDepositDatabaseService.path}.slash_participant_trust_deposit`,
@@ -3163,6 +3194,7 @@ export default class ParticipantIngestService extends Service {
       let classificationReason = '';
 
       const repayer = extractController(msg as unknown as Record<string, unknown>);
+      const repayerCorpId = await resolveCorporationIdByAddress(repayer ?? null);
 
       if (isEcosystemParticipant) {
         isEcosystemSlash = true;
@@ -3188,15 +3220,16 @@ export default class ParticipantIngestService extends Service {
             classificationReason = `EC ${schema.ecosystem_id} not found`;
             trController = null;
           } else {
-            trController = ec.corporation || null;
-            if (!trController) {
-              this.logger.warn(`[Repay] Participant ${msg.id} EC ${schema.ecosystem_id} has no corporation`);
-              classificationReason = `EC ${schema.ecosystem_id} has no corporation`;
-            } else if (repayer && ec.corporation === repayer) {
+            const ecCorpId = Number(ec.corporation_id ?? 0) || 0;
+            trController = ecCorpId > 0 ? String(ecCorpId) : null;
+            if (!ecCorpId) {
+              this.logger.warn(`[Repay] Participant ${msg.id} EC ${schema.ecosystem_id} has no corporation_id`);
+              classificationReason = `EC ${schema.ecosystem_id} has no corporation_id`;
+            } else if (repayerCorpId !== null && ecCorpId === repayerCorpId) {
               isEcosystemSlash = true;
-              classificationReason = `Repay by EC corporation ${repayer}`;
+              classificationReason = `Repay by EC corporation_id ${ecCorpId}`;
             } else {
-              classificationReason = `Repayer ${repayer || "unknown"} != EC corporation ${ec.corporation}`;
+              classificationReason = `Repayer corporation_id ${repayerCorpId ?? "none"} != EC corporation_id ${ecCorpId}`;
             }
           }
         }
@@ -3867,11 +3900,11 @@ export default class ParticipantIngestService extends Service {
         (msg as any).vs_operator ?? (msg as any).vsOperator ?? (msg as any).operator ?? existing?.vs_operator ?? null;
 
       if (!existing) {
-        const creator = requireController(msg, `PP SESSION ${msg.id}`);
+        const corporationId = await resolveCorporationIdForMessage(msg);
         const [session] = await trx("participant_sessions")
           .insert({
             id: msg.id,
-            corporation: creator,
+            corporation_id: corporationId,
             vs_operator: vsOp,
             agent_participant_id: agentParticipantId,
             wallet_agent_participant_id: walletAgentParticipantId,

--- a/src/services/metrics/metrics_api.service.ts
+++ b/src/services/metrics/metrics_api.service.ts
@@ -408,7 +408,7 @@ export default class MetricsApiService extends BaseService {
           .distinctOn("ph.participant_id")
           .select(
             "ph.participant_id",
-            "ph.corporation",
+            "ph.corporation_id",
             "ph.role",
             "ph.repaid",
             "ph.slashed",
@@ -425,7 +425,7 @@ export default class MetricsApiService extends BaseService {
         : knex("participant_history as ph")
           .select(
             "ph.participant_id",
-            "ph.corporation",
+            "ph.corporation_id",
             "ph.role",
             "ph.repaid",
             "ph.slashed",
@@ -442,7 +442,7 @@ export default class MetricsApiService extends BaseService {
         .modify((qb) => {
           if (!IS_PG_CLIENT) qb.where("rn", 1);
         })
-        .whereNotNull("corporation")
+        .where("corporation_id", ">", 0)
         .whereNull("repaid")
         .whereNull("slashed")
         .where((qb) => qb.whereNull("revoked").orWhere("revoked", ">=", nowIso))
@@ -456,25 +456,25 @@ export default class MetricsApiService extends BaseService {
         participantsAgg = await activeParticipantBaseQuery
           .clone()
           .select(
-            knex.raw("COUNT(DISTINCT corporation) as participants"),
-            knex.raw("COUNT(DISTINCT corporation) FILTER (WHERE role = 'ECOSYSTEM') as participants_ecosystem"),
-            knex.raw("COUNT(DISTINCT corporation) FILTER (WHERE role = 'ISSUER_GRANTOR') as participants_issuer_grantor"),
-            knex.raw("COUNT(DISTINCT corporation) FILTER (WHERE role = 'ISSUER') as participants_issuer"),
-            knex.raw("COUNT(DISTINCT corporation) FILTER (WHERE role = 'VERIFIER_GRANTOR') as participants_verifier_grantor"),
-            knex.raw("COUNT(DISTINCT corporation) FILTER (WHERE role = 'VERIFIER') as participants_verifier"),
-            knex.raw("COUNT(DISTINCT corporation) FILTER (WHERE role = 'HOLDER') as participants_holder")
+            knex.raw("COUNT(DISTINCT corporation_id) as participants"),
+            knex.raw("COUNT(DISTINCT corporation_id) FILTER (WHERE role = 'ECOSYSTEM') as participants_ecosystem"),
+            knex.raw("COUNT(DISTINCT corporation_id) FILTER (WHERE role = 'ISSUER_GRANTOR') as participants_issuer_grantor"),
+            knex.raw("COUNT(DISTINCT corporation_id) FILTER (WHERE role = 'ISSUER') as participants_issuer"),
+            knex.raw("COUNT(DISTINCT corporation_id) FILTER (WHERE role = 'VERIFIER_GRANTOR') as participants_verifier_grantor"),
+            knex.raw("COUNT(DISTINCT corporation_id) FILTER (WHERE role = 'VERIFIER') as participants_verifier"),
+            knex.raw("COUNT(DISTINCT corporation_id) FILTER (WHERE role = 'HOLDER') as participants_holder")
           )
           .first();
       } else {
         participantsAgg = await activeParticipantBaseQuery
           .clone()
-          .countDistinct("corporation as participants")
+          .countDistinct("corporation_id as participants")
           .first();
         participantsByTypeAgg = await activeParticipantBaseQuery
           .clone()
           .groupBy("role")
           .select("role")
-          .countDistinct("corporation as participants");
+          .countDistinct("corporation_id as participants");
       }
 
       const participantsByType = {

--- a/src/services/metrics/metrics_helper.ts
+++ b/src/services/metrics/metrics_helper.ts
@@ -359,7 +359,7 @@ export async function computeGlobalMetrics(blockHeight?: number) {
     const participantParticipantCol = await resolveParticipantsParticipantColumn(knex);
     const activeParticipantsBase = () =>
       knex("participants")
-        .whereNotNull(participantParticipantCol)
+        .where(participantParticipantCol, ">", 0)
         .whereNull("repaid")
         .whereNull("slashed")
         .andWhere(function () {
@@ -542,7 +542,8 @@ export async function computeGlobalMetrics(blockHeight?: number) {
       },
       asOfTime
     );
-    const corp = (historyRecord as { corporation?: string }).corporation;
+    const corpId = Number((historyRecord as { corporation_id?: number }).corporation_id ?? 0) || 0;
+    const corp = corpId > 0 ? String(corpId) : "";
     if (participantState === "ACTIVE" && corp) {
       allParticipantsSet.add(corp);
       if (historyRecord.role === "ECOSYSTEM") participantsEcosystemSet.add(corp);

--- a/test/unit/services/api/indexer_snapshot.service.spec.ts
+++ b/test/unit/services/api/indexer_snapshot.service.spec.ts
@@ -43,7 +43,7 @@ describe("IndexerSnapshotService snapshot endpoint", () => {
       await knex.schema.createTable("ecosystem", (table) => {
         table.increments("id").primary();
         table.string("did").notNullable();
-        table.string("corporation").notNullable();
+        table.bigInteger("corporation_id").notNullable().defaultTo(0);
         table.timestamp("created").notNullable();
         table.timestamp("modified").notNullable();
         table.timestamp("archived").nullable();
@@ -85,7 +85,7 @@ describe("IndexerSnapshotService snapshot endpoint", () => {
         table.integer("schema_id").notNullable();
         table.string("role").nullable();
         table.string("did").nullable();
-        table.string("corporation").nullable();
+        table.bigInteger("corporation_id").notNullable().defaultTo(0);
       });
       createdTables.push("participants");
     }
@@ -98,11 +98,11 @@ describe("IndexerSnapshotService snapshot endpoint", () => {
     }
   });
 
-  async function insertEcosystem(args: { did: string; corporation: string; height: number }): Promise<number> {
+  async function insertEcosystem(args: { did: string; corporationId: number; height: number }): Promise<number> {
     const [idRow] = await knex("ecosystem")
       .insert({
       did: args.did,
-      corporation: args.corporation,
+      corporation_id: args.corporationId,
       created: createdAt,
       modified: createdAt,
       archived: null,
@@ -163,13 +163,13 @@ describe("IndexerSnapshotService snapshot endpoint", () => {
     return schemaRowId;
   }
 
-  async function insertParticipant(args: { schemaId: number; did?: string | null; corporation: string }): Promise<number> {
+  async function insertParticipant(args: { schemaId: number; did?: string | null; corporationId: number }): Promise<number> {
     const [idRow] = await knex("participants")
       .insert({
         schema_id: args.schemaId,
         role: "ISSUER",
         did: args.did ?? null,
-        corporation: args.corporation,
+        corporation_id: args.corporationId,
       })
       .returning("id");
     const participantRowId = Number(typeof idRow === "object" ? (idRow as any).id : idRow);
@@ -250,9 +250,9 @@ describe("IndexerSnapshotService snapshot endpoint", () => {
 
   it("returns DID-linked snapshot objects from current tables", async () => {
     const schemaIdSeed = 88000000 + Math.floor(Math.random() * 100000);
-    const ecosystemId = await insertEcosystem({ did: didA, corporation: "cosmos1corp", height: baseHeight });
+    const ecosystemId = await insertEcosystem({ did: didA, corporationId: 1, height: baseHeight });
     const schemaRowId = await insertCredentialSchema({ schemaId: schemaIdSeed, ecosystemId });
-    await insertParticipant({ schemaId: schemaRowId + 100000, did: didA, corporation: "cosmos1other-corp" });
+    await insertParticipant({ schemaId: schemaRowId + 100000, did: didA, corporationId: 999 });
 
     const snap = await getDidSnapshotAtHeight({ did: didA, blockHeight: baseHeight });
     expect(snap.count.ecosystems).toBe(1);
@@ -264,9 +264,9 @@ describe("IndexerSnapshotService snapshot endpoint", () => {
 
   it("returns schema-linked participants", async () => {
     const schemaIdSeed = 88000000 + Math.floor(Math.random() * 100000);
-    const ecosystemId = await insertEcosystem({ did: didA, corporation: "cosmos1corp", height: baseHeight });
+    const ecosystemId = await insertEcosystem({ did: didA, corporationId: 1, height: baseHeight });
     const schemaRowId = await insertCredentialSchema({ schemaId: schemaIdSeed, ecosystemId });
-    await insertParticipant({ schemaId: schemaRowId, did: otherDid, corporation: "cosmos1other-corp" });
+    await insertParticipant({ schemaId: schemaRowId, did: otherDid, corporationId: 999 });
 
     const snap = await getDidSnapshotAtHeight({ did: didA, blockHeight: baseHeight });
     expect(snap.count.participants).toBe(1);
@@ -274,16 +274,16 @@ describe("IndexerSnapshotService snapshot endpoint", () => {
     expect(snap.participants[0]?.did).toBe(otherDid);
   });
 
-  it("returns corporation-linked participants from derived corporation addresses", async () => {
+  it("returns corporation-linked participants from derived corporation_id", async () => {
     const schemaIdSeed = 88000000 + Math.floor(Math.random() * 100000);
-    const corporation = "cosmos1derived-corp";
-    const ecosystemId = await insertEcosystem({ did: didA, corporation, height: baseHeight });
+    const corporationId = 4242;
+    const ecosystemId = await insertEcosystem({ did: didA, corporationId, height: baseHeight });
     const schemaRowId = await insertCredentialSchema({ schemaId: schemaIdSeed, ecosystemId });
-    await insertParticipant({ schemaId: schemaRowId + 100000, did: null, corporation });
+    await insertParticipant({ schemaId: schemaRowId + 100000, did: null, corporationId });
 
     const snap = await getDidSnapshotAtHeight({ did: didA, blockHeight: baseHeight });
     expect(snap.count.participants).toBe(1);
-    expect(snap.participants[0]?.corporation).toBe(corporation);
+    expect(Number(snap.participants[0]?.corporation_id)).toBe(corporationId);
     expect(snap.participants[0]?.schema_id).not.toBe(schemaRowId);
   });
 });

--- a/test/unit/services/crawl-ec/ec_processor.spec.ts
+++ b/test/unit/services/crawl-ec/ec_processor.spec.ts
@@ -58,6 +58,7 @@ describe("EcosystemMessageProcessorService Tests", () => {
         content: {
           did: "did:example:insert",
           creator: "creator_test",
+          corporation_id: 1,
           aka: "Test EC",
           language: "en",
           height,
@@ -76,7 +77,7 @@ describe("EcosystemMessageProcessorService Tests", () => {
       .where({ did: "did:example:insert" })
       .first();
     expect(ec).toBeDefined();
-    expect(ec.corporation).toBe("creator_test");
+    expect(Number(ec.corporation_id)).toBe(1);
 
     const gfv = await knex("governance_framework_version")
       .where({ ecosystem_id: ec.id })
@@ -116,7 +117,7 @@ describe("EcosystemMessageProcessorService Tests", () => {
     const [ecosystemId] = await knex("ecosystem")
       .insert({
         did: "did:example:update",
-        corporation: "creator_update",
+        corporation_id: 2,
         created: timestamp,
         modified: timestamp,
         aka: "Old EC",
@@ -174,7 +175,7 @@ describe("EcosystemMessageProcessorService Tests", () => {
     const [ecosystemId] = await knex("ecosystem")
       .insert({
         did: "did:example:archive",
-        corporation: "creator_archive",
+        corporation_id: 3,
         created: timestamp,
         modified: timestamp,
         aka: "EC Archive",

--- a/test/unit/services/crawl-pp/Pp_database_service.spec.ts
+++ b/test/unit/services/crawl-pp/Pp_database_service.spec.ts
@@ -7,6 +7,7 @@ import { formatTimestamp } from "../../../../src/common/utils/date_utils";
 jest.mock("../../../../src/common/utils/db_connection", () => {
   const mockQuery: any = jest.fn(() => mockQuery);
   mockQuery.where = jest.fn(() => mockQuery);
+  mockQuery.select = jest.fn(() => mockQuery);
   mockQuery.first = jest.fn(() => mockQuery);
   mockQuery.insert = jest.fn(() => mockQuery);
   mockQuery.update = jest.fn(() => mockQuery);
@@ -51,6 +52,7 @@ describe("🧪 ParticipantIngestService Unit Tests", () => {
         schema_id: 99,
         did: "did:test:123",
         creator: "grantee1",
+        corporation_id: 5,
         timestamp: "2025-10-08T00:00:00Z",
         effective_from: "2025-10-09T00:00:00Z",
         effective_until: "2025-12-31T00:00:00Z",
@@ -67,7 +69,7 @@ describe("🧪 ParticipantIngestService Unit Tests", () => {
           schema_id: 99,
           role: "ECOSYSTEM",
           did: "did:test:123",
-          corporation: "grantee1",
+          corporation_id: 5,
           validation_fees: 10,
           issuance_fees: 5,
           verification_fees: 2,
@@ -93,6 +95,7 @@ describe("🧪 ParticipantIngestService Unit Tests", () => {
         schema_id: 99,
         did: "did:test:123",
         creator: "issuer1",
+        corporation_id: 7,
         role: 1,
       };
 
@@ -102,7 +105,7 @@ describe("🧪 ParticipantIngestService Unit Tests", () => {
         expect.objectContaining({
           validator_participant_id: 1,
           schema_id: 99,
-          corporation: "issuer1",
+          corporation_id: 7,
         })
       );
     });
@@ -110,11 +113,11 @@ describe("🧪 ParticipantIngestService Unit Tests", () => {
 
   describe("handleRevokeParticipant", () => {
     it("should revoke participant if caller is grantee", async () => {
-      (knex.first as jest.Mock).mockResolvedValueOnce({
-        id: 10,
-        corporation: "user1",
-        schema_id: 1,
-      });
+      (knex.first as jest.Mock)
+        // applicant participant (owned by corporation_id 3)
+        .mockResolvedValueOnce({ id: 10, corporation_id: 3, schema_id: 1 })
+        // resolveCorporationIdByAddress("user1") -> corporation row id 3
+        .mockResolvedValueOnce({ id: 3 });
       (knex.transaction as jest.Mock).mockImplementation((fn) => fn(knex));
 
       const result = await service.handleRevokeParticipant({
@@ -163,26 +166,26 @@ describe("🧪 ParticipantIngestService Unit Tests", () => {
     });
   });
 
-  describe("mapLedgerParticipantToDbRow (VPR v4 corporation)", () => {
-    it("maps corporation from ledger", () => {
+  describe("mapLedgerParticipantToDbRow (VPR v4 corporation_id)", () => {
+    it("maps corporation_id from ledger", () => {
       const row = mapLedgerParticipantToDbRow({
         id: 1,
         schema_id: 2,
         role: "ECOSYSTEM",
         did: "did:example:x",
-        corporation: "verana1corp",
+        corporation_id: 7,
       });
-      expect(row.corporation).toBe("verana1corp");
+      expect(row.corporation_id).toBe(7);
     });
 
-    it("uses empty string when corporation is missing (NOT NULL column)", () => {
+    it("defaults corporation_id to 0 when missing (NOT NULL column)", () => {
       const row = mapLedgerParticipantToDbRow({
         id: 1,
         schema_id: 2,
         role: "ECOSYSTEM",
         did: "did:x",
       });
-      expect(row.corporation).toBe("");
+      expect(row.corporation_id).toBe(0);
     });
   });
 
@@ -207,7 +210,7 @@ describe("🧪 ParticipantIngestService Unit Tests", () => {
         schema_id: "48",
         role: "ISSUER",
         did: "did:test:issuer",
-        corporation: "verana1test",
+        corporation_id: 5,
         created: "2026-01-29T20:27:06.725Z",
         modified: "2026-01-29T20:27:23.422Z",
         effective_from: "2026-01-29T20:27:23.422Z",

--- a/test/unit/services/crawl-pp/Pp_database_service.spec.ts
+++ b/test/unit/services/crawl-pp/Pp_database_service.spec.ts
@@ -7,7 +7,6 @@ import { formatTimestamp } from "../../../../src/common/utils/date_utils";
 jest.mock("../../../../src/common/utils/db_connection", () => {
   const mockQuery: any = jest.fn(() => mockQuery);
   mockQuery.where = jest.fn(() => mockQuery);
-  mockQuery.select = jest.fn(() => mockQuery);
   mockQuery.first = jest.fn(() => mockQuery);
   mockQuery.insert = jest.fn(() => mockQuery);
   mockQuery.update = jest.fn(() => mockQuery);
@@ -114,9 +113,7 @@ describe("🧪 ParticipantIngestService Unit Tests", () => {
   describe("handleRevokeParticipant", () => {
     it("should revoke participant if caller is grantee", async () => {
       (knex.first as jest.Mock)
-        // applicant participant (owned by corporation_id 3)
         .mockResolvedValueOnce({ id: 10, corporation_id: 3, schema_id: 1 })
-        // resolveCorporationIdByAddress("user1") -> corporation row id 3
         .mockResolvedValueOnce({ id: 3 });
       (knex.transaction as jest.Mock).mockImplementation((fn) => fn(knex));
 

--- a/test/unit/services/crawl-pp/Pp_database_service.spec.ts
+++ b/test/unit/services/crawl-pp/Pp_database_service.spec.ts
@@ -7,6 +7,7 @@ import { formatTimestamp } from "../../../../src/common/utils/date_utils";
 jest.mock("../../../../src/common/utils/db_connection", () => {
   const mockQuery: any = jest.fn(() => mockQuery);
   mockQuery.where = jest.fn(() => mockQuery);
+  mockQuery.select = jest.fn(() => mockQuery);
   mockQuery.first = jest.fn(() => mockQuery);
   mockQuery.insert = jest.fn(() => mockQuery);
   mockQuery.update = jest.fn(() => mockQuery);

--- a/test/unit/services/crawl-pp/pending_flat.spec.ts
+++ b/test/unit/services/crawl-pp/pending_flat.spec.ts
@@ -5,6 +5,7 @@ import knex from "../../../../src/common/utils/db_connection";
 function createKnexChain() {
   const c: any = {};
   c.select = jest.fn(() => c);
+  c.first = jest.fn(() => Promise.resolve({ id: 1 }));
   c.where = jest.fn((fn: unknown) => {
     if (typeof fn === "function") {
       const qb = { where: jest.fn(() => qb), orWhereIn: jest.fn(() => qb) };

--- a/test/unit/services/crawl-pp/pending_flat.spec.ts
+++ b/test/unit/services/crawl-pp/pending_flat.spec.ts
@@ -5,7 +5,6 @@ import knex from "../../../../src/common/utils/db_connection";
 function createKnexChain() {
   const c: any = {};
   c.select = jest.fn(() => c);
-  c.first = jest.fn(() => Promise.resolve({ id: 1 }));
   c.where = jest.fn((fn: unknown) => {
     if (typeof fn === "function") {
       const qb = { where: jest.fn(() => qb), orWhereIn: jest.fn(() => qb) };


### PR DESCRIPTION
**Changes:**
- As part of the migration to verana-types `v0.10.1-dev.13`, Ecosystem/Participant ownership moved from the embedded corporation account address to the corporation_id (FK to Corporation.id). Updated the ingest, APIs, and slash/repay/authorization logic to resolve corporation_id accordingly.
- Updated the re-indexer process to support these changes.
- Updated the affected tests.