### PR TITLE
feat: implement IDX-CO-QRY-1 get corporation (#256)

### DIFF
--- a/src/services/api/api.service.ts
+++ b/src/services/api/api.service.ts
@@ -355,6 +355,9 @@ function createRoute(path: string, aliases: Record<string, string>, requireBlock
       createRoute('/v4/exchange-rate', {
         'GET price': `${SERVICE.V1.ExchangeRateApiService.path}.getPrice`,
       }),
+      createRoute('/v4/corporation', {
+        'GET get/:id': `${SERVICE.V1.CorporationApiService.path}.getCorporationV4`,
+      }),
       createRoute('/verana/td/v1', {
         'GET get/:corporation': `${SERVICE.V1.TrustDepositApiService.path}.getTrustDeposit`,
         'GET params': `${SERVICE.V1.TrustDepositApiService.path}.getModuleParams`,

--- a/src/services/crawl-co/co_api.service.ts
+++ b/src/services/crawl-co/co_api.service.ts
@@ -7,6 +7,17 @@ import { SERVICE } from '../../common'
 import ApiResponder from '../../common/utils/apiResponse'
 import { Corporation } from '../../models/corporation'
 import { CorporationHistory } from '../../models/corporation_history'
+import { enrichTrustDataDeep, parseTrustDataMode } from '../resolver/trust-data-enrichment'
+import {
+  applyGfData,
+  type CorporationGfVersion,
+  calculateCorporationParticipantStats,
+  countControlledEcosystems,
+  deriveActiveVersion,
+  type GfDataMode,
+  getCorporationTrustDeposit,
+  getResolvedBlockHeight,
+} from './co_stats'
 
 @Service({
   name: SERVICE.V1.CorporationApiService.key,
@@ -35,6 +46,79 @@ export default class CorporationApiService extends BaseService {
       return ApiResponder.success(ctx, corporation)
     } catch (err: any) {
       return ApiResponder.error(ctx, err?.message || String(err), 500)
+    }
+  }
+
+  // IDX-CO-QRY-1 Get Corporation (v4)
+  @Action()
+  public async getCorporationV4(
+    ctx: Context<{ id: string; gf_data?: string; preferred_language?: string; trust_data?: string }>
+  ) {
+    try {
+      const { id, preferred_language: preferredLanguage } = ctx.params
+      const gfData = (ctx.params.gf_data ?? 'only_active') as GfDataMode
+
+      const trustDataParsed = parseTrustDataMode(ctx.params.trust_data)
+      if (!trustDataParsed.ok) {
+        return ApiResponder.error(ctx, trustDataParsed.message, 400)
+      }
+      const trustDataMode = trustDataParsed.mode
+
+      const numericId = Number(id)
+      if (!Number.isInteger(numericId) || numericId <= 0) {
+        return ApiResponder.error(ctx, `Invalid corporation id '${id}'`, 400)
+      }
+
+      const meta = (ctx.meta ?? {}) as Record<string, unknown>
+      const blockHeight = typeof meta.blockHeight === 'number' ? meta.blockHeight : undefined
+
+      const corporationRow = await Corporation.query()
+        .findById(numericId)
+        .withGraphFetched('governanceFrameworkVersions.documents')
+
+      if (!corporationRow) {
+        return ApiResponder.error(ctx, `Corporation ${id} not found`, 404)
+      }
+
+      const plain = corporationRow.toJSON() as Record<string, unknown>
+      const corporationId = Number(plain.id)
+      const allVersions = (plain.governanceFrameworkVersions ?? []) as CorporationGfVersion[]
+      const policyAddress = (plain.corporation as string | null) ?? (plain.policy_address as string | null) ?? null
+
+      // Aggregates are latest-state; point-in-time reconstruction is deferred (no corporation_snapshot).
+      const [participantStats, controlledEcosystems, trustDeposit] = await Promise.all([
+        calculateCorporationParticipantStats(corporationId),
+        countControlledEcosystems(corporationId),
+        getCorporationTrustDeposit(policyAddress),
+      ])
+
+      const corporation: Record<string, unknown> = {
+        id: corporationId,
+        did: plain.did,
+        policy_address: plain.policy_address ?? null,
+        language: plain.language ?? null,
+        active_version: deriveActiveVersion(allVersions),
+        archived: null,
+        created: plain.created,
+        modified: plain.modified,
+        controlled_ecosystems: controlledEcosystems,
+        ...participantStats,
+        ...trustDeposit,
+      }
+
+      if (gfData !== 'none') {
+        corporation.versions = applyGfData(allVersions, gfData, preferredLanguage)
+      }
+
+      const responsePayload = { corporation, block_height: await getResolvedBlockHeight(blockHeight) }
+      const enriched =
+        trustDataMode === 'none'
+          ? responsePayload
+          : await enrichTrustDataDeep(responsePayload, trustDataMode, blockHeight)
+
+      return ApiResponder.success(ctx, enriched)
+    } catch (err) {
+      return ApiResponder.error(ctx, err instanceof Error ? err.message : String(err), 500)
     }
   }
 

--- a/src/services/crawl-co/co_stats.ts
+++ b/src/services/crawl-co/co_stats.ts
@@ -1,0 +1,174 @@
+import { BULL_JOB_NAME } from '../../common'
+import { getBlockChainTimeAsOf } from '../../common/utils/block_time'
+import knex from '../../common/utils/db_connection'
+import { Ecosystem } from '../../models/ecosystem'
+import TrustDeposit from '../../models/trust_deposit'
+import { calculateParticipantState } from '../crawl-pp/pp_state_utils'
+
+export type GfDataMode = 'none' | 'only_active' | 'all'
+
+export interface CorporationGfVersion {
+  version: number
+  active_since?: string | Date | null
+  documents?: Array<Record<string, unknown>>
+  [key: string]: unknown
+}
+
+export interface CorporationTrustDepositSnapshot {
+  deposit: number
+  share: number
+  refunded: number
+  slashed_deposit: number
+  repaid_deposit: number
+  slash_count: number
+  last_slashed: string | null
+  last_repaid: string | null
+}
+
+export interface CorporationParticipantStats {
+  participants: number
+  participants_ecosystem: number
+  participants_issuer_grantor: number
+  participants_issuer: number
+  participants_verifier_grantor: number
+  participants_verifier: number
+  participants_holder: number
+}
+
+function emptyParticipantStats(): CorporationParticipantStats {
+  return {
+    participants: 0,
+    participants_ecosystem: 0,
+    participants_issuer_grantor: 0,
+    participants_issuer: 0,
+    participants_verifier_grantor: 0,
+    participants_verifier: 0,
+    participants_holder: 0,
+  }
+}
+
+export async function calculateCorporationParticipantStats(
+  corporationId: number,
+  blockHeight?: number
+): Promise<CorporationParticipantStats> {
+  const stats = emptyParticipantStats()
+
+  let now = new Date()
+  if (typeof blockHeight === 'number') {
+    now = await getBlockChainTimeAsOf(blockHeight, { logContext: '[co_stats]' })
+  }
+
+  const rows = await knex('participants').where('corporation_id', corporationId)
+
+  for (const row of rows) {
+    const state = calculateParticipantState(
+      {
+        repaid: row.repaid,
+        slashed: row.slashed,
+        revoked: row.revoked,
+        effective_from: row.effective_from,
+        effective_until: row.effective_until,
+        role: row.role,
+        op_state: row.op_state,
+        op_exp: row.op_exp,
+        validator_participant_id: row.validator_participant_id,
+      },
+      now
+    )
+    if (state !== 'ACTIVE') continue
+
+    stats.participants += 1
+    if (row.role === 'ECOSYSTEM') stats.participants_ecosystem += 1
+    else if (row.role === 'ISSUER_GRANTOR') stats.participants_issuer_grantor += 1
+    else if (row.role === 'ISSUER') stats.participants_issuer += 1
+    else if (row.role === 'VERIFIER_GRANTOR') stats.participants_verifier_grantor += 1
+    else if (row.role === 'VERIFIER') stats.participants_verifier += 1
+    else if (row.role === 'HOLDER') stats.participants_holder += 1
+  }
+
+  return stats
+}
+
+export async function countControlledEcosystems(corporationId: number): Promise<number> {
+  return Ecosystem.query().where('corporation_id', corporationId).resultSize()
+}
+
+function byActiveSinceDesc(a: CorporationGfVersion, b: CorporationGfVersion): number {
+  if (!a.active_since && !b.active_since) return 0
+  if (!a.active_since) return 1
+  if (!b.active_since) return -1
+  return new Date(b.active_since).getTime() - new Date(a.active_since).getTime()
+}
+
+export function deriveActiveVersion(versions: CorporationGfVersion[]): number | null {
+  const active = versions.filter((v) => v.active_since).sort(byActiveSinceDesc)
+  return active.length > 0 ? active[0].version : null
+}
+
+export async function getCorporationTrustDeposit(address: string | null): Promise<CorporationTrustDepositSnapshot> {
+  const empty: CorporationTrustDepositSnapshot = {
+    deposit: 0,
+    share: 0,
+    refunded: 0,
+    slashed_deposit: 0,
+    repaid_deposit: 0,
+    slash_count: 0,
+    last_slashed: null,
+    last_repaid: null,
+  }
+  if (!address) return empty
+
+  const row = await TrustDeposit.query().findOne({ corporation: address })
+  if (!row) return empty
+
+  return {
+    deposit: Number(row.deposit ?? 0),
+    share: Number(row.share ?? 0),
+    refunded: Number(row.claimable ?? 0),
+    slashed_deposit: Number(row.slashed_deposit ?? 0),
+    repaid_deposit: Number(row.repaid_deposit ?? 0),
+    slash_count: Number(row.slash_count ?? 0),
+    last_slashed: row.last_slashed ?? null,
+    last_repaid: row.last_repaid ?? null,
+  }
+}
+
+function orderDocumentsByLanguage(
+  documents: Array<Record<string, unknown>>,
+  preferredLanguage: string
+): Array<Record<string, unknown>> {
+  const preferred = documents.filter((d) => d.language === preferredLanguage)
+  const rest = documents.filter((d) => d.language !== preferredLanguage)
+  return [...preferred, ...rest]
+}
+
+export function applyGfData(
+  versions: CorporationGfVersion[],
+  gfData: GfDataMode,
+  preferredLanguage?: string
+): CorporationGfVersion[] {
+  let selected: CorporationGfVersion[]
+  if (gfData === 'none') {
+    selected = []
+  } else if (gfData === 'only_active') {
+    selected = versions
+      .filter((v) => v.active_since)
+      .sort(byActiveSinceDesc)
+      .slice(0, 1)
+  } else {
+    selected = [...versions]
+  }
+
+  // ecosystem_id is null for CGF versions (VPR invariant: only EGF versions carry one).
+  return selected.map((v) => ({
+    ...v,
+    ecosystem_id: v.ecosystem_id ? v.ecosystem_id : null,
+    documents: preferredLanguage ? orderDocumentsByLanguage(v.documents ?? [], preferredLanguage) : v.documents,
+  }))
+}
+
+export async function getResolvedBlockHeight(blockHeight?: number): Promise<number> {
+  if (typeof blockHeight === 'number') return blockHeight
+  const row = await knex('block_checkpoint').where('job_name', BULL_JOB_NAME.HANDLE_TRANSACTION).first()
+  return row?.height != null ? Number(row.height) : 0
+}

--- a/test/unit/services/crawl-co/co_api_v4.spec.ts
+++ b/test/unit/services/crawl-co/co_api_v4.spec.ts
@@ -1,0 +1,210 @@
+jest.mock('../../../../src/models/corporation', () => ({ Corporation: { query: jest.fn() } }))
+jest.mock('../../../../src/models/corporation_history', () => ({ CorporationHistory: { query: jest.fn() } }))
+jest.mock('../../../../src/services/crawl-co/co_stats', () => ({
+  calculateCorporationParticipantStats: jest.fn(),
+  countControlledEcosystems: jest.fn(),
+  getCorporationTrustDeposit: jest.fn(),
+  deriveActiveVersion: jest.fn(),
+  applyGfData: jest.fn(),
+  getResolvedBlockHeight: jest.fn(async () => 0),
+}))
+jest.mock('../../../../src/services/resolver/trust-data-enrichment', () => ({
+  parseTrustDataMode: jest.fn(() => ({ ok: true, mode: 'none' })),
+  enrichTrustDataDeep: jest.fn(async (v: unknown) => v),
+}))
+jest.mock('../../../../src/common/utils/apiResponse', () => ({
+  __esModule: true,
+  default: {
+    success: jest.fn((_ctx: unknown, data: unknown) => data),
+    error: jest.fn((_ctx: unknown, message: string, code: number) => ({ error: message, code })),
+  },
+}))
+
+import { ServiceBroker } from 'moleculer'
+import ApiResponder from '../../../../src/common/utils/apiResponse'
+import { Corporation } from '../../../../src/models/corporation'
+import CorporationApiService from '../../../../src/services/crawl-co/co_api.service'
+import {
+  applyGfData,
+  calculateCorporationParticipantStats,
+  countControlledEcosystems,
+  deriveActiveVersion,
+  getCorporationTrustDeposit,
+  getResolvedBlockHeight,
+} from '../../../../src/services/crawl-co/co_stats'
+
+function fetchReturns(corporation: unknown) {
+  ;(Corporation.query as jest.Mock).mockReturnValue({
+    findById: jest.fn().mockReturnValue({
+      withGraphFetched: jest.fn().mockResolvedValue(corporation),
+    }),
+  })
+}
+
+describe('CorporationApiService.getCorporationV4', () => {
+  const broker = new ServiceBroker({ logger: false })
+  const service = new CorporationApiService(broker)
+
+  beforeEach(() => jest.clearAllMocks())
+
+  it('returns 404 when the corporation does not exist', async () => {
+    fetchReturns(undefined)
+    const ctx: any = { params: { id: '99' }, meta: {} }
+
+    await service.getCorporationV4(ctx)
+
+    expect(ApiResponder.error).toHaveBeenCalledWith(ctx, 'Corporation 99 not found', 404)
+  })
+
+  it('returns 400 for a non-numeric id (uint64 required) instead of crashing', async () => {
+    const ctx: any = { params: { id: 'abc' }, meta: {} }
+
+    await service.getCorporationV4(ctx)
+
+    expect(ApiResponder.error).toHaveBeenCalledWith(ctx, expect.stringContaining('Invalid corporation id'), 400)
+    expect(Corporation.query as jest.Mock).not.toHaveBeenCalled()
+  })
+
+  it('builds the spec response object: { corporation } with on-chain fields + aggregates + versions', async () => {
+    fetchReturns({
+      toJSON: () => ({
+        id: 1,
+        did: 'did:example:co',
+        policy_address: 'verana1pol',
+        corporation: 'verana1pol',
+        language: 'en',
+        created: '2024-01-01',
+        modified: '2024-02-01',
+        governanceFrameworkVersions: [{ version: 1, active_since: '2024-01-01', documents: [{ language: 'en' }] }],
+      }),
+    })
+    ;(calculateCorporationParticipantStats as jest.Mock).mockResolvedValue({
+      participants: 2,
+      participants_ecosystem: 0,
+      participants_issuer_grantor: 0,
+      participants_issuer: 1,
+      participants_verifier_grantor: 0,
+      participants_verifier: 0,
+      participants_holder: 1,
+    })
+    ;(countControlledEcosystems as jest.Mock).mockResolvedValue(2)
+    ;(getCorporationTrustDeposit as jest.Mock).mockResolvedValue({
+      deposit: 100,
+      share: 5,
+      refunded: 9,
+      slashed_deposit: 3,
+      repaid_deposit: 2,
+      slash_count: 1,
+      last_slashed: null,
+      last_repaid: null,
+    })
+    ;(deriveActiveVersion as jest.Mock).mockReturnValue(1)
+    ;(applyGfData as jest.Mock).mockReturnValue([
+      { version: 1, active_since: '2024-01-01', documents: [{ language: 'en' }] },
+    ])
+    ;(getResolvedBlockHeight as jest.Mock).mockResolvedValue(175)
+
+    const ctx: any = { params: { id: '1', gf_data: 'all' }, meta: {} }
+    const res: any = await service.getCorporationV4(ctx)
+
+    expect(res.corporation).toEqual({
+      id: 1,
+      did: 'did:example:co',
+      policy_address: 'verana1pol',
+      language: 'en',
+      active_version: 1,
+      archived: null,
+      created: '2024-01-01',
+      modified: '2024-02-01',
+      controlled_ecosystems: 2,
+      participants: 2,
+      participants_ecosystem: 0,
+      participants_issuer_grantor: 0,
+      participants_issuer: 1,
+      participants_verifier_grantor: 0,
+      participants_verifier: 0,
+      participants_holder: 1,
+      deposit: 100,
+      share: 5,
+      refunded: 9,
+      slashed_deposit: 3,
+      repaid_deposit: 2,
+      slash_count: 1,
+      last_slashed: null,
+      last_repaid: null,
+      versions: [{ version: 1, active_since: '2024-01-01', documents: [{ language: 'en' }] }],
+    })
+    expect(res.block_height).toBe(175)
+    expect(getCorporationTrustDeposit).toHaveBeenCalledWith('verana1pol')
+    expect(applyGfData).toHaveBeenCalledWith(expect.any(Array), 'all', undefined)
+  })
+
+  it('omits versions entirely when gf_data is "none"', async () => {
+    fetchReturns({
+      toJSON: () => ({ id: 1, did: 'did:example:co', corporation: 'verana1pol', governanceFrameworkVersions: [] }),
+    })
+    ;(calculateCorporationParticipantStats as jest.Mock).mockResolvedValue({
+      participants: 0,
+      participants_ecosystem: 0,
+      participants_issuer_grantor: 0,
+      participants_issuer: 0,
+      participants_verifier_grantor: 0,
+      participants_verifier: 0,
+      participants_holder: 0,
+    })
+    ;(countControlledEcosystems as jest.Mock).mockResolvedValue(0)
+    ;(getCorporationTrustDeposit as jest.Mock).mockResolvedValue({
+      deposit: 0,
+      share: 0,
+      refunded: 0,
+      slashed_deposit: 0,
+      repaid_deposit: 0,
+      slash_count: 0,
+      last_slashed: null,
+      last_repaid: null,
+    })
+    ;(deriveActiveVersion as jest.Mock).mockReturnValue(null)
+    ;(applyGfData as jest.Mock).mockReturnValue([])
+
+    const ctx: any = { params: { id: '1', gf_data: 'none' }, meta: {} }
+    const res: any = await service.getCorporationV4(ctx)
+
+    expect('versions' in res.corporation).toBe(false)
+  })
+
+  it('computes entity aggregates at latest state, but echoes At-Block-Height (point-in-time deferred)', async () => {
+    fetchReturns({
+      toJSON: () => ({ id: 1, did: 'did:example:co', corporation: 'verana1pol', governanceFrameworkVersions: [] }),
+    })
+    ;(calculateCorporationParticipantStats as jest.Mock).mockResolvedValue({
+      participants: 0,
+      participants_ecosystem: 0,
+      participants_issuer_grantor: 0,
+      participants_issuer: 0,
+      participants_verifier_grantor: 0,
+      participants_verifier: 0,
+      participants_holder: 0,
+    })
+    ;(countControlledEcosystems as jest.Mock).mockResolvedValue(0)
+    ;(getCorporationTrustDeposit as jest.Mock).mockResolvedValue({
+      deposit: 0,
+      share: 0,
+      refunded: 0,
+      slashed_deposit: 0,
+      repaid_deposit: 0,
+      slash_count: 0,
+      last_slashed: null,
+      last_repaid: null,
+    })
+    ;(deriveActiveVersion as jest.Mock).mockReturnValue(null)
+    ;(getResolvedBlockHeight as jest.Mock).mockResolvedValue(5)
+
+    const ctx: any = { params: { id: '1', gf_data: 'none' }, meta: { blockHeight: 5 } }
+    await service.getCorporationV4(ctx)
+
+    // entity counts computed at latest (no block height threaded into the membership query)
+    expect(calculateCorporationParticipantStats).toHaveBeenCalledWith(1)
+    // block_height still resolves/echoes the requested At-Block-Height
+    expect(getResolvedBlockHeight).toHaveBeenCalledWith(5)
+  })
+})

--- a/test/unit/services/crawl-co/co_stats.spec.ts
+++ b/test/unit/services/crawl-co/co_stats.spec.ts
@@ -1,0 +1,205 @@
+const mockParticipantsWhere = jest.fn()
+const mockCheckpointFirst = jest.fn()
+
+jest.mock('../../../../src/common/utils/db_connection', () => ({
+  __esModule: true,
+  default: jest.fn((table: string) => {
+    if (table === 'block_checkpoint') {
+      return { where: jest.fn(() => ({ first: mockCheckpointFirst })) }
+    }
+    return { where: mockParticipantsWhere }
+  }),
+}))
+
+jest.mock('../../../../src/models/ecosystem', () => ({ Ecosystem: { query: jest.fn() } }))
+jest.mock('../../../../src/models/trust_deposit', () => ({ __esModule: true, default: { query: jest.fn() } }))
+
+import { Ecosystem } from '../../../../src/models/ecosystem'
+import TrustDeposit from '../../../../src/models/trust_deposit'
+import {
+  applyGfData,
+  calculateCorporationParticipantStats,
+  countControlledEcosystems,
+  deriveActiveVersion,
+  getCorporationTrustDeposit,
+  getResolvedBlockHeight,
+} from '../../../../src/services/crawl-co/co_stats'
+
+describe('co_stats.calculateCorporationParticipantStats', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('counts only ACTIVE participants, broken down by role, scoped to the corporation', async () => {
+    const past = new Date('2020-01-01T00:00:00Z')
+    mockParticipantsWhere.mockResolvedValueOnce([
+      { corporation_id: 5, role: 'ISSUER', effective_from: past },
+      { corporation_id: 5, role: 'HOLDER', effective_from: past },
+      { corporation_id: 5, role: 'VERIFIER', effective_from: past, revoked: past },
+    ])
+
+    const stats = await calculateCorporationParticipantStats(5)
+
+    expect(stats).toEqual({
+      participants: 2,
+      participants_ecosystem: 0,
+      participants_issuer_grantor: 0,
+      participants_issuer: 1,
+      participants_verifier_grantor: 0,
+      participants_verifier: 0,
+      participants_holder: 1,
+    })
+    expect(mockParticipantsWhere).toHaveBeenCalledWith('corporation_id', 5)
+  })
+})
+
+describe('co_stats.countControlledEcosystems', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('counts ecosystems whose corporation_id matches', async () => {
+    const where = jest.fn().mockReturnValue({ resultSize: jest.fn().mockResolvedValue(3) })
+    ;(Ecosystem.query as jest.Mock).mockReturnValue({ where })
+
+    const n = await countControlledEcosystems(7)
+
+    expect(n).toBe(3)
+    expect(where).toHaveBeenCalledWith('corporation_id', 7)
+  })
+})
+
+describe('co_stats.deriveActiveVersion', () => {
+  it('returns the version number with the most recent active_since', () => {
+    const result = deriveActiveVersion([
+      { version: 1, active_since: '2020-01-01T00:00:00Z' },
+      { version: 3, active_since: '2022-01-01T00:00:00Z' },
+      { version: 2, active_since: '2021-01-01T00:00:00Z' },
+      { version: 4, active_since: null },
+    ])
+    expect(result).toBe(3)
+  })
+
+  it('returns null when no version has been activated', () => {
+    expect(deriveActiveVersion([{ version: 1, active_since: null }])).toBeNull()
+    expect(deriveActiveVersion([])).toBeNull()
+  })
+})
+
+describe('co_stats.getCorporationTrustDeposit', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('maps the trust-deposit row (claimable -> refunded)', async () => {
+    ;(TrustDeposit.query as jest.Mock).mockReturnValue({
+      findOne: jest.fn().mockResolvedValue({
+        deposit: 100,
+        share: 5,
+        claimable: 9,
+        slashed_deposit: 3,
+        repaid_deposit: 2,
+        slash_count: 1,
+        last_slashed: '2021-01-01',
+        last_repaid: '2021-02-01',
+      }),
+    })
+
+    const td = await getCorporationTrustDeposit('verana1abc')
+
+    expect(td).toEqual({
+      deposit: 100,
+      share: 5,
+      refunded: 9,
+      slashed_deposit: 3,
+      repaid_deposit: 2,
+      slash_count: 1,
+      last_slashed: '2021-01-01',
+      last_repaid: '2021-02-01',
+    })
+  })
+
+  it('returns a zeroed snapshot when no trust-deposit row exists', async () => {
+    ;(TrustDeposit.query as jest.Mock).mockReturnValue({ findOne: jest.fn().mockResolvedValue(undefined) })
+
+    const td = await getCorporationTrustDeposit('verana1none')
+
+    expect(td).toEqual({
+      deposit: 0,
+      share: 0,
+      refunded: 0,
+      slashed_deposit: 0,
+      repaid_deposit: 0,
+      slash_count: 0,
+      last_slashed: null,
+      last_repaid: null,
+    })
+  })
+
+  it('returns a zeroed snapshot without querying when address is empty', async () => {
+    const td = await getCorporationTrustDeposit(null)
+    expect(td.deposit).toBe(0)
+    expect(TrustDeposit.query as jest.Mock).not.toHaveBeenCalled()
+  })
+})
+
+describe('co_stats.applyGfData', () => {
+  const versions = [
+    { version: 1, active_since: '2020-01-01T00:00:00Z', documents: [{ language: 'en' }, { language: 'fr' }] },
+    { version: 2, active_since: '2021-01-01T00:00:00Z', documents: [{ language: 'en' }] },
+  ]
+
+  it('returns an empty array when gf_data is "none"', () => {
+    expect(applyGfData(versions, 'none')).toEqual([])
+  })
+
+  it('returns only the most recently activated version when gf_data is "only_active"', () => {
+    const result = applyGfData(versions, 'only_active')
+    expect(result).toHaveLength(1)
+    expect(result[0].version).toBe(2)
+  })
+
+  it('returns all versions when gf_data is "all"', () => {
+    expect(applyGfData(versions, 'all')).toHaveLength(2)
+  })
+
+  it("orders each version's documents by preferred_language (preferred first, none dropped)", () => {
+    const result = applyGfData(versions, 'all', 'fr')
+    expect(result[0].documents).toEqual([{ language: 'fr' }, { language: 'en' }])
+    expect(result[1].documents).toEqual([{ language: 'en' }])
+  })
+
+  it('normalizes ecosystem_id to null for CGF versions (spec: ecosystem_id set iff EGF)', () => {
+    const result = applyGfData(
+      [{ version: 1, ecosystem_id: 0, corporation_id: 7, active_since: '2020-01-01T00:00:00Z', documents: [] }],
+      'all'
+    )
+    expect(result[0].ecosystem_id).toBeNull()
+    expect(result[0].corporation_id).toBe(7)
+  })
+
+  it('returns no version for "only_active" when none has been activated', () => {
+    const result = applyGfData(
+      [
+        { version: 1, active_since: null, documents: [] },
+        { version: 2, active_since: null, documents: [] },
+      ],
+      'only_active'
+    )
+    expect(result).toEqual([])
+  })
+})
+
+describe('co_stats.getResolvedBlockHeight', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('returns the provided block height without a DB lookup', async () => {
+    const h = await getResolvedBlockHeight(42)
+    expect(h).toBe(42)
+    expect(mockCheckpointFirst).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the latest indexed height from block_checkpoint', async () => {
+    mockCheckpointFirst.mockResolvedValueOnce({ height: 175 })
+    expect(await getResolvedBlockHeight()).toBe(175)
+  })
+
+  it('returns 0 when no checkpoint row exists', async () => {
+    mockCheckpointFirst.mockResolvedValueOnce(undefined)
+    expect(await getResolvedBlockHeight()).toBe(0)
+  })
+})


### PR DESCRIPTION
`GET /v4/corporation/get/{id}` — IDX-CO-QRY-1, mirroring the existing getEcosystem read-side.

### Response
`{ corporation, block_height }`. The corporation carries on-chain fields, indexer
aggregates (controlled_ecosystems, participant role counts, trust-deposit snapshot),
and CGF versions[] with documents[].

Params: gf_data (none|only_active|all, default only_active), preferred_language,
trust_data (null|summary|full). At-Block-Height is validated and echoed via block_height.

### Changes
- co_stats.ts (new) — aggregate helpers
- co_api.service.ts — getCorporationV4 action
- api.service.ts — /v4/corporation route
- unit tests

### Verification
- Unit: 21 corporation tests; full suite green; biome + tsc clean.
- Real chain: built verana from source, ran a local node, created a corporation + CGF +
  ecosystem via the test harness, crawled with the indexer, confirmed correct endpoint output.

### Deferred (follow-ups)
- archived → null (no corporation-archive message on-chain yet).
- Point-in-time entity state (no corporation_snapshot; At-Block-Height returns latest).
