### PR TITLE
ci: pin remaining github actions to full commit sha

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       # Please look up the latest version from
       # https://github.com/amannn/action-semantic-pull-request/releases
-      - uses: amannn/action-semantic-pull-request@v6.1.1
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,13 +11,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           run_install: false 
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22.17.1' 
           cache: 'pnpm'

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Release PR
         id: release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
@@ -39,13 +39,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       
       - name: Setup Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
 
       - name: Setup node v22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
 
@@ -58,13 +58,13 @@ jobs:
           pnpm install
 
       - name: Docker login
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           username: ${{ secrets.DOCKER_HUB_LOGIN }}
           password: ${{ secrets.DOCKER_HUB_PWD }}
 
       - name: Build & push stable Docker images
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           file: ./docker/Dockerfile
@@ -100,7 +100,7 @@ jobs:
     if: needs.release-please.outputs.releases_created == 'true'
     permissions:
       contents: read
-    uses: 2060-io/organization/.github/workflows/discord-release-notify-call.yml@main
+    uses: 2060-io/organization/.github/workflows/discord-release-notify-call.yml@5f813454d8962db006c4e4466f3af1cf4af8dfa4 # main
     with:
       tag_name: ${{ needs.release-please.outputs.tag_name }}
     secrets:
@@ -110,7 +110,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
-    uses: 2060-io/organization/.github/workflows/discord-release-notify-call.yml@main
+    uses: 2060-io/organization/.github/workflows/discord-release-notify-call.yml@5f813454d8962db006c4e4466f3af1cf4af8dfa4 # main
     with:
       tag_name: ${{ inputs.notify_tag }}
     secrets:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,19 +31,19 @@ jobs:
           - 6379:6379
           
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.17.1
           registry-url: https://npm.pkg.github.com/aura-nw
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           run_install: false
 
       - name: Cache pnpm store
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}


### PR DESCRIPTION
Pins the remaining workflows: lint.yml, test.yml, lint-pr.yml, stable-release.yml.
dev-release.yml was already pinned (#298). Reuses the team's existing SHAs
(checkout v4.2.2, setup-node v4.4.0, setup-helm v3.5) for consistency; existing
versions kept (no upgrades).
