### PR TITLE
feat: implement IDX-CO-QRY-3 get corporation params (#258)

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4381,6 +4381,36 @@
           "500": { "$ref": "#/components/responses/ServerError" }
         }
       }
+    },
+    "/v4/corporation/params": {
+      "get": {
+        "tags": [
+          "Corporation"
+        ],
+        "summary": "Get Corporation parameters",
+        "description": "Retrieve the network-level Corporation module parameters (IDX-CO-QRY-3). Aligned with VPR MOD-CO-QRY-3. The x/co module currently defines no parameters (reserved for forward compatibility), so an empty params object is returned until governance introduces parameters.",
+        "operationId": "getCorporationParams",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/At-Block-Height"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The Corporation module parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CorporationParamsResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -7060,6 +7090,19 @@
         "required": [
           "corporation",
           "block_height"
+        ]
+      },
+      "CorporationParamsResponse": {
+        "type": "object",
+        "properties": {
+          "params": {
+            "type": "object",
+            "description": "Corporation module parameter set. The x/co module currently defines no parameters (reserved for forward compatibility); an empty object is returned.",
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "params"
         ]
       }
     },

--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -133,6 +133,7 @@ export const MODULE_DISPLAY_NAMES = {
   CREDENTIAL_SCHEMA: 'credentialschema',
   TRUST_DEPOSIT: 'trustdeposit',
   PARTICIPANT: 'participant',
+  CORPORATION: 'corporation',
 } as const
 
 export enum TrustDepositEventType {

--- a/src/services/api/api.service.ts
+++ b/src/services/api/api.service.ts
@@ -337,6 +337,7 @@ function createRoute(path: string, aliases: Record<string, string>, requireBlock
       createRoute('/v4/corporation', {
         'GET get/:id': `${SERVICE.V1.CorporationApiService.path}.getCorporationV4`,
         'GET list': `${SERVICE.V1.CorporationApiService.path}.listCorporations`,
+        'GET params': `${SERVICE.V1.CorporationApiService.path}.getCorporationParams`,
         'GET history/:id': `${SERVICE.V1.CorporationApiService.path}.getCorporationHistory`,
       }),
       createRoute('/v4/participant', {

--- a/src/services/crawl-co/co_api.service.ts
+++ b/src/services/crawl-co/co_api.service.ts
@@ -3,7 +3,7 @@
 import { Action, Service } from '@ourparentcenter/moleculer-decorators-extended'
 import { Context, ServiceBroker } from 'moleculer'
 import BaseService from '../../base/base.service'
-import { SERVICE } from '../../common'
+import { MODULE_DISPLAY_NAMES, ModulesParamsNamesTypes, SERVICE } from '../../common'
 import ApiResponder from '../../common/utils/apiResponse'
 import { getBlockChainTimeAsOf } from '../../common/utils/block_time'
 import { getBlockHeight } from '../../common/utils/blockHeight'
@@ -211,5 +211,11 @@ export default class CorporationApiService extends BaseService {
     } catch (err: any) {
       return ApiResponder.error(ctx, err?.message || String(err), 500)
     }
+  }
+
+  @Action()
+  public async getCorporationParams(ctx: Context) {
+    const { getModuleParamsAction } = await import('../../common/utils/params_service')
+    return getModuleParamsAction(ctx, ModulesParamsNamesTypes.CO, MODULE_DISPLAY_NAMES.CORPORATION)
   }
 }

--- a/test/unit/services/crawl-co/co_api_params.spec.ts
+++ b/test/unit/services/crawl-co/co_api_params.spec.ts
@@ -1,0 +1,43 @@
+jest.mock('../../../../src/common/utils/params_service', () => ({
+  getModuleParamsAction: jest.fn(),
+}))
+
+import { ServiceBroker } from 'moleculer'
+import { MODULE_DISPLAY_NAMES, ModulesParamsNamesTypes } from '../../../../src/common'
+import { getModuleParamsAction } from '../../../../src/common/utils/params_service'
+import CorporationApiService from '../../../../src/services/crawl-co/co_api.service'
+
+describe('CorporationApiService.getCorporationParams', () => {
+  const broker = new ServiceBroker({ logger: false })
+  const service = new CorporationApiService(broker)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(getModuleParamsAction as jest.Mock).mockResolvedValue({ params: {} })
+  })
+
+  it('delegates to the co module params helper and returns its result', async () => {
+    const ctx: any = { params: {}, meta: {} }
+
+    const res = await service.getCorporationParams(ctx)
+
+    expect(getModuleParamsAction).toHaveBeenCalledWith(
+      ctx,
+      ModulesParamsNamesTypes.CO,
+      MODULE_DISPLAY_NAMES.CORPORATION
+    )
+    expect(res).toEqual({ params: {} })
+  })
+
+  it('forwards the ctx (carrying At-Block-Height in meta) so the helper can resolve point-in-time', async () => {
+    const ctx: any = { params: {}, meta: { blockHeight: 42 } }
+
+    await service.getCorporationParams(ctx)
+
+    expect(getModuleParamsAction).toHaveBeenCalledWith(
+      ctx,
+      ModulesParamsNamesTypes.CO,
+      MODULE_DISPLAY_NAMES.CORPORATION
+    )
+  })
+})


### PR DESCRIPTION
GET /v4/corporation/params - IDX-CO-QRY-3. Returns { params }, the Corporation module
parameter set. Aligned with VPR MOD-CO-QRY-3.

The x/co module defines no on-chain parameters yet (the proto Params message is empty,
reserved for forward compatibility), so an empty params object is returned. The spec's
example keys (min trust-deposit, CGF doc-size limits) are aspirational; verified against
the chain, /co/v1/params returns {"params":{}}.
