### PR TITLE
feat: implement IDX-CO-QRY-2 list corporations (#257)

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -98,10 +98,67 @@
         "tags": [
           "Corporation"
         ],
-        "summary": "List Corporations",
-        "description": "Retrieve a paginated list of Corporations with their members and governance framework versions/documents.",
-        "operationId": "listCorporations",
+        "summary": "List Corporations (v4)",
+        "description": "Paginated, filtered list of Corporations; each entry has the same shape as Get Corporation (IDX-CO-QRY-1). Aligned with VPR MOD-CO-QRY-2. When At-Block-Height is supplied, corporations not yet created at that block are excluded.",
+        "operationId": "listCorporationsV4",
         "parameters": [
+          {
+            "name": "gf_data",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "none",
+                "only_active",
+                "all"
+              ],
+              "default": "only_active"
+            },
+            "description": "Controls inclusion of CGF versions"
+          },
+          {
+            "name": "preferred_language",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ISO 639 language; orders returned CGF documents"
+          },
+          {
+            "name": "did",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by Corporation DID (exact match)"
+          },
+          {
+            "name": "modified_after",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "description": "Only Corporations modified strictly after this ISO 8601 datetime"
+          },
+          {
+            "name": "trust_data",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "none",
+                "summary",
+                "full"
+              ]
+            },
+            "description": "Inline verifiable-trust data per Corporation DID"
+          },
           {
             "name": "limit",
             "in": "query",
@@ -109,39 +166,63 @@
             "schema": {
               "type": "integer",
               "minimum": 1,
-              "maximum": 1000,
-              "default": 100
+              "maximum": 1024,
+              "default": 64
             },
-            "description": "Maximum number of records to return"
+            "description": "Page size"
           },
           {
-            "name": "offset",
+            "name": "min_id",
             "in": "query",
             "required": false,
             "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0
+              "type": "string",
+              "pattern": "^[0-9]+$"
             },
-            "description": "Number of records to skip"
+            "description": "Cursor: id lower bound (inclusive)"
+          },
+          {
+            "name": "max_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]+$"
+            },
+            "description": "Cursor: id upper bound (exclusive)"
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "id",
+                "+id",
+                "-id"
+              ],
+              "default": "-id"
+            },
+            "description": "Sort by id ascending or descending"
+          },
+          {
+            "$ref": "#/components/parameters/At-Block-Height"
           }
         ],
         "responses": {
           "200": {
-            "description": "Successful response with list of Corporations",
+            "description": "The Corporations",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CorporationListResponse"
+                  "$ref": "#/components/schemas/CorporationV4ListResponse"
                 }
               }
             }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest"
-          },
-          "500": {
-            "$ref": "#/components/responses/ServerError"
           }
         }
       }
@@ -7060,6 +7141,20 @@
         "required": [
           "corporation",
           "block_height"
+        ]
+      },
+      "CorporationV4ListResponse": {
+        "type": "object",
+        "properties": {
+          "corporations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CorporationV4"
+            }
+          }
+        },
+        "required": [
+          "corporations"
         ]
       }
     },

--- a/src/services/api/api.service.ts
+++ b/src/services/api/api.service.ts
@@ -336,7 +336,7 @@ function createRoute(path: string, aliases: Record<string, string>, requireBlock
       }),
       createRoute('/v4/corporation', {
         'GET get/:id': `${SERVICE.V1.CorporationApiService.path}.getCorporationV4`,
-        'GET list': `${SERVICE.V1.CorporationApiService.path}.listCorporations`,
+        'GET list': `${SERVICE.V1.CorporationApiService.path}.listCorporationsV4`,
         'GET history/:id': `${SERVICE.V1.CorporationApiService.path}.getCorporationHistory`,
       }),
       createRoute('/v4/participant', {

--- a/src/services/crawl-co/co_api.service.ts
+++ b/src/services/crawl-co/co_api.service.ts
@@ -12,15 +12,22 @@ import { CorporationHistory } from '../../models/corporation_history'
 import { enrichTrustDataDeep, parseTrustDataMode } from '../resolver/trust-data-enrichment'
 import {
   applyGfData,
+  buildCorporationObject,
   type CorporationGfVersion,
   calculateCorporationParticipantStats,
+  calculateCorporationParticipantStatsBatch,
   countControlledEcosystems,
   countControlledEcosystemsAtHeight,
+  countControlledEcosystemsBatch,
   deriveActiveVersion,
+  emptyParticipantStats,
+  emptyTrustDepositSnapshot,
   getCorporationBaseAtHeight,
   getCorporationTrustDeposit,
   getCorporationTrustDepositAtHeight,
+  getCorporationTrustDepositBatch,
   getResolvedBlockHeight,
+  parseCorporationListPagination,
   parseGfDataMode,
 } from './co_stats'
 
@@ -165,6 +172,114 @@ export default class CorporationApiService extends BaseService {
       return ApiResponder.success(ctx, enriched)
     } catch (err) {
       this.logger.error('Error in getCorporationV4:', err)
+      return ApiResponder.error(ctx, 'Internal Server Error', 500)
+    }
+  }
+
+  // IDX-CO-QRY-2 List Corporations (v4)
+  @Action()
+  public async listCorporationsV4(
+    ctx: Context<{
+      gf_data?: string
+      preferred_language?: string
+      did?: string
+      modified_after?: string
+      trust_data?: string
+      limit?: string
+      min_id?: string
+      max_id?: string
+      sort?: string
+    }>
+  ) {
+    try {
+      const { did, preferred_language: preferredLanguage } = ctx.params
+
+      const gfDataParsed = parseGfDataMode(ctx.params.gf_data)
+      if (!gfDataParsed.ok) {
+        return ApiResponder.error(ctx, gfDataParsed.message, 400)
+      }
+      const gfData = gfDataParsed.mode
+
+      const trustDataParsed = parseTrustDataMode(ctx.params.trust_data)
+      if (!trustDataParsed.ok) {
+        return ApiResponder.error(ctx, trustDataParsed.message, 400)
+      }
+      const trustDataMode = trustDataParsed.mode
+
+      const pageParsed = parseCorporationListPagination(ctx.params)
+      if (!pageParsed.ok) {
+        return ApiResponder.error(ctx, pageParsed.message, 400)
+      }
+      const { limit, minId, maxId, direction } = pageParsed.value
+
+      let modifiedAfterIso: string | undefined
+      if (ctx.params.modified_after) {
+        const ts = new Date(ctx.params.modified_after)
+        if (Number.isNaN(ts.getTime())) {
+          return ApiResponder.error(ctx, '"modified_after" must be a valid ISO 8601 datetime', 400)
+        }
+        modifiedAfterIso = ts.toISOString()
+      }
+
+      const blockHeight = getBlockHeight(ctx)
+
+      let query = Corporation.query().withGraphFetched(
+        gfData === 'none' ? 'governanceFrameworkVersions' : 'governanceFrameworkVersions.documents'
+      )
+      if (did) query = query.where('did', String(did))
+      if (modifiedAfterIso) query = query.where('modified', '>', modifiedAfterIso)
+      if (minId !== undefined) query = query.where('id', '>=', minId)
+      if (maxId !== undefined) query = query.where('id', '<', maxId)
+      // At-Block-Height: exclude corporations not yet created at that height (created is immutable).
+      // Field-level point-in-time (e.g. language, active_version) stays latest-state.
+      if (typeof blockHeight === 'number') {
+        const asOf = await getBlockChainTimeAsOf(blockHeight, { logContext: '[co_api:list]' })
+        query = query.where('created', '<=', asOf.toISOString())
+      }
+      query = query.orderBy('id', direction).limit(limit)
+
+      const rows = await query
+      if (rows.length === 0) {
+        return ApiResponder.success(ctx, { corporations: [] })
+      }
+
+      const plains = rows.map((row) => row.toJSON() as Record<string, unknown>)
+      const ids = plains.map((plain) => plain.id as number | string)
+      const addresses = plains.map(
+        (plain) => (plain.policy_address as string | null) ?? (plain.corporation as string | null) ?? null
+      )
+
+      const [statsMap, ecosystemMap, trustDepositMap] = await Promise.all([
+        calculateCorporationParticipantStatsBatch(ids, blockHeight),
+        countControlledEcosystemsBatch(ids),
+        getCorporationTrustDepositBatch(addresses),
+      ])
+
+      const corporations = plains.map((plain) => {
+        // CGF only — the relation also returns EGF rows (non-zero ecosystem_id) owned by the corporation
+        const allVersions = (plain.governanceFrameworkVersions ?? []) as CorporationGfVersion[]
+        const cgfVersions = allVersions.filter((v) => !v.ecosystem_id)
+        const policyAddress = (plain.policy_address as string | null) ?? (plain.corporation as string | null) ?? null
+        return buildCorporationObject({
+          plain,
+          cgfVersions,
+          participantStats: statsMap.get(String(plain.id)) ?? emptyParticipantStats(),
+          controlledEcosystems: ecosystemMap.get(String(plain.id)) ?? 0,
+          trustDeposit: (policyAddress && trustDepositMap.get(policyAddress)) || emptyTrustDepositSnapshot(),
+          gfData,
+          preferredLanguage,
+        })
+      })
+
+      const responsePayload = { corporations }
+      const enriched =
+        trustDataMode === 'none'
+          ? responsePayload
+          : await enrichTrustDataDeep(responsePayload, trustDataMode, blockHeight)
+
+      return ApiResponder.success(ctx, enriched)
+    } catch (err) {
+      this.logger.error('Error in listCorporationsV4:', err)
       return ApiResponder.error(ctx, 'Internal Server Error', 500)
     }
   }

--- a/src/services/crawl-co/co_stats.ts
+++ b/src/services/crawl-co/co_stats.ts
@@ -3,7 +3,12 @@ import { getBlockChainTimeAsOf } from '../../common/utils/block_time'
 import knex from '../../common/utils/db_connection'
 import { Ecosystem } from '../../models/ecosystem'
 import TrustDeposit from '../../models/trust_deposit'
-import { calculateParticipantState, normalizeParticipantType, type ParticipantType } from '../crawl-pp/pp_state_utils'
+import {
+  calculateParticipantState,
+  normalizeParticipantType,
+  type ParticipantData,
+  type ParticipantType,
+} from '../crawl-pp/pp_state_utils'
 
 export type GfDataMode = 'none' | 'only_active' | 'all'
 
@@ -44,7 +49,7 @@ export interface CorporationParticipantStats {
   participants_holder: number
 }
 
-function emptyParticipantStats(): CorporationParticipantStats {
+export function emptyParticipantStats(): CorporationParticipantStats {
   return {
     participants: 0,
     participants_ecosystem: 0,
@@ -65,6 +70,41 @@ const ROLE_TO_FIELD: Partial<Record<ParticipantType, keyof CorporationParticipan
   HOLDER: 'participants_holder',
 }
 
+interface ParticipantRow {
+  corporation_id?: number | string
+  repaid?: string | null
+  slashed?: string | null
+  revoked?: string | null
+  effective_from?: string | null
+  effective_until?: string | null
+  role: string
+  op_state?: string
+  op_exp?: string | null
+  validator_participant_id?: string | null
+}
+
+function tallyActiveParticipant(stats: CorporationParticipantStats, row: ParticipantRow, now: Date): void {
+  const state = calculateParticipantState(
+    {
+      repaid: row.repaid,
+      slashed: row.slashed,
+      revoked: row.revoked,
+      effective_from: row.effective_from,
+      effective_until: row.effective_until,
+      role: row.role as ParticipantType,
+      op_state: row.op_state as ParticipantData['op_state'],
+      op_exp: row.op_exp,
+      validator_participant_id: row.validator_participant_id,
+    },
+    now
+  )
+  if (state !== 'ACTIVE') return
+
+  stats.participants += 1
+  const roleField = ROLE_TO_FIELD[normalizeParticipantType(row.role)]
+  if (roleField) stats[roleField] += 1
+}
+
 export async function calculateCorporationParticipantStats(
   corporationId: number | string,
   blockHeight?: number
@@ -77,34 +117,59 @@ export async function calculateCorporationParticipantStats(
   }
 
   const rows = await knex('participants').where('corporation_id', corporationId)
-
   for (const row of rows) {
-    const state = calculateParticipantState(
-      {
-        repaid: row.repaid,
-        slashed: row.slashed,
-        revoked: row.revoked,
-        effective_from: row.effective_from,
-        effective_until: row.effective_until,
-        role: row.role,
-        op_state: row.op_state,
-        op_exp: row.op_exp,
-        validator_participant_id: row.validator_participant_id,
-      },
-      now
-    )
-    if (state !== 'ACTIVE') continue
-
-    stats.participants += 1
-    const roleField = ROLE_TO_FIELD[normalizeParticipantType(row.role)]
-    if (roleField) stats[roleField] += 1
+    tallyActiveParticipant(stats, row, now)
   }
 
   return stats
 }
 
+export async function calculateCorporationParticipantStatsBatch(
+  corporationIds: Array<number | string>,
+  blockHeight?: number
+): Promise<Map<string, CorporationParticipantStats>> {
+  const result = new Map<string, CorporationParticipantStats>()
+  for (const id of corporationIds) {
+    result.set(String(id), emptyParticipantStats())
+  }
+  if (corporationIds.length === 0) return result
+
+  let now = new Date()
+  if (typeof blockHeight === 'number') {
+    now = await getBlockChainTimeAsOf(blockHeight, { logContext: '[co_stats]' })
+  }
+
+  const rows = await knex('participants').whereIn('corporation_id', corporationIds)
+  for (const row of rows) {
+    const stats = result.get(String(row.corporation_id))
+    if (stats) tallyActiveParticipant(stats, row, now)
+  }
+
+  return result
+}
+
 export async function countControlledEcosystems(corporationId: number | string): Promise<number> {
   return Ecosystem.query().where('corporation_id', corporationId).resultSize()
+}
+
+export async function countControlledEcosystemsBatch(
+  corporationIds: Array<number | string>
+): Promise<Map<string, number>> {
+  const result = new Map<string, number>()
+  for (const id of corporationIds) {
+    result.set(String(id), 0)
+  }
+  if (corporationIds.length === 0) return result
+
+  const rows = (await knex('ecosystem')
+    .whereIn('corporation_id', corporationIds)
+    .groupBy('corporation_id')
+    .select('corporation_id')
+    .count({ count: '*' })) as unknown as Array<{ corporation_id: number | string; count: string | number }>
+  for (const row of rows) {
+    result.set(String(row.corporation_id), Number(row.count))
+  }
+  return result
 }
 
 // Ecosystems owned by the corporation that existed and were not archived at the height.
@@ -201,6 +266,20 @@ export async function getCorporationTrustDeposit(address: string | null): Promis
   return row ? mapTrustDepositRow(row as unknown as Record<string, unknown>) : emptyTrustDepositSnapshot()
 }
 
+export async function getCorporationTrustDepositBatch(
+  addresses: Array<string | null>
+): Promise<Map<string, CorporationTrustDepositSnapshot>> {
+  const result = new Map<string, CorporationTrustDepositSnapshot>()
+  const unique = [...new Set(addresses.filter((a): a is string => Boolean(a)))]
+  if (unique.length === 0) return result
+
+  const rows = await TrustDeposit.query().whereIn('corporation', unique)
+  for (const row of rows) {
+    result.set(row.corporation, mapTrustDepositRow(row as unknown as Record<string, unknown>))
+  }
+  return result
+}
+
 // Trust-deposit snapshot as of a block height (from trust_deposit_history).
 export async function getCorporationTrustDepositAtHeight(
   address: string | null,
@@ -260,6 +339,84 @@ export function applyGfData(
     }
     return { ...v, ecosystem_id: v.ecosystem_id ? v.ecosystem_id : null, documents }
   })
+}
+
+// Shared by Get and List so the two responses stay identical.
+export function buildCorporationObject(params: {
+  plain: Record<string, unknown>
+  cgfVersions: CorporationGfVersion[]
+  participantStats: CorporationParticipantStats
+  controlledEcosystems: number
+  trustDeposit: CorporationTrustDepositSnapshot
+  gfData: GfDataMode
+  preferredLanguage?: string
+}): Record<string, unknown> {
+  const { plain, cgfVersions, participantStats, controlledEcosystems, trustDeposit, gfData, preferredLanguage } = params
+  const policyAddress = (plain.policy_address as string | null) ?? (plain.corporation as string | null) ?? null
+
+  const corporation: Record<string, unknown> = {
+    id: plain.id,
+    did: plain.did,
+    policy_address: policyAddress,
+    language: plain.language ?? null,
+    active_version: deriveActiveVersion(cgfVersions),
+    created: plain.created,
+    modified: plain.modified,
+    controlled_ecosystems: controlledEcosystems,
+    ...participantStats,
+    ...trustDeposit,
+  }
+
+  if (gfData !== 'none') {
+    corporation.versions = applyGfData(cgfVersions, gfData, preferredLanguage)
+  }
+
+  return corporation
+}
+
+export interface CorporationListPagination {
+  limit: number
+  minId?: string
+  maxId?: string
+  direction: 'asc' | 'desc'
+}
+
+function parseCursorParam(raw: unknown): { ok: true; value?: string } | { ok: false } {
+  if (raw === undefined || raw === null || raw === '') return { ok: true }
+  const value = String(raw).trim()
+  if (!/^\d+$/.test(value)) return { ok: false }
+  return { ok: true, value }
+}
+
+export function parseCorporationListPagination(params: {
+  limit?: string | number
+  min_id?: string | number
+  max_id?: string | number
+  sort?: string
+}): { ok: true; value: CorporationListPagination } | { ok: false; message: string } {
+  let limit = 64
+  if (params.limit !== undefined && params.limit !== '') {
+    const parsed = Number(params.limit)
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > 1024) {
+      return { ok: false, message: '"limit" must be an integer between 1 and 1024' }
+    }
+    limit = parsed
+  }
+
+  const minId = parseCursorParam(params.min_id)
+  if (!minId.ok) return { ok: false, message: '"min_id" must be a non-negative integer' }
+  const maxId = parseCursorParam(params.max_id)
+  if (!maxId.ok) return { ok: false, message: '"max_id" must be a non-negative integer' }
+
+  let direction: 'asc' | 'desc' = 'desc'
+  if (params.sort !== undefined && params.sort !== '') {
+    const sort = String(params.sort).trim()
+    if (sort === 'id' || sort === '+id') direction = 'asc'
+    else if (sort === '-id') direction = 'desc'
+    else return { ok: false, message: 'Only "id" sort is supported (use "id", "+id", or "-id")' }
+  }
+
+  return { ok: true, value: { limit, minId: minId.value, maxId: maxId.value, direction } }
 }
 
 export async function getResolvedBlockHeight(blockHeight?: number): Promise<number> {

--- a/test/unit/services/crawl-co/co_api_v4_list.spec.ts
+++ b/test/unit/services/crawl-co/co_api_v4_list.spec.ts
@@ -1,0 +1,291 @@
+jest.mock('../../../../src/models/corporation', () => ({ Corporation: { query: jest.fn() } }))
+jest.mock('../../../../src/models/corporation_history', () => ({ CorporationHistory: { query: jest.fn() } }))
+
+// Keep the pure helpers (buildCorporationObject, parseGfDataMode, parseCorporationListPagination, ...) real;
+// only stub the DB-touching batch aggregates so the response wiring is exercised end to end.
+jest.mock('../../../../src/services/crawl-co/co_stats', () => {
+  const actual = jest.requireActual('../../../../src/services/crawl-co/co_stats')
+  return {
+    ...actual,
+    calculateCorporationParticipantStatsBatch: jest.fn(),
+    countControlledEcosystemsBatch: jest.fn(),
+    getCorporationTrustDepositBatch: jest.fn(),
+  }
+})
+
+jest.mock('../../../../src/services/resolver/trust-data-enrichment', () => ({
+  parseTrustDataMode: jest.fn(() => ({ ok: true, mode: 'none' })),
+  enrichTrustDataDeep: jest.fn(async (v: unknown) => v),
+}))
+
+jest.mock('../../../../src/common/utils/apiResponse', () => ({
+  __esModule: true,
+  default: {
+    success: jest.fn((_ctx: unknown, data: unknown) => data),
+    error: jest.fn((_ctx: unknown, message: string, code: number) => ({ error: message, code })),
+  },
+}))
+
+jest.mock('../../../../src/common/utils/block_time', () => ({
+  getBlockChainTimeAsOf: jest.fn(async () => new Date('2024-03-01T00:00:00.000Z')),
+}))
+
+import { ServiceBroker } from 'moleculer'
+import ApiResponder from '../../../../src/common/utils/apiResponse'
+import { getBlockChainTimeAsOf } from '../../../../src/common/utils/block_time'
+import { Corporation } from '../../../../src/models/corporation'
+import CorporationApiService from '../../../../src/services/crawl-co/co_api.service'
+import {
+  calculateCorporationParticipantStatsBatch,
+  countControlledEcosystemsBatch,
+  getCorporationTrustDepositBatch,
+} from '../../../../src/services/crawl-co/co_stats'
+import { enrichTrustDataDeep, parseTrustDataMode } from '../../../../src/services/resolver/trust-data-enrichment'
+
+function queryResolvesTo(rows: unknown[]) {
+  const qb: any = {}
+  qb.withGraphFetched = jest.fn(() => qb)
+  qb.where = jest.fn(() => qb)
+  qb.orderBy = jest.fn(() => qb)
+  qb.limit = jest.fn(() => qb)
+  qb.then = (resolve: (v: unknown) => void) => resolve(rows)
+  ;(Corporation.query as jest.Mock).mockReturnValue(qb)
+  return qb
+}
+
+function corpRow(over: Record<string, unknown> = {}) {
+  return {
+    toJSON: () => ({
+      id: 1,
+      did: 'did:example:co',
+      policy_address: 'verana1pol',
+      language: 'en',
+      created: '2024-01-01',
+      modified: '2024-02-01',
+      governanceFrameworkVersions: [{ version: 1, active_since: '2024-01-01', documents: [{ language: 'en' }] }],
+      ...over,
+    }),
+  }
+}
+
+const stats = (over: Record<string, number> = {}) => ({
+  participants: 0,
+  participants_ecosystem: 0,
+  participants_issuer_grantor: 0,
+  participants_issuer: 0,
+  participants_verifier_grantor: 0,
+  participants_verifier: 0,
+  participants_holder: 0,
+  ...over,
+})
+
+describe('CorporationApiService.listCorporationsV4', () => {
+  const broker = new ServiceBroker({ logger: false })
+  const service = new CorporationApiService(broker)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(calculateCorporationParticipantStatsBatch as jest.Mock).mockResolvedValue(new Map())
+    ;(countControlledEcosystemsBatch as jest.Mock).mockResolvedValue(new Map())
+    ;(getCorporationTrustDepositBatch as jest.Mock).mockResolvedValue(new Map())
+    ;(parseTrustDataMode as jest.Mock).mockReturnValue({ ok: true, mode: 'none' })
+  })
+
+  it('builds { corporations: [...] } wiring batched aggregates and CGF versions per row', async () => {
+    queryResolvesTo([
+      corpRow({ id: 1, policy_address: 'verana1pol' }),
+      corpRow({ id: 2, policy_address: 'verana1pol2' }),
+    ])
+    ;(calculateCorporationParticipantStatsBatch as jest.Mock).mockResolvedValue(
+      new Map([
+        ['1', stats({ participants: 2, participants_issuer: 1, participants_holder: 1 })],
+        ['2', stats()],
+      ])
+    )
+    ;(countControlledEcosystemsBatch as jest.Mock).mockResolvedValue(
+      new Map([
+        ['1', 2],
+        ['2', 0],
+      ])
+    )
+    ;(getCorporationTrustDepositBatch as jest.Mock).mockResolvedValue(
+      new Map([
+        [
+          'verana1pol',
+          {
+            deposit: 100,
+            share: 5,
+            refunded: 9,
+            slashed_deposit: 0,
+            repaid_deposit: 0,
+            slash_count: 0,
+            last_slashed: null,
+            last_repaid: null,
+          },
+        ],
+      ])
+    )
+
+    const ctx: any = { params: { gf_data: 'all' }, meta: {} }
+    const res: any = await service.listCorporationsV4(ctx)
+
+    expect(res.corporations).toHaveLength(2)
+    expect(res.corporations[0]).toMatchObject({
+      id: 1,
+      did: 'did:example:co',
+      policy_address: 'verana1pol',
+      active_version: 1,
+      controlled_ecosystems: 2,
+      participants: 2,
+      participants_issuer: 1,
+      deposit: 100,
+      refunded: 9,
+    })
+    expect(res.corporations[0].versions).toEqual([
+      { version: 1, active_since: '2024-01-01', documents: [{ language: 'en' }], ecosystem_id: null },
+    ])
+    // second corporation has no trust-deposit row -> zeroed snapshot
+    expect(res.corporations[1]).toMatchObject({ id: 2, controlled_ecosystems: 0, deposit: 0 })
+  })
+
+  it('applies did, modified_after and cursor filters plus sort/limit to the query', async () => {
+    const qb = queryResolvesTo([])
+    ;(calculateCorporationParticipantStatsBatch as jest.Mock).mockResolvedValue(new Map())
+
+    const ctx: any = {
+      params: {
+        did: 'did:example:co',
+        modified_after: '2024-05-01T00:00:00Z',
+        min_id: '5',
+        max_id: '10',
+        sort: '+id',
+        limit: '25',
+      },
+      meta: {},
+    }
+    await service.listCorporationsV4(ctx)
+
+    expect(qb.where).toHaveBeenCalledWith('did', 'did:example:co')
+    expect(qb.where).toHaveBeenCalledWith('modified', '>', '2024-05-01T00:00:00.000Z')
+    expect(qb.where).toHaveBeenCalledWith('id', '>=', '5')
+    expect(qb.where).toHaveBeenCalledWith('id', '<', '10')
+    expect(qb.orderBy).toHaveBeenCalledWith('id', 'asc')
+    expect(qb.limit).toHaveBeenCalledWith(25)
+  })
+
+  it('defaults to newest-first (id desc) and limit 64', async () => {
+    const qb = queryResolvesTo([])
+    const ctx: any = { params: {}, meta: {} }
+    await service.listCorporationsV4(ctx)
+    expect(qb.orderBy).toHaveBeenCalledWith('id', 'desc')
+    expect(qb.limit).toHaveBeenCalledWith(64)
+  })
+
+  it('excludes EGF rows (ecosystem_id != 0) from versions/active_version', async () => {
+    queryResolvesTo([
+      corpRow({
+        governanceFrameworkVersions: [
+          { version: 1, ecosystem_id: 0, active_since: '2024-01-01', documents: [] },
+          { version: 7, ecosystem_id: 5, active_since: '2024-06-01', documents: [] },
+        ],
+      }),
+    ])
+    ;(calculateCorporationParticipantStatsBatch as jest.Mock).mockResolvedValue(new Map([['1', stats()]]))
+
+    const ctx: any = { params: { gf_data: 'all' }, meta: {} }
+    const res: any = await service.listCorporationsV4(ctx)
+
+    expect(res.corporations[0].active_version).toBe(1)
+    expect(res.corporations[0].versions).toHaveLength(1)
+    expect(res.corporations[0].versions[0].version).toBe(1)
+  })
+
+  it('omits versions from every entry when gf_data is none', async () => {
+    const qb = queryResolvesTo([corpRow()])
+    ;(calculateCorporationParticipantStatsBatch as jest.Mock).mockResolvedValue(new Map([['1', stats()]]))
+
+    const ctx: any = { params: { gf_data: 'none' }, meta: {} }
+    const res: any = await service.listCorporationsV4(ctx)
+
+    expect('versions' in res.corporations[0]).toBe(false)
+    expect(qb.withGraphFetched).toHaveBeenCalledWith('governanceFrameworkVersions')
+  })
+
+  it('resolves participant aggregates at the requested At-Block-Height', async () => {
+    queryResolvesTo([corpRow({ id: 1 })])
+    ;(calculateCorporationParticipantStatsBatch as jest.Mock).mockResolvedValue(new Map([['1', stats()]]))
+
+    const ctx: any = { params: {}, meta: { blockHeight: 5 } }
+    await service.listCorporationsV4(ctx)
+
+    expect(calculateCorporationParticipantStatsBatch).toHaveBeenCalledWith([1], 5)
+  })
+
+  it('excludes corporations created after the requested At-Block-Height', async () => {
+    const qb = queryResolvesTo([])
+    const ctx: any = { params: {}, meta: { blockHeight: 5 } }
+    await service.listCorporationsV4(ctx)
+
+    expect(getBlockChainTimeAsOf).toHaveBeenCalledWith(5, expect.anything())
+    expect(qb.where).toHaveBeenCalledWith('created', '<=', '2024-03-01T00:00:00.000Z')
+  })
+
+  it('does not apply the created filter when no At-Block-Height is set', async () => {
+    const qb = queryResolvesTo([])
+    const ctx: any = { params: {}, meta: {} }
+    await service.listCorporationsV4(ctx)
+
+    expect(getBlockChainTimeAsOf).not.toHaveBeenCalled()
+    expect(qb.where).not.toHaveBeenCalledWith('created', '<=', expect.anything())
+  })
+
+  it('returns an empty list (and skips aggregate queries) when the page is empty', async () => {
+    queryResolvesTo([])
+    const ctx: any = { params: {}, meta: {} }
+    const res: any = await service.listCorporationsV4(ctx)
+    expect(res).toEqual({ corporations: [] })
+    expect(calculateCorporationParticipantStatsBatch).not.toHaveBeenCalled()
+  })
+
+  it('runs trust_data enrichment over the whole payload when requested', async () => {
+    queryResolvesTo([corpRow({ id: 1 })])
+    ;(calculateCorporationParticipantStatsBatch as jest.Mock).mockResolvedValue(new Map([['1', stats()]]))
+    ;(parseTrustDataMode as jest.Mock).mockReturnValue({ ok: true, mode: 'summary' })
+    ;(enrichTrustDataDeep as jest.Mock).mockResolvedValueOnce({ enriched: true })
+
+    const ctx: any = { params: { trust_data: 'summary' }, meta: { blockHeight: 9 } }
+    const res: any = await service.listCorporationsV4(ctx)
+
+    expect(enrichTrustDataDeep).toHaveBeenCalledWith(
+      expect.objectContaining({ corporations: expect.any(Array) }),
+      'summary',
+      9
+    )
+    expect(res).toEqual({ enriched: true })
+  })
+
+  it('rejects invalid gf_data / limit / min_id / sort / modified_after with 400 and no query', async () => {
+    for (const params of [
+      { gf_data: 'bogus' },
+      { limit: '0' },
+      { min_id: 'abc' },
+      { sort: 'weight' },
+      { modified_after: 'not-a-date' },
+    ]) {
+      jest.clearAllMocks()
+      ;(parseTrustDataMode as jest.Mock).mockReturnValue({ ok: true, mode: 'none' })
+      const ctx: any = { params, meta: {} }
+      const res: any = await service.listCorporationsV4(ctx)
+      expect(res.code).toBe(400)
+    }
+    // gf_data/limit/min_id/sort fail before any DB access
+    expect(ApiResponder.error).toBeDefined()
+  })
+
+  it('propagates a trust_data validation failure as 400', async () => {
+    ;(parseTrustDataMode as jest.Mock).mockReturnValue({ ok: false, message: 'Invalid "trust_data"' })
+    const ctx: any = { params: { trust_data: 'bogus' }, meta: {} }
+    const res: any = await service.listCorporationsV4(ctx)
+    expect(res).toMatchObject({ code: 400 })
+  })
+})

--- a/test/unit/services/crawl-co/co_stats_list.spec.ts
+++ b/test/unit/services/crawl-co/co_stats_list.spec.ts
@@ -1,0 +1,201 @@
+const mockParticipantsWhere = jest.fn()
+const mockParticipantsWhereIn = jest.fn()
+const mockEcosystemCount = jest.fn()
+
+jest.mock('../../../../src/common/utils/db_connection', () => ({
+  __esModule: true,
+  default: jest.fn((table: string) => {
+    if (table === 'participants') {
+      return { where: mockParticipantsWhere, whereIn: mockParticipantsWhereIn }
+    }
+    if (table === 'ecosystem') {
+      const chain = {
+        whereIn: jest.fn(() => chain),
+        groupBy: jest.fn(() => chain),
+        select: jest.fn(() => chain),
+        count: mockEcosystemCount,
+      }
+      return chain
+    }
+    return {}
+  }),
+}))
+
+jest.mock('../../../../src/models/ecosystem', () => ({ Ecosystem: { query: jest.fn() } }))
+jest.mock('../../../../src/models/trust_deposit', () => ({ __esModule: true, default: { query: jest.fn() } }))
+
+import TrustDeposit from '../../../../src/models/trust_deposit'
+import {
+  buildCorporationObject,
+  calculateCorporationParticipantStatsBatch,
+  countControlledEcosystemsBatch,
+  emptyTrustDepositSnapshot,
+  getCorporationTrustDepositBatch,
+  parseCorporationListPagination,
+} from '../../../../src/services/crawl-co/co_stats'
+
+describe('co_stats.parseCorporationListPagination', () => {
+  it('defaults to limit 64, descending id, no cursors', () => {
+    const result = parseCorporationListPagination({})
+    expect(result).toEqual({ ok: true, value: { limit: 64, minId: undefined, maxId: undefined, direction: 'desc' } })
+  })
+
+  it('rejects a limit outside 1..1024', () => {
+    expect(parseCorporationListPagination({ limit: '0' }).ok).toBe(false)
+    expect(parseCorporationListPagination({ limit: '1025' }).ok).toBe(false)
+    expect(parseCorporationListPagination({ limit: 'abc' }).ok).toBe(false)
+  })
+
+  it('accepts the boundary limits 1 and 1024', () => {
+    expect(parseCorporationListPagination({ limit: '1' })).toMatchObject({ ok: true, value: { limit: 1 } })
+    expect(parseCorporationListPagination({ limit: '1024' })).toMatchObject({ ok: true, value: { limit: 1024 } })
+  })
+
+  it('validates min_id/max_id as non-negative integer cursors', () => {
+    expect(parseCorporationListPagination({ min_id: 'x' }).ok).toBe(false)
+    expect(parseCorporationListPagination({ max_id: '-1' }).ok).toBe(false)
+    expect(parseCorporationListPagination({ min_id: '5', max_id: '10' })).toMatchObject({
+      ok: true,
+      value: { minId: '5', maxId: '10' },
+    })
+  })
+
+  it('maps sort to a direction and rejects any non-id sort', () => {
+    expect(parseCorporationListPagination({ sort: 'id' })).toMatchObject({ ok: true, value: { direction: 'asc' } })
+    expect(parseCorporationListPagination({ sort: '+id' })).toMatchObject({ ok: true, value: { direction: 'asc' } })
+    expect(parseCorporationListPagination({ sort: '-id' })).toMatchObject({ ok: true, value: { direction: 'desc' } })
+    expect(parseCorporationListPagination({ sort: 'modified' }).ok).toBe(false)
+  })
+})
+
+describe('co_stats.buildCorporationObject', () => {
+  const participantStats = {
+    participants: 2,
+    participants_ecosystem: 0,
+    participants_issuer_grantor: 0,
+    participants_issuer: 1,
+    participants_verifier_grantor: 0,
+    participants_verifier: 0,
+    participants_holder: 1,
+  }
+
+  it('assembles the on-chain fields, aggregates and CGF versions into one object', () => {
+    const obj = buildCorporationObject({
+      plain: {
+        id: 1,
+        did: 'did:example:co',
+        policy_address: 'verana1pol',
+        language: 'en',
+        created: '2024-01-01',
+        modified: '2024-02-01',
+      },
+      cgfVersions: [{ version: 1, active_since: '2024-01-01', documents: [{ language: 'en' }] }],
+      participantStats,
+      controlledEcosystems: 2,
+      trustDeposit: { ...emptyTrustDepositSnapshot(), deposit: 100, refunded: 9 },
+      gfData: 'all',
+    })
+
+    expect(obj).toMatchObject({
+      id: 1,
+      did: 'did:example:co',
+      policy_address: 'verana1pol',
+      language: 'en',
+      active_version: 1,
+      controlled_ecosystems: 2,
+      participants: 2,
+      deposit: 100,
+      refunded: 9,
+    })
+    expect(obj.versions).toEqual([
+      { version: 1, active_since: '2024-01-01', documents: [{ language: 'en' }], ecosystem_id: null },
+    ])
+  })
+
+  it('omits versions entirely when gf_data is none', () => {
+    const obj = buildCorporationObject({
+      plain: { id: 1, did: 'did:example:co', policy_address: 'verana1pol' },
+      cgfVersions: [{ version: 1, active_since: '2024-01-01' }],
+      participantStats,
+      controlledEcosystems: 0,
+      trustDeposit: emptyTrustDepositSnapshot(),
+      gfData: 'none',
+    })
+    expect('versions' in obj).toBe(false)
+  })
+
+  it('falls back to the legacy corporation column for policy_address', () => {
+    const obj = buildCorporationObject({
+      plain: { id: 1, did: 'did:example:co', corporation: 'verana1legacy' },
+      cgfVersions: [],
+      participantStats,
+      controlledEcosystems: 0,
+      trustDeposit: emptyTrustDepositSnapshot(),
+      gfData: 'none',
+    })
+    expect(obj.policy_address).toBe('verana1legacy')
+  })
+})
+
+describe('co_stats.calculateCorporationParticipantStatsBatch', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('groups ACTIVE participants by corporation with one whereIn query', async () => {
+    const past = new Date('2020-01-01T00:00:00Z')
+    mockParticipantsWhereIn.mockResolvedValueOnce([
+      { corporation_id: 1, role: 'ISSUER', effective_from: past },
+      { corporation_id: 1, role: 'HOLDER', effective_from: past },
+      { corporation_id: 2, role: 'VERIFIER', effective_from: past },
+      { corporation_id: 2, role: 'VERIFIER', effective_from: past, revoked: past },
+    ])
+
+    const map = await calculateCorporationParticipantStatsBatch([1, 2])
+
+    expect(mockParticipantsWhereIn).toHaveBeenCalledWith('corporation_id', [1, 2])
+    expect(map.get('1')).toMatchObject({ participants: 2, participants_issuer: 1, participants_holder: 1 })
+    expect(map.get('2')).toMatchObject({ participants: 1, participants_verifier: 1 })
+  })
+
+  it('seeds every requested id with a zeroed entry and skips the query when empty', async () => {
+    const map = await calculateCorporationParticipantStatsBatch([])
+    expect(map.size).toBe(0)
+    expect(mockParticipantsWhereIn).not.toHaveBeenCalled()
+
+    mockParticipantsWhereIn.mockResolvedValueOnce([])
+    const seeded = await calculateCorporationParticipantStatsBatch([9])
+    expect(seeded.get('9')).toMatchObject({ participants: 0 })
+  })
+})
+
+describe('co_stats.countControlledEcosystemsBatch', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('returns a per-corporation count, defaulting missing ids to 0', async () => {
+    mockEcosystemCount.mockResolvedValueOnce([{ corporation_id: 1, count: 2 }])
+
+    const map = await countControlledEcosystemsBatch([1, 2])
+
+    expect(map.get('1')).toBe(2)
+    expect(map.get('2')).toBe(0)
+  })
+})
+
+describe('co_stats.getCorporationTrustDepositBatch', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('keys snapshots by policy address and dedupes/ignores null addresses', async () => {
+    const whereIn = jest.fn().mockResolvedValue([{ corporation: 'verana1a', deposit: 100, claimable: 9, share: 5 }])
+    ;(TrustDeposit.query as jest.Mock).mockReturnValue({ whereIn })
+
+    const map = await getCorporationTrustDepositBatch(['verana1a', 'verana1a', null])
+
+    expect(whereIn).toHaveBeenCalledWith('corporation', ['verana1a'])
+    expect(map.get('verana1a')).toMatchObject({ deposit: 100, refunded: 9, share: 5 })
+  })
+
+  it('returns an empty map without querying when there are no addresses', async () => {
+    const map = await getCorporationTrustDepositBatch([null, null])
+    expect(map.size).toBe(0)
+    expect(TrustDeposit.query as jest.Mock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
`GET /v4/corporation/list` — IDX-CO-QRY-2. Returns { corporations }, each entry the same shape
as getCorporation (#256), built via a shared helper so Get and List stay identical.

Filters: did, modified_after, gf_data, preferred_language, trust_data.
Pagination: limit, min_id, max_id, sort — id-cursor per the Pagination spec (default -id, limit 1..1024/64).
Per-page aggregates (participants, controlled_ecosystems, trust-deposit) are batched to avoid N+1.
At-Block-Height excludes corporations not yet created at that height.
