### PR TITLE
fix: update endpoint according to IDX-INDEXER-QRY-5

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -639,7 +639,7 @@
         }
       }
     },
-    "/verana/indexer/v1/changes/{block_height}": {
+    "/v4/indexer/changes": {
       "get": {
         "400": {
           "$ref": "#/components/responses/BadRequest"
@@ -651,18 +651,11 @@
           "Indexer"
         ],
         "summary": "List entity changes at a block height",
-        "description": "Return all indexed entity changes for the requested block height.",
+        "description": "Return all indexed entity changes committed at the block selected by the At-Block-Height header (or the latest indexed block when omitted).",
         "operationId": "listChanges",
         "parameters": [
           {
-            "name": "block_height",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "minimum": 0
-            },
-            "description": "The block height to query changes for. Must be a positive integer not exceeding the current indexed block height."
+            "$ref": "#/components/parameters/At-Block-Height"
           }
         ],
         "responses": {

--- a/src/services/api/api.service.ts
+++ b/src/services/api/api.service.ts
@@ -402,10 +402,10 @@ function createRoute(
       }),
       createRoute("/v4/indexer", {
         "GET snapshot": `${SERVICE.V1.IndexerSnapshotService.path}.getSnapshot`,
+        "GET changes": `${SERVICE.V1.IndexerMetaService.path}.listChanges`,
       }),
       createRoute("/verana/indexer/v1", {
         "GET block-height": `${SERVICE.V1.IndexerMetaService.path}.getBlockHeight`,
-        "GET changes/:block_height": `${SERVICE.V1.IndexerMetaService.path}.listChanges`,
         "GET events": `${SERVICE.V1.IndexerEventsService.path}.listEvents`,
         "GET version": `${SERVICE.V1.IndexerMetaService.path}.getVersion`,
         "GET status": `${SERVICE.V1.IndexerStatusService.path}.getDetailedStatus`,

--- a/src/services/manager/indexer_meta.service.ts
+++ b/src/services/manager/indexer_meta.service.ts
@@ -249,21 +249,22 @@ export default class IndexerMetaService extends BaseService {
     );
   }
 
-  @Action({
-    params: {
-      block_height: { type: "number", integer: true, positive: true, convert: true },
-    },
-  })
-  public async listChanges(ctx: Context<{ block_height: number }>) {
-    const blockHeight = ctx.params.block_height;
+  private async getLatestIndexedHeight(): Promise<number> {
+    const checkpoint = await knex("block_checkpoint")
+      .select("height")
+      .where("job_name", BULL_JOB_NAME.HANDLE_TRANSACTION)
+      .first();
+    const height = Number(checkpoint?.height ?? 0);
+    return Number.isInteger(height) && height >= 0 ? height : 0;
+  }
 
-    if (!Number.isInteger(blockHeight) || blockHeight < 0) {
-      return ApiResponder.error(
-        ctx,
-        "block_height parameter is required and must be a positive integer",
-        400
-      );
-    }
+  @Action()
+  public async listChanges(ctx: Context<unknown>) {
+    const headerHeight = (ctx.meta as { blockHeight?: number } | undefined)?.blockHeight;
+    const blockHeight =
+      typeof headerHeight === "number" && Number.isInteger(headerHeight) && headerHeight >= 0
+        ? headerHeight
+        : await this.getLatestIndexedHeight();
 
     const heightTimestampPromise = knex("transaction")
       .select("timestamp")

--- a/test/integration/api-endpoints.spec.ts
+++ b/test/integration/api-endpoints.spec.ts
@@ -208,10 +208,14 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
       expect(response.status).not.toBeGreaterThanOrEqual(500);
     });
 
-    itIf('should get changes by block height - valid height', async () => {
-      const response = await testEndpoint('GET', `/verana/indexer/v1/changes/${SAMPLE_BLOCK_HEIGHT}`);
+    itIf('should list changes at block height via At-Block-Height header', async () => {
+      const response = await testEndpoint('GET', '/v4/indexer/changes', {}, {
+        'At-Block-Height': SAMPLE_BLOCK_HEIGHT,
+      });
       expect(response.status).not.toBeGreaterThanOrEqual(500);
       if (response.status === 200) {
+        expect(response.data).toHaveProperty('block_height');
+        expect(response.data.block_height).toBe(SAMPLE_BLOCK_HEIGHT);
         expect(response.data).toHaveProperty('next_change_at');
         const nextChangeAt = response.data?.next_change_at;
         expect(nextChangeAt === null || Number.isInteger(nextChangeAt)).toBe(true);
@@ -221,23 +225,32 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
       }
     });
 
-    itIf('should get changes by block height - edge case: height 0', async () => {
-      const response = await testEndpoint('GET', '/verana/indexer/v1/changes/0');
-      expect(response.status).not.toBeGreaterThanOrEqual(500);
-    });
-
-    itIf('should get changes by block height - edge case: very large height', async () => {
-      const response = await testEndpoint('GET', '/verana/indexer/v1/changes/999999999');
+    itIf('should list changes at latest block when At-Block-Height is omitted', async () => {
+      const response = await testEndpoint('GET', '/v4/indexer/changes');
       expect(response.status).not.toBeGreaterThanOrEqual(500);
       if (response.status === 200) {
+        expect(response.data).toHaveProperty('block_height');
+        expect(Number.isInteger(response.data.block_height)).toBe(true);
         expect(response.data).toHaveProperty('next_change_at');
-        expect(response.data.next_change_at).toBeNull();
+        expect(response.data).toHaveProperty('activity');
+        expect(Array.isArray(response.data.activity)).toBe(true);
       }
     });
 
-    itIf('should get changes by block height - invalid: non-numeric', async () => {
-      const response = await testEndpoint('GET', '/verana/indexer/v1/changes/invalid');
+    itIf('should reject At-Block-Height above latest indexed height', async () => {
+      const response = await testEndpoint('GET', '/v4/indexer/changes', {}, {
+        'At-Block-Height': 999999999,
+      });
       expect(response.status).not.toBeGreaterThanOrEqual(500);
+      expect([400, 409]).toContain(response.status);
+    });
+
+    itIf('should reject non-numeric At-Block-Height', async () => {
+      const response = await testEndpoint('GET', '/v4/indexer/changes', {}, {
+        'At-Block-Height': 'invalid',
+      });
+      expect(response.status).not.toBeGreaterThanOrEqual(500);
+      expect(response.status).toBe(400);
     });
   });
 


### PR DESCRIPTION
**Changes**
* Moved routing to `/v4/indexer/changes`.
* Updated `listChanges` to resolve the block height from the `At-Block-Height` header according to the specification.
* Updated and validated the corresponding tests.