### PR TITLE
feat: implemented IDX-VT-QRY-3

### DIFF
--- a/docker/verana-test-flow.sh
+++ b/docker/verana-test-flow.sh
@@ -153,7 +153,7 @@ cat <<JSON | put /tmp/grant-prop.json
     "corporation": "${CORP}", "operator": "", "grantee": "${ADDR}",
     "msg_types": [$(echo "$GRANT_MSGS" | awk -F, '{for(i=1;i<=NF;i++){printf "%s\"%s\"",(i>1?",":""),$i}}')],
     "expiration": null, "authz_spend_limit": [], "authz_spend_limit_period": null,
-    "with_feegrant": false, "feegrant_spend_limit": [], "feegrant_spend_limit_period": null, "fee_spend_limit": []
+    "with_feegrant": false, "feegrant_spend_limit": [], "feegrant_spend_limit_period": null
   }],
   "metadata": "grant-operator-authz", "title": "Grant operator authz to ${KEY}",
   "summary": "Authorize ${KEY} to run VPR messages on behalf of the corporation",

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3970,6 +3970,83 @@
           "500": { "$ref": "#/components/responses/ServerError" }
         }
       }
+    },
+    "/v4/verifiable-trust/dids": {
+      "get": {
+        "tags": [
+          "Resolver"
+        ],
+        "summary": "List Indexed DIDs (IDX-VT-QRY-3)",
+        "description": "Enumerates the universe of DIDs the indexer can resolve at a frozen snapshot block, so a client with an empty mirror can bootstrap by resolving each via `/v4/verifiable-trust/resolve`. The snapshot block is selected via the `At-Block-Height` header (latest indexed block when omitted). The DID universe is the union of every Corporation `did`, every Ecosystem `did`, the DID of every in-scope Participant, and any DID previously evaluated by the resolver that the indexer still tracks.",
+        "operationId": "listIndexedDids",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/At-Block-Height"
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string" },
+            "description": "Opaque pagination cursor returned as `nextCursor` by a previous page. Omit for the first page."
+          },
+          {
+            "name": "corporation_id",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer", "format": "int64" },
+            "description": "Restrict the enumeration to the Corporation's expanded membership set at the snapshot block (direct ownership plus the one-hop validator-tree branch, same semantics as the WS subscribe of IDX-VT-SUB-1)."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer", "minimum": 1, "maximum": 10000, "default": 1000 },
+            "description": "Maximum number of DIDs to return. Defaults to 1000, capped at 10000."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of indexed DIDs at the resolved snapshot block.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["atBlock", "dids", "nextCursor"],
+                  "properties": {
+                    "atBlock": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "description": "Echo of the resolved snapshot block (the `At-Block-Height` value if provided, otherwise the latest indexed block)."
+                    },
+                    "dids": {
+                      "type": "array",
+                      "description": "Page of indexed DIDs in stable sort order across pages.",
+                      "items": { "type": "string" }
+                    },
+                    "nextCursor": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Opaque cursor for the next page; null (or absent) on the last page."
+                    }
+                  }
+                },
+                "example": {
+                  "atBlock": 1500004,
+                  "dids": [
+                    "did:webvh:QmRhJBzLMF6L3REha9xFpLgxui9X5tFm4TDxHoEHpA8Kpr:organization.vs.hologram.zone",
+                    "did:webvh:QmZ8Y3xRkH2pV4qTw9nL7sFmJg6cN5dB1aWxKvE3uPyT8r:corp.acme.example",
+                    "did:web:ecosystem.eu-passport.example"
+                  ],
+                  "nextCursor": "eyJvZmZzZXQiOjEwMDB9"
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
     }
   },
   "components": {

--- a/src/services/api/api.service.ts
+++ b/src/services/api/api.service.ts
@@ -124,7 +124,7 @@ async function parseAtBlockHeight(
   if (checkpoint && checkpoint.height > 0 && parsedHeight > checkpoint.height) {
     throw new Errors.MoleculerError(
       `Requested height ${parsedHeight} exceeds indexed height ${checkpoint.height}`,
-      409,
+      400,
       "AT_BLOCK_HEIGHT_AHEAD"
     );
   }
@@ -400,6 +400,7 @@ function createRoute(
       createRoute("/v4/verifiable-trust", {
         "POST resolve": `${SERVICE.V1.TrustV1ApiService.path}.resolveV4`,
         "GET changes": `${SERVICE.V1.IndexerMetaService.path}.listVtChanges`,
+        "GET dids": `${SERVICE.V1.IndexerMetaService.path}.listIndexedDids`,
       }),
       createRoute("/v4/indexer", {
         "GET snapshot": `${SERVICE.V1.IndexerSnapshotService.path}.getSnapshot`,

--- a/src/services/manager/indexer_meta.service.ts
+++ b/src/services/manager/indexer_meta.service.ts
@@ -13,13 +13,18 @@ import {
   VeranaCredentialSchemaMessageTypes,
   VeranaParticipantMessageTypes,
 } from "../../common/verana-message-types";
-import { toIsoSeconds } from "../api/api_shared";
+import { parseCorporationId, toIsoSeconds } from "../api/api_shared";
 import {
   buildVtChangesEnvelope,
   parseVtChangesQuery,
   type VtChange,
 } from "../api/vt_subscribe_protocol";
 import { buildVtChangesForBlock, listVtChangeHeights } from "../resolver/vt_change_detection";
+import {
+  decodeOffsetCursor,
+  listIndexedDidsPage,
+  parseIndexedDidsLimit,
+} from "../resolver/vt_indexed_dids";
 
 const VT_CHANGES_SCAN_PAGE = 500;
 
@@ -557,6 +562,39 @@ export default class IndexerMetaService extends BaseService {
       { currentBlock, fromBlock, blocks, nextFromBlock },
       200
     );
+  }
+
+  @Action({
+    params: {
+      cursor: { type: "any", optional: true },
+      corporation_id: { type: "any", optional: true },
+      limit: { type: "any", optional: true },
+    },
+  })
+  public async listIndexedDids(ctx: Context<Record<string, unknown>>) {
+    const params = ctx.params ?? {};
+
+    const corp = parseCorporationId(params.corporation_id);
+    if (!corp.ok) return ApiResponder.error(ctx, corp.error, 400);
+
+    const limit = parseIndexedDidsLimit(params.limit);
+    if (!limit.ok) return ApiResponder.error(ctx, limit.error, 400);
+
+    const cursor = decodeOffsetCursor(params.cursor);
+    if (!cursor.ok) return ApiResponder.error(ctx, cursor.error, 400);
+
+    const metaBlockHeight = (ctx.meta as { blockHeight?: number } | undefined)?.blockHeight;
+    const atBlock =
+      typeof metaBlockHeight === "number" ? metaBlockHeight : await this.getLatestIndexedHeight();
+
+    const { dids, nextCursor } = await listIndexedDidsPage({
+      atBlock,
+      corporationId: corp.value,
+      offset: cursor.value,
+      limit: limit.value,
+    });
+
+    return ApiResponder.success(ctx, { atBlock, dids, nextCursor }, 200);
   }
 
   private async blockTimesForHeights(heights: number[]): Promise<Map<number, string>> {

--- a/src/services/resolver/vt_indexed_dids.ts
+++ b/src/services/resolver/vt_indexed_dids.ts
@@ -1,0 +1,115 @@
+import knex from "../../common/utils/db_connection";
+
+export const INDEXED_DIDS_DEFAULT_LIMIT = 1000;
+export const INDEXED_DIDS_MAX_LIMIT = 10000;
+
+export function parseIndexedDidsLimit(
+  raw: unknown
+): { ok: true; value: number } | { ok: false; error: string } {
+  if (raw === undefined || raw === null || raw === "") {
+    return { ok: true, value: INDEXED_DIDS_DEFAULT_LIMIT };
+  }
+  const n = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isInteger(n) || n < 1 || n > INDEXED_DIDS_MAX_LIMIT) {
+    return {
+      ok: false,
+      error: `'limit' must be an integer between 1 and ${INDEXED_DIDS_MAX_LIMIT}; got ${String(raw)}`,
+    };
+  }
+  return { ok: true, value: n };
+}
+
+export function encodeOffsetCursor(offset: number): string {
+  return Buffer.from(JSON.stringify({ offset }), "utf-8").toString("base64");
+}
+
+export function decodeOffsetCursor(
+  raw: unknown
+): { ok: true; value: number } | { ok: false; error: string } {
+  if (raw === undefined || raw === null || raw === "") return { ok: true, value: 0 };
+  if (typeof raw !== "string") return { ok: false, error: "'cursor' must be a string" };
+  try {
+    const decoded = JSON.parse(Buffer.from(raw, "base64").toString("utf-8")) as { offset?: unknown };
+    const offset = Number(decoded.offset);
+    if (!Number.isInteger(offset) || offset < 0) {
+      return { ok: false, error: "'cursor' is not a valid pagination cursor" };
+    }
+    return { ok: true, value: offset };
+  } catch {
+    return { ok: false, error: "'cursor' is not a valid pagination cursor" };
+  }
+}
+
+function universeSubqueries(atBlock: number) {
+  const base = (table: string) =>
+    knex(table).distinct("did").whereNotNull("did").andWhere("height", "<=", atBlock);
+  return [
+    base("corporation_history"),
+    base("ecosystem_history"),
+    base("participant_history"),
+    base("trust_results"),
+  ];
+}
+
+function corporationSubqueries(atBlock: number, corporationId: number) {
+  const scoped = (table: string) =>
+    knex(table)
+      .distinct("did")
+      .whereNotNull("did")
+      .andWhere("height", "<=", atBlock)
+      .andWhere("corporation_id", corporationId);
+  const validatorsAtBlock = knex("participant_history as vph")
+    .distinctOn("vph.participant_id")
+    .select("vph.participant_id", "vph.corporation_id")
+    .where("vph.height", "<=", atBlock)
+    .orderBy("vph.participant_id", "asc")
+    .orderBy("vph.height", "desc")
+    .orderBy("vph.id", "desc");
+
+  const validatorIdsOwnedByCorp = knex
+    .from(validatorsAtBlock.as("v"))
+    .select("v.participant_id")
+    .where("v.corporation_id", corporationId);
+
+  const validatorBranch = knex("participant_history as ph")
+    .distinct("ph.did as did")
+    .whereNotNull("ph.did")
+    .andWhere("ph.height", "<=", atBlock)
+    .whereIn("ph.validator_participant_id", validatorIdsOwnedByCorp);
+  return [
+    scoped("corporation_history"),
+    scoped("ecosystem_history"),
+    scoped("participant_history"),
+    validatorBranch,
+  ];
+}
+
+export async function listIndexedDidsPage(opts: {
+  atBlock: number;
+  corporationId: number | null;
+  offset: number;
+  limit: number;
+}): Promise<{ dids: string[]; nextCursor: string | null }> {
+  const { atBlock, corporationId, offset, limit } = opts;
+  if (!Number.isInteger(atBlock) || atBlock < 0) {
+    return { dids: [], nextCursor: null };
+  }
+
+  const subqueries =
+    corporationId === null
+      ? universeSubqueries(atBlock)
+      : corporationSubqueries(atBlock, corporationId);
+
+  const union = knex.union(subqueries, true);
+  const rows = (await knex
+    .from(union.as("u"))
+    .distinct("did")
+    .orderBy("did", "asc")
+    .offset(offset)
+    .limit(limit + 1)) as Array<{ did: string }>;
+
+  const hasMore = rows.length > limit;
+  const dids = rows.slice(0, limit).map((r) => r.did);
+  const nextCursor = hasMore ? encodeOffsetCursor(offset + limit) : null;
+  return { dids, nextCursor };
+}

--- a/test/unit/services/resolver/vt_indexed_dids.spec.ts
+++ b/test/unit/services/resolver/vt_indexed_dids.spec.ts
@@ -1,0 +1,55 @@
+import {
+  INDEXED_DIDS_DEFAULT_LIMIT,
+  INDEXED_DIDS_MAX_LIMIT,
+  decodeOffsetCursor,
+  encodeOffsetCursor,
+  parseIndexedDidsLimit,
+} from "../../../../src/services/resolver/vt_indexed_dids";
+
+describe("vt_indexed_dids helpers", () => {
+  describe("parseIndexedDidsLimit", () => {
+    it("defaults when missing", () => {
+      for (const raw of [undefined, null, ""]) {
+        const r = parseIndexedDidsLimit(raw);
+        expect(r).toEqual({ ok: true, value: INDEXED_DIDS_DEFAULT_LIMIT });
+      }
+    });
+
+    it("accepts in-range integers (string or number)", () => {
+      expect(parseIndexedDidsLimit("500")).toEqual({ ok: true, value: 500 });
+      expect(parseIndexedDidsLimit(1)).toEqual({ ok: true, value: 1 });
+      expect(parseIndexedDidsLimit(INDEXED_DIDS_MAX_LIMIT)).toEqual({
+        ok: true,
+        value: INDEXED_DIDS_MAX_LIMIT,
+      });
+    });
+
+    it("rejects out-of-range, zero, negative and non-integers", () => {
+      for (const raw of [0, -1, 1.5, INDEXED_DIDS_MAX_LIMIT + 1, "abc"]) {
+        expect(parseIndexedDidsLimit(raw).ok).toBe(false);
+      }
+    });
+  });
+
+  describe("offset cursor round-trip", () => {
+    it("matches the spec example payload", () => {
+      expect(encodeOffsetCursor(1000)).toBe("eyJvZmZzZXQiOjEwMDB9");
+      expect(decodeOffsetCursor("eyJvZmZzZXQiOjEwMDB9")).toEqual({ ok: true, value: 1000 });
+    });
+
+    it("treats missing cursor as offset 0", () => {
+      for (const raw of [undefined, null, ""]) {
+        expect(decodeOffsetCursor(raw)).toEqual({ ok: true, value: 0 });
+      }
+    });
+
+    it("rejects malformed cursors", () => {
+      expect(decodeOffsetCursor("not-base64-json").ok).toBe(false);
+      expect(decodeOffsetCursor(123).ok).toBe(false);
+      const negative = Buffer.from(JSON.stringify({ offset: -1 }), "utf-8").toString("base64");
+      expect(decodeOffsetCursor(negative).ok).toBe(false);
+      const noOffset = Buffer.from(JSON.stringify({ foo: 1 }), "utf-8").toString("base64");
+      expect(decodeOffsetCursor(noOffset).ok).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
**Changes**
- Add GET /v4/verifiable-trust/dids listing the indexed DID universe at a snapshot block, with At-Block-Height, cursor, corporation_id and limit.
- Fix At-Block-Height over-range error 409 -> 400 per spec, update OpenAPI.
- Add unit testing.