### PR TITLE
feat: implement idx vt sub 1 verifiable trust subscribe changes

### DIFF
--- a/src/services/api/api.service.ts
+++ b/src/services/api/api.service.ts
@@ -9,6 +9,7 @@ import { BULL_JOB_NAME, SERVICE } from "../../common";
 import knex from "../../common/utils/db_connection";
 import { swaggerUiComponent } from "./swagger_ui";
 import { subscribeBroadcaster } from "./subscribe_broadcaster";
+import { vtSubscribeBroadcaster } from "./vt_subscribe_broadcaster";
 import { indexerStatusManager } from "../manager/indexer_status.manager";
 import { isUnknownMessageError } from "./api_shared";
 
@@ -438,13 +439,17 @@ export default class ApiService extends BaseService {
       subscribeBroadcaster.setLogger(this.logger);
       subscribeBroadcaster.initialize(server);
       this.logger.info("WebSocket subscribe broadcaster initialized on /v4/indexer/subscribe");
+      vtSubscribeBroadcaster.setLogger(this.logger);
+      vtSubscribeBroadcaster.initialize(server);
+      this.logger.info("WebSocket subscribe broadcaster initialized on /v4/verifiable-trust/subscribe");
     } else {
-      this.logger.warn("HTTP server not found, WebSocket subscribe broadcaster not initialized");
+      this.logger.warn("HTTP server not found, WebSocket subscribe broadcasters not initialized");
     }
   }
 
   async stopped() {
     subscribeBroadcaster.close();
+    vtSubscribeBroadcaster.close();
     this.logger.info("🔌 WebSocket broadcasters closed");
   }
 }

--- a/src/services/api/api_shared.ts
+++ b/src/services/api/api_shared.ts
@@ -1,3 +1,5 @@
+import { uniqueNormalizedDids } from "./indexer_event_utils";
+
 export type LoggerLike = {
   info?: (...args: any[]) => void;
   warn?: (...args: any[]) => void;
@@ -38,8 +40,72 @@ export function applyBlockHeightFilter(
   return query;
 }
 
-export function toIsoSeconds(value: Date | string = new Date()): string {
-  const date = value instanceof Date ? value : new Date(value);
-  return date.toISOString().replace(/\.\d{3}Z$/, "Z");
+export function toIsoSeconds(value: Date | string | null | undefined = new Date()): string {
+  const date = value instanceof Date ? value : new Date(value ?? Date.now());
+  const safe = Number.isFinite(date.getTime()) ? date : new Date();
+  return safe.toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+export type SubscribeMembership = { dids: string[] | null; corporationId: number | null };
+
+export function parseCorporationId(
+  raw: unknown
+): { ok: true; value: number | null } | { ok: false; error: string } {
+  if (raw === undefined || raw === null) return { ok: true, value: null };
+  const n = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isInteger(n) || n <= 0) {
+    return { ok: false, error: `'corporationId' must be a positive integer; got ${String(raw)}` };
+  }
+  return { ok: true, value: n };
+}
+
+export function parseSubscribeMembership(
+  source: Record<string, unknown>
+): { ok: true; value: SubscribeMembership } | { ok: false; error: string } {
+  const corp = parseCorporationId(source.corporationId);
+  if (!corp.ok) return { ok: false, error: corp.error };
+  const corporationId = corp.value;
+
+  const rawDids = source.dids;
+  if (rawDids === undefined || rawDids === null) {
+    return { ok: true, value: { dids: null, corporationId } };
+  }
+  if (!Array.isArray(rawDids)) {
+    return { ok: false, error: "'dids' must be an array of DID strings" };
+  }
+  if (rawDids.length === 0) {
+    return { ok: true, value: { dids: null, corporationId } };
+  }
+  for (const candidate of rawDids) {
+    if (!isValidDid(candidate)) {
+      return { ok: false, error: `Invalid DID in 'dids': ${String(candidate)}` };
+    }
+  }
+  const normalized = uniqueNormalizedDids(rawDids);
+  if (normalized.length === 0) {
+    return { ok: false, error: "No valid DIDs after normalization" };
+  }
+  return { ok: true, value: { dids: normalized, corporationId } };
+}
+
+export type MembershipTarget = {
+  did: string;
+  relatedDids?: Iterable<string>;
+  corporationIds?: Iterable<number>;
+};
+
+export function matchesMembership(
+  dids: Set<string> | null,
+  corporationId: number | null,
+  target: MembershipTarget
+): boolean {
+  const didOk =
+    dids === null ||
+    dids.has(target.did) ||
+    (target.relatedDids ? [...target.relatedDids].some((d) => dids.has(d)) : false);
+  const corpOk =
+    corporationId === null ||
+    (target.corporationIds ? [...target.corporationIds].some((c) => c === corporationId) : false);
+  return didOk && corpOk;
 }
 

--- a/src/services/api/subscribe_broadcaster.ts
+++ b/src/services/api/subscribe_broadcaster.ts
@@ -1,12 +1,9 @@
-import { Server } from "http";
-import { WebSocket, WebSocketServer } from "ws";
-import { indexerStatusManager } from "../manager/indexer_status.manager";
 import type { IndexerEventRecord } from "./indexer_events_query";
-import { createLogger, toIsoSeconds, type LoggerLike } from "./api_shared";
+import { BaseSubscribeServer, type ControlParseResult } from "./subscribe_ws_server";
 import {
   buildBlockEnvelope,
-  buildReadyMessage,
   parseControlMessage,
+  type ControlMessage,
 } from "./subscribe_protocol";
 
 type ClientState = {
@@ -15,119 +12,27 @@ type ClientState = {
   corporationId: number | null;
 };
 
-export class SubscribeBroadcaster {
-  private wss: WebSocketServer | null = null;
-  private clients: Map<WebSocket, ClientState> = new Map();
-  private clientAlive: Map<WebSocket, boolean> = new Map();
-  private pingInterval: NodeJS.Timeout | null = null;
-  private readonly MAX_CLIENTS = 10000; // TODO: Review this values
-  private readonly PING_INTERVAL = 30000;
-  private readonly MAX_CONTROL_MESSAGE_BYTES = 64 * 1024;
-  private logger = createLogger(console);
+export class SubscribeBroadcaster extends BaseSubscribeServer<ControlMessage, ClientState> {
+  protected readonly path = "/v4/indexer/subscribe";
 
-  setLogger(logger: LoggerLike): void {
-    this.logger = createLogger(logger);
+  protected createInitialState(): ClientState {
+    return { established: false, dids: null, corporationId: null };
   }
 
-  initialize(server: Server): void {
-    if (this.wss) {
-      this.logger.warn("[SubscribeBroadcaster] WebSocket server already initialized");
-      return;
-    }
-
-    this.wss = new WebSocketServer({
-      server,
-      path: "/v4/indexer/subscribe",
-      perMessageDeflate: false,
-      maxPayload: this.MAX_CONTROL_MESSAGE_BYTES,
-      verifyClient: () => {
-        if (this.clients.size >= this.MAX_CLIENTS) {
-          this.logger.warn(
-            `[SubscribeBroadcaster] Max clients reached (${this.MAX_CLIENTS}), rejecting connection`
-          );
-          return false;
-        }
-        return true;
-      },
-    });
-
-    this.wss.on("connection", async (ws: WebSocket) => {
-      if (this.clients.size >= this.MAX_CLIENTS) {
-        ws.close(1013, "Server overloaded");
-        return;
-      }
-
-      this.clients.set(ws, { established: false, dids: null, corporationId: null });
-      this.clientAlive.set(ws, true);
-
-      this.logger.info(
-        `[SubscribeBroadcaster] New client connected. Total clients: ${this.clients.size}`
-      );
-
-      ws.on("close", () => this.cleanupClient(ws));
-      ws.on("error", (error) => {
-        this.logger.error("[SubscribeBroadcaster] WebSocket error:", error);
-        this.cleanupClient(ws);
-      });
-      ws.on("pong", () => {
-        this.clientAlive.set(ws, true);
-      });
-      ws.on("message", (raw) => this.handleControlMessage(ws, raw.toString()));
-
-      try {
-        await this.sendReady(ws);
-      } catch (error) {
-        this.logger.error("[SubscribeBroadcaster] Error sending ready message:", error);
-        this.cleanupClient(ws);
-      }
-    });
-
-    this.wss.on("error", (error) => {
-      this.logger.error("[SubscribeBroadcaster] WebSocketServer error:", error);
-    });
-
-    this.pingInterval = setInterval(() => {
-      this.pingClients();
-    }, this.PING_INTERVAL);
-
-    this.logger.info(
-      "[SubscribeBroadcaster] WebSocket server initialized on /v4/indexer/subscribe"
-    );
+  protected parseControl(raw: string): ControlParseResult<ControlMessage> {
+    return parseControlMessage(raw);
   }
 
-  private async sendReady(ws: WebSocket): Promise<void> {
-    const status = await indexerStatusManager.getDetailedStatus();
-    const lastProcessedBlock = status.lastProcessedBlock ?? 0;
-    const lastBlockTime = status.lastBlockTime ?? toIsoSeconds();
-    const ready = buildReadyMessage(lastProcessedBlock, lastBlockTime);
-    this.sendJson(ws, ready as unknown as Record<string, unknown>);
-  }
-
-  private handleControlMessage(ws: WebSocket, raw: string): void {
-    const result = parseControlMessage(raw);
-    if (!result.ok) {
-      this.logger.warn(`[SubscribeBroadcaster] Invalid control message: ${result.error}`);
-      try {
-        ws.close(1008, result.error);
-      } catch {
-      }
-      this.cleanupClient(ws);
-      return;
+  protected applyControl(_state: ClientState, message: ControlMessage): ClientState {
+    if (message.action === "unsubscribe") {
+      return { established: false, dids: null, corporationId: null };
     }
 
-    const state = this.clients.get(ws);
-    if (!state) return;
-
-    if (result.message.action === "unsubscribe") {
-      state.established = false;
-      state.dids = null;
-      state.corporationId = null;
-      return;
-    }
-
-    state.established = true;
-    state.dids = result.message.dids === null ? null : new Set(result.message.dids);
-    state.corporationId = result.message.corporationId;
+    return {
+      established: true,
+      dids: message.dids === null ? null : new Set(message.dids),
+      corporationId: message.corporationId,
+    };
   }
 
   broadcastBlockEnvelope(args: {
@@ -154,84 +59,6 @@ export class SubscribeBroadcaster {
       this.logger.info(
         `[SubscribeBroadcaster] Broadcasted block ${args.block} to ${sent} subscriber(s)`
       );
-    }
-  }
-
-  private sendJson(ws: WebSocket, payload: Record<string, unknown>): boolean {
-    if (ws.readyState !== WebSocket.OPEN) {
-      this.cleanupClient(ws);
-      return false;
-    }
-    try {
-      ws.send(JSON.stringify(payload), { compress: false });
-      return true;
-    } catch {
-      this.cleanupClient(ws);
-      return false;
-    }
-  }
-
-  private cleanupClient(ws: WebSocket): void {
-    const had = this.clients.delete(ws);
-    this.clientAlive.delete(ws);
-    if (had) {
-      this.logger.info(
-        `[SubscribeBroadcaster] Client disconnected. Total clients: ${this.clients.size}`
-      );
-    }
-  }
-
-  private pingClients(): void {
-    const stale: WebSocket[] = [];
-    this.clients.forEach((_, ws) => {
-      const alive = this.clientAlive.get(ws);
-      if (alive === false) {
-        stale.push(ws);
-        return;
-      }
-      this.clientAlive.set(ws, false);
-      try {
-        ws.ping();
-      } catch {
-        stale.push(ws);
-      }
-    });
-    stale.forEach((ws) => {
-      try {
-        ws.terminate();
-      } catch {
-      }
-      this.cleanupClient(ws);
-    });
-  }
-
-  getClientCount(): number {
-    return this.clients.size;
-  }
-
-  close(): void {
-    if (this.pingInterval) {
-      clearInterval(this.pingInterval);
-      this.pingInterval = null;
-    }
-    this.clients.forEach((_, ws) => {
-      try {
-        if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
-          ws.close();
-        } else {
-          ws.terminate();
-        }
-      } catch {
-      }
-    });
-    this.clients.clear();
-    this.clientAlive.clear();
-
-    if (this.wss) {
-      this.wss.close(() => {
-        this.logger.info("[SubscribeBroadcaster] WebSocket server closed");
-      });
-      this.wss = null;
     }
   }
 }

--- a/src/services/api/subscribe_protocol.ts
+++ b/src/services/api/subscribe_protocol.ts
@@ -1,5 +1,4 @@
-import { isValidDid } from "./api_shared";
-import { uniqueNormalizedDids } from "./indexer_event_utils";
+import { matchesMembership, parseSubscribeMembership } from "./api_shared";
 import type { IndexerEventRecord } from "./indexer_events_query";
 
 export const CHAIN_BLOCK_INTERVAL_MS = 6000;
@@ -55,48 +54,15 @@ export function parseControlMessage(raw: string): ControlParseResult {
     return { ok: true, message: { action: "unsubscribe" } };
   }
 
-  const corporationIdResult = parseCorporationId((json as Record<string, unknown>).corporationId);
-  if (!corporationIdResult.ok) {
-    return { ok: false, error: corporationIdResult.error };
-  }
-  const corporationId = corporationIdResult.value;
-
-  const rawDids = (json as Record<string, unknown>).dids;
-  if (rawDids === undefined || rawDids === null) {
-    return { ok: true, message: { action: "subscribe", dids: null, corporationId } };
+  const base = parseSubscribeMembership(json as Record<string, unknown>);
+  if (!base.ok) {
+    return { ok: false, error: base.error };
   }
 
-  if (!Array.isArray(rawDids)) {
-    return { ok: false, error: "'dids' must be an array of DID strings" };
-  }
-
-  if (rawDids.length === 0) {
-    return { ok: true, message: { action: "subscribe", dids: null, corporationId } };
-  }
-
-  for (const candidate of rawDids) {
-    if (!isValidDid(candidate)) {
-      return { ok: false, error: `Invalid DID in 'dids': ${String(candidate)}` };
-    }
-  }
-
-  const normalized = uniqueNormalizedDids(rawDids);
-  if (normalized.length === 0) {
-    return { ok: false, error: "No valid DIDs after normalization" };
-  }
-
-  return { ok: true, message: { action: "subscribe", dids: normalized, corporationId } };
-}
-
-function parseCorporationId(
-  raw: unknown
-): { ok: true; value: number | null } | { ok: false; error: string } {
-  if (raw === undefined || raw === null) return { ok: true, value: null };
-  const n = typeof raw === "number" ? raw : Number(raw);
-  if (!Number.isInteger(n) || n <= 0) {
-    return { ok: false, error: `'corporationId' must be a positive integer; got ${String(raw)}` };
-  }
-  return { ok: true, value: n };
+  return {
+    ok: true,
+    message: { action: "subscribe", dids: base.value.dids, corporationId: base.value.corporationId },
+  };
 }
 
 export function buildReadyMessage(lastProcessedBlock: number, lastBlockTime: string): ReadyMessage {
@@ -119,27 +85,20 @@ export function buildBlockEnvelope(
     return { type: "block", block, blockTime, events };
   }
 
-  const filtered = events.filter((event) => {
-    const matchesDids = didFilter === null || eventMatchesDids(event, didFilter);
-    const matchesCorporation =
-      corporationId === null || eventMatchesCorporation(event, corporationId);
-    return matchesDids && matchesCorporation;
-  });
+  const filtered = events.filter((event) =>
+    matchesMembership(didFilter, corporationId, {
+      did: event.did,
+      relatedDids: event.payload?.related_dids ?? [],
+      corporationIds: eventCorporationIds(event),
+    })
+  );
 
   return { type: "block", block, blockTime, events: filtered };
 }
 
-function eventMatchesDids(event: IndexerEventRecord, didFilter: Set<string>): boolean {
-  if (didFilter.has(event.did)) return true;
-  const related = event.payload?.related_dids ?? [];
-  for (const candidate of related) {
-    if (didFilter.has(candidate)) return true;
-  }
-  return false;
-}
-
-function eventMatchesCorporation(event: IndexerEventRecord, corporationId: number): boolean {
-  if (event.payload?.corporation_id === corporationId) return true;
-  const related = event.payload?.related_corporation_ids ?? [];
-  return related.includes(corporationId);
+function eventCorporationIds(event: IndexerEventRecord): number[] {
+  const ids: number[] = [];
+  if (typeof event.payload?.corporation_id === "number") ids.push(event.payload.corporation_id);
+  if (event.payload?.related_corporation_ids) ids.push(...event.payload.related_corporation_ids);
+  return ids;
 }

--- a/src/services/api/subscribe_ws_server.ts
+++ b/src/services/api/subscribe_ws_server.ts
@@ -1,0 +1,206 @@
+import { Server } from "http";
+import { WebSocket, WebSocketServer } from "ws";
+import { indexerStatusManager } from "../manager/indexer_status.manager";
+import { createLogger, toIsoSeconds, type LoggerLike } from "./api_shared";
+import { buildReadyMessage } from "./subscribe_protocol";
+
+export type ControlParseResult<TMessage> =
+  | { ok: true; message: TMessage }
+  | { ok: false; error: string };
+
+export abstract class BaseSubscribeServer<TControl, TState> {
+  private wss: WebSocketServer | null = null;
+  protected clients: Map<WebSocket, TState> = new Map();
+  private clientAlive: Map<WebSocket, boolean> = new Map();
+  private pingInterval: NodeJS.Timeout | null = null;
+  private readonly MAX_CLIENTS = 10000; // TODO: Review this values
+  private readonly PING_INTERVAL = 30000;
+  private readonly MAX_CONTROL_MESSAGE_BYTES = 64 * 1024;
+  protected logger = createLogger(console);
+
+  protected abstract readonly path: string;
+
+  protected abstract createInitialState(): TState;
+
+  protected abstract parseControl(raw: string): ControlParseResult<TControl>;
+
+  protected abstract applyControl(state: TState, message: TControl): TState;
+
+  setLogger(logger: LoggerLike): void {
+    this.logger = createLogger(logger);
+  }
+
+  initialize(server: Server): void {
+    if (this.wss) {
+      this.logger.warn(`[${this.constructor.name}] WebSocket server already initialized`);
+      return;
+    }
+
+    this.wss = new WebSocketServer({
+      server,
+      path: this.path,
+      perMessageDeflate: false,
+      maxPayload: this.MAX_CONTROL_MESSAGE_BYTES,
+      verifyClient: () => {
+        if (this.clients.size >= this.MAX_CLIENTS) {
+          this.logger.warn(
+            `[${this.constructor.name}] Max clients reached (${this.MAX_CLIENTS}), rejecting connection`
+          );
+          return false;
+        }
+        return true;
+      },
+    });
+
+    this.wss.on("connection", async (ws: WebSocket) => {
+      if (this.clients.size >= this.MAX_CLIENTS) {
+        ws.close(1013, "Server overloaded");
+        return;
+      }
+
+      this.clients.set(ws, this.createInitialState());
+      this.clientAlive.set(ws, true);
+
+      this.logger.info(
+        `[${this.constructor.name}] New client connected. Total clients: ${this.clients.size}`
+      );
+
+      ws.on("close", () => this.cleanupClient(ws));
+      ws.on("error", (error) => {
+        this.logger.error(`[${this.constructor.name}] WebSocket error:`, error);
+        this.cleanupClient(ws);
+      });
+      ws.on("pong", () => {
+        this.clientAlive.set(ws, true);
+      });
+      ws.on("message", (raw) => this.handleControlMessage(ws, raw.toString()));
+
+      try {
+        await this.sendReady(ws);
+      } catch (error) {
+        this.logger.error(`[${this.constructor.name}] Error sending ready message:`, error);
+        this.cleanupClient(ws);
+      }
+    });
+
+    this.wss.on("error", (error) => {
+      this.logger.error(`[${this.constructor.name}] WebSocketServer error:`, error);
+    });
+
+    this.pingInterval = setInterval(() => {
+      this.pingClients();
+    }, this.PING_INTERVAL);
+
+    this.logger.info(`[${this.constructor.name}] WebSocket server initialized on ${this.path}`);
+  }
+
+  private async sendReady(ws: WebSocket): Promise<void> {
+    const status = await indexerStatusManager.getDetailedStatus();
+    const lastProcessedBlock = status.lastProcessedBlock ?? 0;
+    const lastBlockTime = status.lastBlockTime ?? toIsoSeconds();
+    const ready = buildReadyMessage(lastProcessedBlock, lastBlockTime);
+    this.sendJson(ws, ready as unknown as Record<string, unknown>);
+  }
+
+  private handleControlMessage(ws: WebSocket, raw: string): void {
+    const result = this.parseControl(raw);
+    if (!result.ok) {
+      this.logger.warn(`[${this.constructor.name}] Invalid control message: ${result.error}`);
+      try {
+        ws.close(1008, result.error);
+      } catch {
+      }
+      this.cleanupClient(ws);
+      return;
+    }
+
+    const state = this.clients.get(ws);
+    if (!state) return;
+
+    this.clients.set(ws, this.applyControl(state, result.message));
+  }
+
+  protected sendJson(ws: WebSocket, payload: Record<string, unknown>, closeCodeOnFailure = 0): boolean {
+    if (ws.readyState !== WebSocket.OPEN) {
+      this.cleanupClient(ws);
+      return false;
+    }
+    try {
+      ws.send(JSON.stringify(payload), { compress: false });
+      return true;
+    } catch {
+      if (closeCodeOnFailure) {
+        try {
+          ws.close(closeCodeOnFailure, "Server overloaded");
+        } catch {
+        }
+      }
+      this.cleanupClient(ws);
+      return false;
+    }
+  }
+
+  private cleanupClient(ws: WebSocket): void {
+    const had = this.clients.delete(ws);
+    this.clientAlive.delete(ws);
+    if (had) {
+      this.logger.info(
+        `[${this.constructor.name}] Client disconnected. Total clients: ${this.clients.size}`
+      );
+    }
+  }
+
+  private pingClients(): void {
+    const stale: WebSocket[] = [];
+    this.clients.forEach((_, ws) => {
+      const alive = this.clientAlive.get(ws);
+      if (alive === false) {
+        stale.push(ws);
+        return;
+      }
+      this.clientAlive.set(ws, false);
+      try {
+        ws.ping();
+      } catch {
+        stale.push(ws);
+      }
+    });
+    stale.forEach((ws) => {
+      try {
+        ws.terminate();
+      } catch {
+      }
+      this.cleanupClient(ws);
+    });
+  }
+
+  getClientCount(): number {
+    return this.clients.size;
+  }
+
+  close(): void {
+    if (this.pingInterval) {
+      clearInterval(this.pingInterval);
+      this.pingInterval = null;
+    }
+    this.clients.forEach((_, ws) => {
+      try {
+        if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+          ws.close();
+        } else {
+          ws.terminate();
+        }
+      } catch {
+      }
+    });
+    this.clients.clear();
+    this.clientAlive.clear();
+
+    if (this.wss) {
+      this.wss.close(() => {
+        this.logger.info(`[${this.constructor.name}] WebSocket server closed`);
+      });
+      this.wss = null;
+    }
+  }
+}

--- a/src/services/api/subscribe_ws_server.ts
+++ b/src/services/api/subscribe_ws_server.ts
@@ -1,4 +1,5 @@
-import { Server } from "http";
+import { Server, type IncomingMessage } from "http";
+import type { Duplex } from "stream";
 import { WebSocket, WebSocketServer } from "ws";
 import { indexerStatusManager } from "../manager/indexer_status.manager";
 import { createLogger, toIsoSeconds, type LoggerLike } from "./api_shared";
@@ -10,6 +11,8 @@ export type ControlParseResult<TMessage> =
 
 export abstract class BaseSubscribeServer<TControl, TState> {
   private wss: WebSocketServer | null = null;
+  private server: Server | null = null;
+  private upgradeHandler: ((req: IncomingMessage, socket: Duplex, head: Buffer) => void) | null = null;
   protected clients: Map<WebSocket, TState> = new Map();
   private clientAlive: Map<WebSocket, boolean> = new Map();
   private pingInterval: NodeJS.Timeout | null = null;
@@ -37,20 +40,34 @@ export abstract class BaseSubscribeServer<TControl, TState> {
     }
 
     this.wss = new WebSocketServer({
-      server,
-      path: this.path,
+      noServer: true,
       perMessageDeflate: false,
       maxPayload: this.MAX_CONTROL_MESSAGE_BYTES,
-      verifyClient: () => {
-        if (this.clients.size >= this.MAX_CLIENTS) {
-          this.logger.warn(
-            `[${this.constructor.name}] Max clients reached (${this.MAX_CLIENTS}), rejecting connection`
-          );
-          return false;
-        }
-        return true;
-      },
     });
+
+    this.server = server;
+    this.upgradeHandler = (req: IncomingMessage, socket: Duplex, head: Buffer) => {
+      let pathname: string;
+      try {
+        pathname = new URL(req.url ?? "", "http://localhost").pathname;
+      } catch {
+        return;
+      }
+      if (pathname !== this.path) return;
+
+      if (this.clients.size >= this.MAX_CLIENTS) {
+        this.logger.warn(
+          `[${this.constructor.name}] Max clients reached (${this.MAX_CLIENTS}), rejecting connection`
+        );
+        socket.destroy();
+        return;
+      }
+
+      this.wss!.handleUpgrade(req, socket, head, (ws) => {
+        this.wss!.emit("connection", ws, req);
+      });
+    };
+    server.on("upgrade", this.upgradeHandler);
 
     this.wss.on("connection", async (ws: WebSocket) => {
       if (this.clients.size >= this.MAX_CLIENTS) {
@@ -195,6 +212,12 @@ export abstract class BaseSubscribeServer<TControl, TState> {
     });
     this.clients.clear();
     this.clientAlive.clear();
+
+    if (this.server && this.upgradeHandler) {
+      this.server.off("upgrade", this.upgradeHandler);
+    }
+    this.server = null;
+    this.upgradeHandler = null;
 
     if (this.wss) {
       this.wss.close(() => {

--- a/src/services/api/vt_subscribe_broadcaster.ts
+++ b/src/services/api/vt_subscribe_broadcaster.ts
@@ -1,0 +1,64 @@
+import { BaseSubscribeServer, type ControlParseResult } from "./subscribe_ws_server";
+import {
+  buildVtChangesEnvelope,
+  parseVtControlMessage,
+  type VtChannelOptions,
+  type VtControlMessage,
+  type VtRawChange,
+} from "./vt_subscribe_protocol";
+
+type VtClientState = {
+  established: boolean;
+  dids: Set<string> | null;
+  corporationId: number | null;
+  channels: VtChannelOptions | null;
+};
+
+export class VtSubscribeBroadcaster extends BaseSubscribeServer<VtControlMessage, VtClientState> {
+  protected readonly path = "/v4/verifiable-trust/subscribe";
+
+  protected createInitialState(): VtClientState {
+    return { established: false, dids: null, corporationId: null, channels: null };
+  }
+
+  protected parseControl(raw: string): ControlParseResult<VtControlMessage> {
+    return parseVtControlMessage(raw);
+  }
+
+  protected applyControl(_state: VtClientState, message: VtControlMessage): VtClientState {
+    if (message.action === "unsubscribe") {
+      return { established: false, dids: null, corporationId: null, channels: null };
+    }
+
+    return {
+      established: true,
+      dids: message.dids === null ? null : new Set(message.dids),
+      corporationId: message.corporationId,
+      channels: message.channels,
+    };
+  }
+
+  broadcastChangesEnvelope(args: { block: number; blockTime: string; changes: VtRawChange[] }): void {
+    if (this.clients.size === 0) return;
+
+    let sent = 0;
+    this.clients.forEach((state, ws) => {
+      if (!state.established || !state.channels) return;
+      const envelope = buildVtChangesEnvelope(
+        args.block,
+        args.blockTime,
+        args.changes,
+        state.dids,
+        state.corporationId,
+        state.channels
+      );
+      if (this.sendJson(ws, envelope as unknown as Record<string, unknown>, 1011)) sent++;
+    });
+
+    if (sent > 0) {
+      this.logger.info(`[VtSubscribeBroadcaster] Broadcasted block ${args.block} to ${sent} subscriber(s)`);
+    }
+  }
+}
+
+export const vtSubscribeBroadcaster = new VtSubscribeBroadcaster();

--- a/src/services/api/vt_subscribe_protocol.ts
+++ b/src/services/api/vt_subscribe_protocol.ts
@@ -1,0 +1,291 @@
+import { matchesMembership, parseSubscribeMembership } from "./api_shared";
+
+export type VtTrustCore = {
+  trusted: boolean;
+  evaluatedAtTime: string;
+  evaluatedAtBlock: number;
+  expiresAtTime: string;
+  corporationId: number | null;
+};
+
+export type CorporationChannelOptions = {
+  include: boolean;
+  includeDepositChanges: boolean;
+};
+
+export type ParticipationsChannelOptions = {
+  include: boolean;
+  includeWeightChanges: boolean;
+  includeParticipantCounts: boolean;
+  includeIssuedCredentials: boolean;
+  includeVerifiedCredentials: boolean;
+};
+
+export type EcosystemsChannelOptions = {
+  include: boolean;
+  includeParticipantCounts: boolean;
+  includeIssuedCredentials: boolean;
+  includeVerifiedCredentials: boolean;
+};
+
+export type VtChannelOptions = {
+  trust: boolean;
+  ecsCredentials: boolean;
+  presentations: boolean;
+  services: boolean;
+  corporation: CorporationChannelOptions;
+  participations: ParticipationsChannelOptions;
+  ecosystems: EcosystemsChannelOptions;
+};
+
+export type VtSubscribeControl = {
+  action: "subscribe";
+  dids: string[] | null;
+  corporationId: number | null;
+  channels: VtChannelOptions;
+};
+
+export type VtUnsubscribeControl = { action: "unsubscribe" };
+
+export type VtControlMessage = VtSubscribeControl | VtUnsubscribeControl;
+
+export type VtRawChange = {
+  did: string;
+  relatedDids: Set<string>;
+  corporationIds: Set<number>;
+  trust: VtTrustCore | null;
+  corporation: { structural: boolean; deposit: boolean } | null;
+  participations: {
+    structural: boolean;
+    weight: boolean;
+    counts: boolean;
+    issued: boolean;
+    verified: boolean;
+  } | null;
+  ecosystems: { structural: boolean; counts: boolean; issued: boolean; verified: boolean } | null;
+  content: boolean;
+};
+
+export type VtChange = {
+  did: string;
+  trust?: VtTrustCore;
+  corporation?: boolean;
+  participations?: boolean;
+  ecsCredentials?: boolean;
+  presentations?: boolean;
+  services?: boolean;
+  ecosystems?: boolean;
+};
+
+export type VtBlockEnvelope = {
+  type: "block";
+  block: number;
+  blockTime: string;
+  changes: VtChange[];
+};
+
+export type VtControlParseResult =
+  | { ok: true; message: VtControlMessage }
+  | { ok: false; error: string };
+
+function boolOption(raw: unknown, key: string, fallback = false): boolean {
+  if (raw === undefined || raw === null) return fallback;
+  const v = (raw as Record<string, unknown>)[key];
+  return v === true;
+}
+
+function parseCorporationChannel(raw: unknown): CorporationChannelOptions {
+  if (raw === true) return { include: true, includeDepositChanges: false };
+  if (raw && typeof raw === "object") {
+    return { include: true, includeDepositChanges: boolOption(raw, "includeDepositChanges") };
+  }
+  return { include: false, includeDepositChanges: false };
+}
+
+function parseParticipationsChannel(raw: unknown): ParticipationsChannelOptions {
+  const base = {
+    includeWeightChanges: false,
+    includeParticipantCounts: false,
+    includeIssuedCredentials: false,
+    includeVerifiedCredentials: false,
+  };
+  if (raw === true) return { include: true, ...base };
+  if (raw && typeof raw === "object") {
+    return {
+      include: true,
+      includeWeightChanges: boolOption(raw, "includeWeightChanges"),
+      includeParticipantCounts: boolOption(raw, "includeParticipantCounts"),
+      includeIssuedCredentials: boolOption(raw, "includeIssuedCredentials"),
+      includeVerifiedCredentials: boolOption(raw, "includeVerifiedCredentials"),
+    };
+  }
+  return { include: false, ...base };
+}
+
+function parseEcosystemsChannel(raw: unknown): EcosystemsChannelOptions {
+  const base = {
+    includeParticipantCounts: false,
+    includeIssuedCredentials: false,
+    includeVerifiedCredentials: false,
+  };
+  if (raw === true) return { include: true, ...base };
+  if (raw && typeof raw === "object") {
+    return {
+      include: true,
+      includeParticipantCounts: boolOption(raw, "includeParticipantCounts"),
+      includeIssuedCredentials: boolOption(raw, "includeIssuedCredentials"),
+      includeVerifiedCredentials: boolOption(raw, "includeVerifiedCredentials"),
+    };
+  }
+  return { include: false, ...base };
+}
+
+function parseChannels(raw: unknown): VtChannelOptions {
+  const map = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+  return {
+    trust: map.trust === true,
+    ecsCredentials: map.ecsCredentials === true,
+    presentations: map.presentations === true,
+    services: map.services === true,
+    corporation: parseCorporationChannel(map.corporation),
+    participations: parseParticipationsChannel(map.participations),
+    ecosystems: parseEcosystemsChannel(map.ecosystems),
+  };
+}
+
+function hasAnyChannel(channels: VtChannelOptions): boolean {
+  return (
+    channels.trust ||
+    channels.ecsCredentials ||
+    channels.presentations ||
+    channels.services ||
+    channels.corporation.include ||
+    channels.participations.include ||
+    channels.ecosystems.include
+  );
+}
+
+export function parseVtControlMessage(raw: string): VtControlParseResult {
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch {
+    return { ok: false, error: "Invalid JSON" };
+  }
+
+  if (!json || typeof json !== "object") {
+    return { ok: false, error: "Control message must be an object" };
+  }
+
+  const action = (json as Record<string, unknown>).action;
+  if (action !== "subscribe" && action !== "unsubscribe") {
+    return { ok: false, error: "Unknown action. Expected 'subscribe' or 'unsubscribe'" };
+  }
+
+  if (action === "unsubscribe") {
+    return { ok: true, message: { action: "unsubscribe" } };
+  }
+
+  const channels = parseChannels((json as Record<string, unknown>).channels);
+  if (!hasAnyChannel(channels)) {
+    return { ok: false, error: "'channels' must enable at least one channel" };
+  }
+
+  const base = parseSubscribeMembership(json as Record<string, unknown>);
+  if (!base.ok) {
+    return { ok: false, error: base.error };
+  }
+
+  return {
+    ok: true,
+    message: {
+      action: "subscribe",
+      dids: base.value.dids,
+      corporationId: base.value.corporationId,
+      channels,
+    },
+  };
+}
+
+export function projectVtChange(raw: VtRawChange, channels: VtChannelOptions): VtChange | null {
+  const change: VtChange = { did: raw.did };
+  let any = false;
+
+  if (channels.trust && raw.trust) {
+    change.trust = raw.trust;
+    any = true;
+  }
+
+  if (channels.corporation.include) {
+    const c = raw.corporation;
+    const signal = Boolean(
+      c && (c.structural || (channels.corporation.includeDepositChanges && c.deposit))
+    );
+    change.corporation = signal;
+    if (signal) any = true;
+  }
+
+  if (channels.participations.include) {
+    const p = raw.participations;
+    const signal = Boolean(
+      p &&
+        (p.structural ||
+          (channels.participations.includeWeightChanges && p.weight) ||
+          (channels.participations.includeParticipantCounts && p.counts) ||
+          (channels.participations.includeIssuedCredentials && p.issued) ||
+          (channels.participations.includeVerifiedCredentials && p.verified))
+    );
+    change.participations = signal;
+    if (signal) any = true;
+  }
+
+  if (channels.ecosystems.include) {
+    const e = raw.ecosystems;
+    const signal = Boolean(
+      e &&
+        (e.structural ||
+          (channels.ecosystems.includeParticipantCounts && e.counts) ||
+          (channels.ecosystems.includeIssuedCredentials && e.issued) ||
+          (channels.ecosystems.includeVerifiedCredentials && e.verified))
+    );
+    change.ecosystems = signal;
+    if (signal) any = true;
+  }
+
+  if (channels.ecsCredentials) {
+    change.ecsCredentials = raw.content;
+    if (raw.content) any = true;
+  }
+  if (channels.presentations) {
+    change.presentations = raw.content;
+    if (raw.content) any = true;
+  }
+  if (channels.services) {
+    change.services = raw.content;
+    if (raw.content) any = true;
+  }
+
+  return any ? change : null;
+}
+
+export function buildVtChangesEnvelope(
+  block: number,
+  blockTime: string,
+  rawChanges: VtRawChange[],
+  didFilter: Set<string> | null,
+  corporationId: number | null,
+  channels: VtChannelOptions
+): VtBlockEnvelope {
+  const changes: VtChange[] = [];
+  for (const raw of rawChanges) {
+    const inMembership = matchesMembership(didFilter, corporationId, {
+      did: raw.did,
+      relatedDids: raw.relatedDids,
+      corporationIds: raw.corporationIds,
+    });
+    if (!inMembership) continue;
+    const projected = projectVtChange(raw, channels);
+    if (projected) changes.push(projected);
+  }
+  return { type: "block", block, blockTime, changes };
+}

--- a/src/services/resolver/resolver-poll.service.ts
+++ b/src/services/resolver/resolver-poll.service.ts
@@ -14,6 +14,9 @@ import {
   resolveTrustForDidAtHeight,
   resolveTrustForBlock,
 } from "./trust-resolve";
+import { buildVtChangesForBlock } from "./vt_change_detection";
+import { vtSubscribeBroadcaster } from "../api/vt_subscribe_broadcaster";
+import { toIsoSeconds } from "../api/api_shared";
 
 const checkCrawlingStatusPromise = import("../../common/utils/error_handler");
 
@@ -133,7 +136,20 @@ const ResolverPollService = {
     async processBlock(this: any, blockHeight: number): Promise<void> {
       if (!Number.isInteger(blockHeight) || blockHeight < 0) return;
       await resolveTrustForBlock(blockHeight);
-      // TODO: broadcast resolved block when /v4/verifiable-trust/subscribe (IDX-VT-SUB-1) lands.
+      await this.broadcastResolvedBlock(blockHeight);
+    },
+
+    async broadcastResolvedBlock(this: any, blockHeight: number): Promise<void> {
+      try {
+        const changes = await buildVtChangesForBlock(blockHeight);
+        const blockRow = await knex("block").select("time").where("height", blockHeight).first();
+        const blockTime = toIsoSeconds(
+          (blockRow as { time?: Date | string } | undefined)?.time ?? new Date()
+        );
+        vtSubscribeBroadcaster.broadcastChangesEnvelope({ block: blockHeight, blockTime, changes });
+      } catch (err) {
+        this.logger.warn(`[RESOLVER] Failed to broadcast trust changes for block ${blockHeight}:`, err);
+      }
     },
 
     async pollOnce(this: any): Promise<void> {

--- a/src/services/resolver/trust-resolve.ts
+++ b/src/services/resolver/trust-resolve.ts
@@ -171,7 +171,9 @@ export async function findHeightsWithTrustModuleMessages(fromExclusive: number, 
       AND (
         tm.type LIKE '/verana.ec%'
         OR tm.type LIKE '/verana.cs%'
-        OR tm.type LIKE '/verana.participant%'
+        OR tm.type LIKE '/verana.pp%'
+        OR tm.type LIKE '/verana.co%'
+        OR tm.type LIKE '/verana.td%'
       )
     ORDER BY t.height ASC
     `,

--- a/src/services/resolver/vt_change_detection.ts
+++ b/src/services/resolver/vt_change_detection.ts
@@ -191,13 +191,14 @@ export async function buildVtChangesForBlock(blockHeight: number): Promise<VtRaw
         .filter((id) => Number.isInteger(id) && id > 0)
     ),
   ];
-  const validatorDidById = new Map<number, string>();
+  const validatorById = new Map<number, { did: string | null; corporation_id: number | null }>();
   if (validatorIds.length > 0) {
     const validators = (await knex("participants")
-      .select("id", "did")
-      .whereIn("id", validatorIds)
-      .whereNotNull("did")) as Array<{ id: number; did: string }>;
-    for (const v of validators) validatorDidById.set(Number(v.id), v.did);
+      .select("id", "did", "corporation_id")
+      .whereIn("id", validatorIds)) as Array<{ id: number; did: string | null; corporation_id: number | null }>;
+    for (const v of validators) {
+      validatorById.set(Number(v.id), { did: v.did, corporation_id: v.corporation_id });
+    }
   }
 
   for (const row of participantRows) {
@@ -206,8 +207,11 @@ export async function buildVtChangesForBlock(blockHeight: number): Promise<VtRaw
     rc.participations = mergeParticipations(rc.participations, classifyParticipations(row.changes));
     addCorporationId(rc.corporationIds, row.corporation_id);
     const vid = Number(row.validator_perm_id);
-    const vdid = Number.isInteger(vid) ? validatorDidById.get(vid) : undefined;
-    if (vdid) rc.relatedDids.add(vdid);
+    const validator = Number.isInteger(vid) ? validatorById.get(vid) : undefined;
+    if (validator) {
+      if (validator.did) rc.relatedDids.add(validator.did);
+      addCorporationId(rc.corporationIds, validator.corporation_id);
+    }
   }
 
   const ecosystemRows = (await knex("ecosystem_history")

--- a/src/services/resolver/vt_change_detection.ts
+++ b/src/services/resolver/vt_change_detection.ts
@@ -1,0 +1,294 @@
+import knex from "../../common/utils/db_connection";
+import { isValidDid, toIsoSeconds } from "../api/api_shared";
+import { getTrustResultLatestByDidAtOrBeforeHeight, type TrustResultsRow } from "./trust-resolve";
+import type { VtRawChange, VtTrustCore } from "../api/vt_subscribe_protocol";
+
+const ROW_BOOKKEEPING_KEYS = new Set([
+  "id",
+  "height",
+  "event_type",
+  "action",
+  "created",
+  "created_at",
+  "modified",
+]);
+
+const PARTICIPANT_COUNT_KEYS = [
+  "participants",
+  "participants_ecosystem",
+  "participants_issuer_grantor",
+  "participants_issuer",
+  "participants_verifier_grantor",
+  "participants_verifier",
+  "participants_holder",
+];
+
+const PARTICIPATIONS_METRICS = {
+  weight: new Set(["weight"]),
+  counts: new Set(PARTICIPANT_COUNT_KEYS),
+  issued: new Set(["issued"]),
+  verified: new Set(["verified"]),
+};
+
+const ECOSYSTEMS_METRICS = {
+  counts: new Set(PARTICIPANT_COUNT_KEYS),
+  issued: new Set(["issued"]),
+  verified: new Set(["verified"]),
+};
+
+const DEPOSIT_KEYS = new Set([
+  "deposit",
+  "share",
+  "claimable",
+  "slashed_deposit",
+  "repaid_deposit",
+  "last_slashed",
+  "last_repaid",
+  "slash_count",
+]);
+
+function changeKeys(changes: unknown): string[] {
+  if (!changes || typeof changes !== "object") return [];
+  return Object.keys(changes as Record<string, unknown>);
+}
+
+type ParticipationsCats = { structural: boolean; weight: boolean; counts: boolean; issued: boolean; verified: boolean };
+type EcosystemsCats = { structural: boolean; counts: boolean; issued: boolean; verified: boolean };
+
+function classifyParticipations(changes: unknown): ParticipationsCats {
+  const keys = changeKeys(changes);
+  if (keys.length === 0) return { structural: true, weight: false, counts: false, issued: false, verified: false };
+  const cats: ParticipationsCats = { structural: false, weight: false, counts: false, issued: false, verified: false };
+  for (const key of keys) {
+    if (ROW_BOOKKEEPING_KEYS.has(key)) continue;
+    if (PARTICIPATIONS_METRICS.weight.has(key)) cats.weight = true;
+    else if (PARTICIPATIONS_METRICS.counts.has(key)) cats.counts = true;
+    else if (PARTICIPATIONS_METRICS.issued.has(key)) cats.issued = true;
+    else if (PARTICIPATIONS_METRICS.verified.has(key)) cats.verified = true;
+    else cats.structural = true;
+  }
+  return cats;
+}
+
+function classifyEcosystems(changes: unknown): EcosystemsCats {
+  const keys = changeKeys(changes);
+  if (keys.length === 0) return { structural: true, counts: false, issued: false, verified: false };
+  const cats: EcosystemsCats = { structural: false, counts: false, issued: false, verified: false };
+  for (const key of keys) {
+    if (ROW_BOOKKEEPING_KEYS.has(key)) continue;
+    if (ECOSYSTEMS_METRICS.counts.has(key)) cats.counts = true;
+    else if (ECOSYSTEMS_METRICS.issued.has(key)) cats.issued = true;
+    else if (ECOSYSTEMS_METRICS.verified.has(key)) cats.verified = true;
+    else cats.structural = true;
+  }
+  return cats;
+}
+
+function classifyDeposit(changes: unknown): boolean {
+  const keys = changeKeys(changes);
+  if (keys.length === 0) return true;
+  return keys.some((key) => DEPOSIT_KEYS.has(key));
+}
+
+function trustCoreFromRow(row: TrustResultsRow, corporationId: number | null): VtTrustCore {
+  const status = String(row.trust_status ?? "UNTRUSTED").toUpperCase();
+  return {
+    trusted: status === "TRUSTED" || status === "PARTIAL",
+    evaluatedAtTime: toIsoSeconds(row.evaluated_at ?? row.created_at),
+    evaluatedAtBlock: Number(row.height ?? 0),
+    expiresAtTime: toIsoSeconds(row.expires_at),
+    corporationId,
+  };
+}
+
+function trustResultChanged(next: VtTrustCore, prev: VtTrustCore | null): boolean {
+  if (!prev) return true;
+  return next.trusted !== prev.trusted || next.corporationId !== prev.corporationId;
+}
+
+export class VtChangeAccumulator {
+  private byDid = new Map<string, VtRawChange>();
+
+  ensure(did: string): VtRawChange {
+    let rc = this.byDid.get(did);
+    if (!rc) {
+      rc = {
+        did,
+        relatedDids: new Set(),
+        corporationIds: new Set(),
+        trust: null,
+        corporation: null,
+        participations: null,
+        ecosystems: null,
+        content: false,
+      };
+      this.byDid.set(did, rc);
+    }
+    return rc;
+  }
+
+  values(): VtRawChange[] {
+    return [...this.byDid.values()];
+  }
+}
+
+function mergeParticipations(
+  cur: VtRawChange["participations"],
+  cats: ParticipationsCats
+): ParticipationsCats {
+  const base = cur ?? { structural: false, weight: false, counts: false, issued: false, verified: false };
+  return {
+    structural: base.structural || cats.structural,
+    weight: base.weight || cats.weight,
+    counts: base.counts || cats.counts,
+    issued: base.issued || cats.issued,
+    verified: base.verified || cats.verified,
+  };
+}
+
+function mergeEcosystems(cur: VtRawChange["ecosystems"], cats: EcosystemsCats): EcosystemsCats {
+  const base = cur ?? { structural: false, counts: false, issued: false, verified: false };
+  return {
+    structural: base.structural || cats.structural,
+    counts: base.counts || cats.counts,
+    issued: base.issued || cats.issued,
+    verified: base.verified || cats.verified,
+  };
+}
+
+function mergeCorporation(
+  cur: VtRawChange["corporation"],
+  structural: boolean,
+  deposit: boolean
+): { structural: boolean; deposit: boolean } {
+  const base = cur ?? { structural: false, deposit: false };
+  return { structural: base.structural || structural, deposit: base.deposit || deposit };
+}
+
+function addCorporationId(ids: Set<number>, value: unknown): void {
+  const n = Number(value);
+  if (Number.isInteger(n) && n > 0) ids.add(n);
+}
+
+export async function buildVtChangesForBlock(blockHeight: number): Promise<VtRawChange[]> {
+  if (!Number.isInteger(blockHeight) || blockHeight < 0) return [];
+  const acc = new VtChangeAccumulator();
+
+  const participantRows = (await knex("participant_history")
+    .select("did", "corporation_id", "validator_perm_id", "changes")
+    .where("height", blockHeight)
+    .whereNotNull("did")) as Array<{
+    did: string;
+    corporation_id: number | null;
+    validator_perm_id: number | null;
+    changes: unknown;
+  }>;
+
+  const validatorIds = [
+    ...new Set(
+      participantRows
+        .map((r) => Number(r.validator_perm_id))
+        .filter((id) => Number.isInteger(id) && id > 0)
+    ),
+  ];
+  const validatorDidById = new Map<number, string>();
+  if (validatorIds.length > 0) {
+    const validators = (await knex("participants")
+      .select("id", "did")
+      .whereIn("id", validatorIds)
+      .whereNotNull("did")) as Array<{ id: number; did: string }>;
+    for (const v of validators) validatorDidById.set(Number(v.id), v.did);
+  }
+
+  for (const row of participantRows) {
+    if (!isValidDid(row.did)) continue;
+    const rc = acc.ensure(row.did);
+    rc.participations = mergeParticipations(rc.participations, classifyParticipations(row.changes));
+    addCorporationId(rc.corporationIds, row.corporation_id);
+    const vid = Number(row.validator_perm_id);
+    const vdid = Number.isInteger(vid) ? validatorDidById.get(vid) : undefined;
+    if (vdid) rc.relatedDids.add(vdid);
+  }
+
+  const ecosystemRows = (await knex("ecosystem_history")
+    .select("did", "corporation_id", "changes")
+    .where("height", blockHeight)
+    .whereNotNull("did")) as Array<{ did: string; corporation_id: number | null; changes: unknown }>;
+  for (const row of ecosystemRows) {
+    if (!isValidDid(row.did)) continue;
+    const rc = acc.ensure(row.did);
+    rc.ecosystems = mergeEcosystems(rc.ecosystems, classifyEcosystems(row.changes));
+    addCorporationId(rc.corporationIds, row.corporation_id);
+  }
+
+  const schemaRows = (await knex("credential_schema_history as csh")
+    .join("ecosystem as e", "e.id", "csh.ecosystem_id")
+    .select("e.did as did", "e.corporation_id as corporation_id", "csh.changes as changes")
+    .where("csh.height", blockHeight)
+    .whereNotNull("e.did")) as Array<{ did: string; corporation_id: number | null; changes: unknown }>;
+  for (const row of schemaRows) {
+    if (!isValidDid(row.did)) continue;
+    const rc = acc.ensure(row.did);
+    rc.ecosystems = mergeEcosystems(rc.ecosystems, classifyEcosystems(row.changes));
+    addCorporationId(rc.corporationIds, row.corporation_id);
+  }
+
+  const corporationRows = (await knex("corporation_history")
+    .select("did", "corporation_id", "changes")
+    .where("height", blockHeight)
+    .whereNotNull("did")) as Array<{ did: string; corporation_id: number | null; changes: unknown }>;
+  for (const row of corporationRows) {
+    if (!isValidDid(row.did)) continue;
+    const rc = acc.ensure(row.did);
+    rc.corporation = mergeCorporation(rc.corporation, true, false);
+    addCorporationId(rc.corporationIds, row.corporation_id);
+  }
+
+  const depositRows = (await knex("trust_deposit_history")
+    .select("corporation", "changes")
+    .where("height", blockHeight)) as Array<{ corporation: string; changes: unknown }>;
+  const accounts = [...new Set(depositRows.map((r) => r.corporation).filter((a) => typeof a === "string" && a))];
+  const corpByAccount = new Map<string, { did: string; id: number }>();
+  if (accounts.length > 0) {
+    const corps = (await knex("corporation")
+      .select("corporation", "did", "id")
+      .whereIn("corporation", accounts)
+      .whereNotNull("did")) as Array<{ corporation: string; did: string; id: number }>;
+    for (const c of corps) corpByAccount.set(c.corporation, { did: c.did, id: Number(c.id) });
+  }
+  for (const row of depositRows) {
+    const meta = corpByAccount.get(row.corporation);
+    if (!meta || !isValidDid(meta.did)) continue;
+    const rc = acc.ensure(meta.did);
+    rc.corporation = mergeCorporation(rc.corporation, false, classifyDeposit(row.changes));
+    addCorporationId(rc.corporationIds, meta.id);
+  }
+
+  const trustRows = (await knex("trust_results")
+    .select("did", "height", "trust_status", "production", "evaluated_at", "expires_at", "created_at")
+    .where("height", blockHeight)) as TrustResultsRow[];
+  if (trustRows.length > 0) {
+    const trustDids = [...new Set(trustRows.map((r) => r.did).filter(isValidDid))];
+    const corpIdByDid = new Map<string, number>();
+    if (trustDids.length > 0) {
+      const corps = (await knex("corporation")
+        .select("did", "id")
+        .whereIn("did", trustDids)) as Array<{ did: string; id: number }>;
+      for (const c of corps) corpIdByDid.set(c.did, Number(c.id));
+    }
+
+    for (const row of trustRows) {
+      if (!isValidDid(row.did)) continue;
+      const rc = acc.ensure(row.did);
+      rc.content = true;
+      const corporationId = corpIdByDid.get(row.did) ?? null;
+      if (corporationId != null) rc.corporationIds.add(corporationId);
+      const nextCore = trustCoreFromRow(row, corporationId);
+      const prevRow = await getTrustResultLatestByDidAtOrBeforeHeight(row.did, blockHeight - 1);
+      const prevCore = prevRow ? trustCoreFromRow(prevRow, corporationId) : null;
+      if (trustResultChanged(nextCore, prevCore)) rc.trust = nextCore;
+    }
+  }
+
+  return acc.values();
+}

--- a/src/services/resolver/vt_change_detection.ts
+++ b/src/services/resolver/vt_change_detection.ts
@@ -175,19 +175,19 @@ export async function buildVtChangesForBlock(blockHeight: number): Promise<VtRaw
   const acc = new VtChangeAccumulator();
 
   const participantRows = (await knex("participant_history")
-    .select("did", "corporation_id", "validator_perm_id", "changes")
+    .select("did", "corporation_id", "validator_participant_id", "changes")
     .where("height", blockHeight)
     .whereNotNull("did")) as Array<{
     did: string;
     corporation_id: number | null;
-    validator_perm_id: number | null;
+    validator_participant_id: number | null;
     changes: unknown;
   }>;
 
   const validatorIds = [
     ...new Set(
       participantRows
-        .map((r) => Number(r.validator_perm_id))
+        .map((r) => Number(r.validator_participant_id))
         .filter((id) => Number.isInteger(id) && id > 0)
     ),
   ];
@@ -206,7 +206,7 @@ export async function buildVtChangesForBlock(blockHeight: number): Promise<VtRaw
     const rc = acc.ensure(row.did);
     rc.participations = mergeParticipations(rc.participations, classifyParticipations(row.changes));
     addCorporationId(rc.corporationIds, row.corporation_id);
-    const vid = Number(row.validator_perm_id);
+    const vid = Number(row.validator_participant_id);
     const validator = Number.isInteger(vid) ? validatorById.get(vid) : undefined;
     if (validator) {
       if (validator.did) rc.relatedDids.add(validator.did);

--- a/test/unit/services/api/vt_subscribe_broadcaster.spec.ts
+++ b/test/unit/services/api/vt_subscribe_broadcaster.spec.ts
@@ -1,0 +1,233 @@
+import { createServer, Server } from "http";
+import { WebSocket, type RawData } from "ws";
+import { VtSubscribeBroadcaster } from "../../../../src/services/api/vt_subscribe_broadcaster";
+import type { VtRawChange } from "../../../../src/services/api/vt_subscribe_protocol";
+
+jest.setTimeout(15000);
+
+function waitForMessage(
+  ws: WebSocket,
+  predicate: (message: any) => boolean,
+  timeoutMs = 5000
+): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      ws.off("message", onMessage);
+      reject(new Error("Timed out waiting for WebSocket message"));
+    }, timeoutMs);
+    const onMessage = (data: RawData) => {
+      const message = JSON.parse(data.toString());
+      if (!predicate(message)) return;
+      clearTimeout(timeout);
+      ws.off("message", onMessage);
+      resolve(message);
+    };
+    ws.on("message", onMessage);
+  });
+}
+
+function waitForOpen(ws: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    ws.once("open", () => resolve());
+    ws.once("error", reject);
+  });
+}
+
+function waitForClose(ws: WebSocket): Promise<{ code: number; reason: string }> {
+  return new Promise((resolve) => {
+    ws.once("close", (code, reason) => resolve({ code, reason: reason.toString() }));
+  });
+}
+
+function waitForCondition(predicate: () => boolean, timeoutMs = 1500): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const startedAt = Date.now();
+    const check = () => {
+      if (predicate()) return resolve();
+      if (Date.now() - startedAt >= timeoutMs) return reject(new Error("Timed out waiting for condition"));
+      setTimeout(check, 25);
+    };
+    check();
+  });
+}
+
+function closeSocket(ws: WebSocket): void {
+  if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) ws.close();
+}
+
+const TRUST_CORE = {
+  trusted: true,
+  evaluatedAtTime: "2026-05-11T13:00:05Z",
+  evaluatedAtBlock: 1500005,
+  expiresAtTime: "2026-05-12T13:00:05Z",
+  corporationId: 42,
+};
+
+function rawChange(did: string, overrides: Partial<VtRawChange> = {}): VtRawChange {
+  return {
+    did,
+    relatedDids: new Set(),
+    corporationIds: new Set(),
+    trust: null,
+    corporation: null,
+    participations: null,
+    ecosystems: null,
+    content: false,
+    ...overrides,
+  };
+}
+
+async function openSubscribed(url: string, body: Record<string, unknown>): Promise<WebSocket> {
+  const ws = new WebSocket(url);
+  await waitForOpen(ws);
+  await waitForMessage(ws, (msg) => msg.type === "ready");
+  ws.send(JSON.stringify({ action: "subscribe", ...body }));
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  return ws;
+}
+
+describe("VtSubscribeBroadcaster", () => {
+  let broadcaster: VtSubscribeBroadcaster;
+  let httpServer: Server;
+  let WS_URL = "";
+
+  beforeAll((done) => {
+    httpServer = createServer();
+    httpServer.listen(0, () => {
+      const addr = httpServer.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      WS_URL = `ws://localhost:${port}/v4/verifiable-trust/subscribe`;
+      done();
+    });
+  });
+
+  afterAll((done) => {
+    broadcaster?.close();
+    httpServer.close(() => done());
+  });
+
+  beforeEach(() => {
+    broadcaster?.close();
+    broadcaster = new VtSubscribeBroadcaster();
+    broadcaster.setLogger({ info: () => {}, warn: () => {}, error: () => {} });
+    broadcaster.initialize(httpServer);
+  });
+
+  afterEach(() => {
+    broadcaster.close();
+  });
+
+  it("sends a ready message on connect", async () => {
+    const ws = new WebSocket(WS_URL);
+    await waitForOpen(ws);
+    const message = await waitForMessage(ws, (msg) => msg.type === "ready");
+    expect(message).toMatchObject({ type: "ready" });
+    expect(typeof message.blockIntervalMs).toBe("number");
+    expect(broadcaster.getClientCount()).toBe(1);
+    closeSocket(ws);
+    await waitForClose(ws);
+    await waitForCondition(() => broadcaster.getClientCount() === 0);
+  });
+
+  it("rejects a subscribe with no enabled channels (close 1008)", async () => {
+    const ws = new WebSocket(WS_URL);
+    await waitForOpen(ws);
+    await waitForMessage(ws, (msg) => msg.type === "ready");
+    ws.send(JSON.stringify({ action: "subscribe", channels: {} }));
+    const close = await waitForClose(ws);
+    expect(close.code).toBe(1008);
+  });
+
+  it("delivers a changes envelope with the inline trust object to a wildcard subscriber", async () => {
+    const ws = await openSubscribed(WS_URL, { channels: { trust: true } });
+    const promise = waitForMessage(ws, (msg) => msg.type === "block");
+    broadcaster.broadcastChangesEnvelope({
+      block: 1500005,
+      blockTime: "2026-05-11T13:00:05Z",
+      changes: [rawChange("did:web:a", { trust: TRUST_CORE })],
+    });
+    const msg = await promise;
+    expect(msg.block).toBe(1500005);
+    expect(msg.changes).toHaveLength(1);
+    expect(msg.changes[0]).toMatchObject({ did: "did:web:a", trust: TRUST_CORE });
+    closeSocket(ws);
+  });
+
+  it("applies channel sub-option gating (weight-only suppressed without includeWeightChanges)", async () => {
+    const ws = await openSubscribed(WS_URL, { channels: { participations: true } });
+    let received: any = null;
+    ws.on("message", (data) => {
+      const m = JSON.parse(data.toString());
+      if (m.type === "block") received = m;
+    });
+    broadcaster.broadcastChangesEnvelope({
+      block: 10,
+      blockTime: "t",
+      changes: [
+        rawChange("did:web:a", {
+          participations: { structural: false, weight: true, counts: false, issued: false, verified: false },
+        }),
+      ],
+    });
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(received).toMatchObject({ type: "block", block: 10, changes: [] });
+    closeSocket(ws);
+  });
+
+  it("filters changes by DID subscription", async () => {
+    const wsMatch = await openSubscribed(WS_URL, { channels: { trust: true }, dids: ["did:web:a"] });
+    const wsOther = await openSubscribed(WS_URL, { channels: { trust: true }, dids: ["did:web:z"] });
+
+    const matchPromise = waitForMessage(wsMatch, (msg) => msg.type === "block" && msg.changes.length > 0);
+    let otherGotChange = false;
+    wsOther.on("message", (data) => {
+      const m = JSON.parse(data.toString());
+      if (m.type === "block" && m.changes.length > 0) otherGotChange = true;
+    });
+
+    broadcaster.broadcastChangesEnvelope({
+      block: 10,
+      blockTime: "t",
+      changes: [rawChange("did:web:a", { trust: TRUST_CORE })],
+    });
+
+    const env = await matchPromise;
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(env.changes[0].did).toBe("did:web:a");
+    expect(otherGotChange).toBe(false);
+    closeSocket(wsMatch);
+    closeSocket(wsOther);
+  });
+
+  it("emits empty changes as a heartbeat", async () => {
+    const ws = await openSubscribed(WS_URL, { channels: { trust: true }, dids: ["did:web:a"] });
+    const promise = waitForMessage(ws, (msg) => msg.type === "block");
+    broadcaster.broadcastChangesEnvelope({
+      block: 777,
+      blockTime: "t",
+      changes: [rawChange("did:web:other", { trust: TRUST_CORE })],
+    });
+    const msg = await promise;
+    expect(msg).toMatchObject({ type: "block", block: 777, changes: [] });
+    closeSocket(ws);
+  });
+
+  it("does not deliver to clients that have not subscribed", async () => {
+    const ws = new WebSocket(WS_URL);
+    await waitForOpen(ws);
+    await waitForMessage(ws, (msg) => msg.type === "ready");
+    let gotBlock = false;
+    ws.on("message", (data) => {
+      const m = JSON.parse(data.toString());
+      if (m.type === "block") gotBlock = true;
+    });
+    broadcaster.broadcastChangesEnvelope({
+      block: 10,
+      blockTime: "t",
+      changes: [rawChange("did:web:a", { trust: TRUST_CORE })],
+    });
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(gotBlock).toBe(false);
+    closeSocket(ws);
+  });
+});

--- a/test/unit/services/api/vt_subscribe_protocol.spec.ts
+++ b/test/unit/services/api/vt_subscribe_protocol.spec.ts
@@ -1,0 +1,201 @@
+import {
+  parseVtControlMessage,
+  projectVtChange,
+  buildVtChangesEnvelope,
+  type VtChannelOptions,
+  type VtRawChange,
+} from "../../../../src/services/api/vt_subscribe_protocol";
+
+function rawChange(overrides: Partial<VtRawChange> & { did: string }): VtRawChange {
+  return {
+    relatedDids: new Set(),
+    corporationIds: new Set(),
+    trust: null,
+    corporation: null,
+    participations: null,
+    ecosystems: null,
+    content: false,
+    ...overrides,
+  };
+}
+
+function channels(overrides: Partial<VtChannelOptions> = {}): VtChannelOptions {
+  return {
+    trust: false,
+    ecsCredentials: false,
+    presentations: false,
+    services: false,
+    corporation: { include: false, includeDepositChanges: false },
+    participations: {
+      include: false,
+      includeWeightChanges: false,
+      includeParticipantCounts: false,
+      includeIssuedCredentials: false,
+      includeVerifiedCredentials: false,
+    },
+    ecosystems: {
+      include: false,
+      includeParticipantCounts: false,
+      includeIssuedCredentials: false,
+      includeVerifiedCredentials: false,
+    },
+    ...overrides,
+  };
+}
+
+describe("parseVtControlMessage", () => {
+  it("parses a subscribe with boolean channels and defaults sub-options to false", () => {
+    const res = parseVtControlMessage(
+      JSON.stringify({ action: "subscribe", channels: { trust: true, participations: true } })
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok || res.message.action !== "subscribe") throw new Error("expected subscribe");
+    expect(res.message.dids).toBeNull();
+    expect(res.message.corporationId).toBeNull();
+    expect(res.message.channels.trust).toBe(true);
+    expect(res.message.channels.participations).toMatchObject({
+      include: true,
+      includeWeightChanges: false,
+      includeParticipantCounts: false,
+    });
+    expect(res.message.channels.ecosystems.include).toBe(false);
+  });
+
+  it("parses participations sub-options", () => {
+    const res = parseVtControlMessage(
+      JSON.stringify({
+        action: "subscribe",
+        channels: { participations: { includeWeightChanges: true, includeIssuedCredentials: true } },
+      })
+    );
+    expect(res.ok).toBe(true);
+    if (!res.ok || res.message.action !== "subscribe") throw new Error("expected subscribe");
+    expect(res.message.channels.participations).toMatchObject({
+      include: true,
+      includeWeightChanges: true,
+      includeParticipantCounts: false,
+      includeIssuedCredentials: true,
+      includeVerifiedCredentials: false,
+    });
+  });
+
+  it("rejects a subscribe with no enabled channels", () => {
+    const res = parseVtControlMessage(JSON.stringify({ action: "subscribe", channels: {} }));
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects an invalid DID", () => {
+    const res = parseVtControlMessage(
+      JSON.stringify({ action: "subscribe", channels: { trust: true }, dids: ["not-a-did"] })
+    );
+    expect(res.ok).toBe(false);
+  });
+
+  it("rejects a non-positive corporationId", () => {
+    const res = parseVtControlMessage(
+      JSON.stringify({ action: "subscribe", channels: { trust: true }, corporationId: 0 })
+    );
+    expect(res.ok).toBe(false);
+  });
+
+  it("parses unsubscribe", () => {
+    const res = parseVtControlMessage(JSON.stringify({ action: "unsubscribe" }));
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error("expected ok");
+    expect(res.message.action).toBe("unsubscribe");
+  });
+});
+
+describe("projectVtChange (sub-option gating)", () => {
+  it("includes the inline trust object only when subscribed", () => {
+    const core = {
+      trusted: true,
+      evaluatedAtTime: "2026-05-11T13:00:05Z",
+      evaluatedAtBlock: 10,
+      expiresAtTime: "2026-05-12T13:00:05Z",
+      corporationId: 42,
+    };
+    const raw = rawChange({ did: "did:web:a", trust: core });
+    expect(projectVtChange(raw, channels({ trust: true }))?.trust).toEqual(core);
+    expect(projectVtChange(raw, channels({ ecsCredentials: true }))).toBeNull();
+  });
+
+  it("suppresses a weight-only participations change unless includeWeightChanges is set", () => {
+    const raw = rawChange({
+      did: "did:web:a",
+      participations: { structural: false, weight: true, counts: false, issued: false, verified: false },
+    });
+    expect(projectVtChange(raw, channels({ participations: { include: true, includeWeightChanges: false, includeParticipantCounts: false, includeIssuedCredentials: false, includeVerifiedCredentials: false } }))).toBeNull();
+    const enabled = projectVtChange(
+      raw,
+      channels({ participations: { include: true, includeWeightChanges: true, includeParticipantCounts: false, includeIssuedCredentials: false, includeVerifiedCredentials: false } })
+    );
+    expect(enabled?.participations).toBe(true);
+  });
+
+  it("always signals a structural participations change regardless of sub-options", () => {
+    const raw = rawChange({
+      did: "did:web:a",
+      participations: { structural: true, weight: false, counts: false, issued: false, verified: false },
+    });
+    expect(projectVtChange(raw, channels({ participations: { include: true, includeWeightChanges: false, includeParticipantCounts: false, includeIssuedCredentials: false, includeVerifiedCredentials: false } }))?.participations).toBe(true);
+  });
+
+  it("gates corporation deposit changes behind includeDepositChanges", () => {
+    const raw = rawChange({ did: "did:web:a", corporation: { structural: false, deposit: true } });
+    expect(projectVtChange(raw, channels({ corporation: { include: true, includeDepositChanges: false } }))).toBeNull();
+    expect(
+      projectVtChange(raw, channels({ corporation: { include: true, includeDepositChanges: true } }))?.corporation
+    ).toBe(true);
+  });
+
+  it("maps the content flag to ecsCredentials/presentations/services", () => {
+    const raw = rawChange({ did: "did:web:a", content: true });
+    const out = projectVtChange(raw, channels({ ecsCredentials: true, services: true }));
+    expect(out).toMatchObject({ ecsCredentials: true, services: true });
+    expect(out).not.toHaveProperty("presentations");
+  });
+});
+
+describe("buildVtChangesEnvelope (membership filter)", () => {
+  const core = {
+    trusted: true,
+    evaluatedAtTime: "2026-05-11T13:00:05Z",
+    evaluatedAtBlock: 10,
+    expiresAtTime: "2026-05-12T13:00:05Z",
+    corporationId: 7,
+  };
+
+  it("delivers all changed DIDs to a wildcard subscriber", () => {
+    const raws = [
+      rawChange({ did: "did:web:a", trust: core }),
+      rawChange({ did: "did:web:b", trust: core }),
+    ];
+    const env = buildVtChangesEnvelope(10, "t", raws, null, null, channels({ trust: true }));
+    expect(env.type).toBe("block");
+    expect(env.changes.map((c) => c.did).sort()).toEqual(["did:web:a", "did:web:b"]);
+  });
+
+  it("filters by DID and matches the validator one-hop relatedDids", () => {
+    const raws = [
+      rawChange({ did: "did:web:leaf", trust: core, relatedDids: new Set(["did:web:validator"]) }),
+      rawChange({ did: "did:web:other", trust: core }),
+    ];
+    const env = buildVtChangesEnvelope(10, "t", raws, new Set(["did:web:validator"]), null, channels({ trust: true }));
+    expect(env.changes.map((c) => c.did)).toEqual(["did:web:leaf"]);
+  });
+
+  it("filters by corporationId", () => {
+    const raws = [
+      rawChange({ did: "did:web:a", trust: core, corporationIds: new Set([42]) }),
+      rawChange({ did: "did:web:b", trust: core, corporationIds: new Set([99]) }),
+    ];
+    const env = buildVtChangesEnvelope(10, "t", raws, null, 42, channels({ trust: true }));
+    expect(env.changes.map((c) => c.did)).toEqual(["did:web:a"]);
+  });
+
+  it("emits an empty changes array as a heartbeat", () => {
+    const env = buildVtChangesEnvelope(10, "t", [], null, null, channels({ trust: true }));
+    expect(env.changes).toEqual([]);
+  });
+});


### PR DESCRIPTION
**Changes**
Implements IDX-VT-SUB-1: a new WebSocket endpoint `/v4/verifiable-trust/subscribe` to follow Verifiable Trust changes in real time, with subscription filters and per-channel options, plus tests for the new features.
- New `WS /v4/verifiable-trust/subscribe` that streams one `changes` envelope per processed block.
- `subscribe` control with `dids`, `corporationId` and `channels` (per-channel sub-options: weight, participant counts, issued/verified, deposit) and per-subscriber gating.
- Change-detection engine that derives per-DID signals from the persisted history `changes`, plus the inline `trust` core via diff against the previous block.
- Refactor: shared subscribe transport (`BaseSubscribeServer`) and shared helpers in `api_shared` (`parseSubscribeMembership`, `matchesMembership`) reused by the indexer and VT subscribes.