### PR TITLE
fix: do not stop the indexer on a recoverable duplicate-block insert

### DIFF
--- a/src/common/utils/error_handler.ts
+++ b/src/common/utils/error_handler.ts
@@ -58,7 +58,7 @@ export function analyzeError(error: any): ErrorInfo {
     'canceling statement',
     'Connection terminated unexpectedly',
   ];
-  
+
   const postgresTimeoutCodes = ['57014'];
 
   const serverErrorPatterns = [
@@ -66,10 +66,6 @@ export function analyzeError(error: any): ErrorInfo {
     'Service Unavailable',
     'Gateway Timeout',
     'Internal Server Error',
-    '502',
-    '503',
-    '504',
-    '500',
   ];
 
   const isNetworkError =
@@ -81,10 +77,7 @@ export function analyzeError(error: any): ErrorInfo {
     );
 
   const isServerError =
-    (statusCode && statusCode >= 500) ||
-    statusCode === 502 ||
-    statusCode === 503 ||
-    statusCode === 504 ||
+    (statusCode != null && statusCode >= 500 && statusCode <= 599) ||
     serverErrorPatterns.some(pattern =>
       errorMessage.includes(pattern) ||
       statusText.includes(pattern)
@@ -105,15 +98,20 @@ export function analyzeError(error: any): ErrorInfo {
     error?.type === 'REQUEST_TIMEOUT' ||
     error?.name === 'RequestTimeoutError';
 
-  const shouldStopIndexer =
+  const isRecoverableDbConflict =
+    errorCode === '23505' ||
+    errorMessage.toLowerCase().includes('duplicate key value violates unique constraint');
+
+  const shouldStopIndexer = Boolean(
     !isNonCritical &&
     !isMoleculerRequestTimeout &&
+    !isRecoverableDbConflict &&
     (
       isNetworkError ||
       isServerError ||
-      isTimeoutError ||
-      (statusCode && statusCode >= 500)
-    );
+      isTimeoutError
+    )
+  );
 
   return {
     isNetworkError,
@@ -162,8 +160,8 @@ export async function handleErrorGracefully(
 
   const isNonCritical = errorMessage.toLowerCase().includes('non-critical') ||
     errorMessage.toLowerCase().includes('service will continue');
-  
-  const isTimeoutError = errorInfo.isTimeoutError || 
+
+  const isTimeoutError = errorInfo.isTimeoutError ||
     errorMessage.toLowerCase().includes('timeout') ||
     errorMessage.toLowerCase().includes('exceeded') ||
     errorMessage.toLowerCase().includes('timed out') ||
@@ -171,7 +169,7 @@ export async function handleErrorGracefully(
     error?.code === 'ECONNABORTED';
 
   const logger = (global as any).logger || console;
-  
+
   if (isNonCritical && isTimeoutError) {
     if (logger.warn) {
       logger.warn(`Non-critical timeout error in ${serviceName}: ${errorMessage}. Crawling will continue.`);
@@ -289,5 +287,3 @@ export function checkCrawlingStatus(): void {
     throw error;
   }
 }
-
-

--- a/test/unit/common/error_handler.spec.ts
+++ b/test/unit/common/error_handler.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from '@jest/globals';
+import { analyzeError } from '../../../src/common/utils/error_handler';
+
+describe('analyzeError', () => {
+  it('does not stop the indexer on a duplicate-key block insert whose SQL contains $500..$504 placeholders', () => {
+    const message =
+      'insert into "block" ("data","hash","height","proposer_address","time","tx_count") values ' +
+      '($499, $500, $501, $502, $503, $504) returning "height" - ' +
+      'duplicate key value violates unique constraint "block_pkey"';
+    const error: any = new Error(message);
+    error.code = '23505';
+
+    const info = analyzeError(error);
+
+    expect(info.isServerError).toBe(false);
+    expect(info.shouldStopIndexer).toBe(false);
+  });
+
+  it('treats a unique-constraint violation as recoverable regardless of message content', () => {
+    const error: any = new Error('duplicate key value violates unique constraint "block_pkey"');
+    error.code = '23505';
+    expect(analyzeError(error).shouldStopIndexer).toBe(false);
+  });
+
+  it('does not misclassify arbitrary numeric content in a message as a 5xx server error', () => {
+    const info = analyzeError(new Error('processed block 500123 with a warning'));
+    expect(info.isServerError).toBe(false);
+    expect(info.shouldStopIndexer).toBe(false);
+  });
+
+  it('still stops the indexer on a real HTTP 5xx by status code', () => {
+    const error: any = new Error('Request failed');
+    error.response = { status: 502, statusText: 'Bad Gateway' };
+    const info = analyzeError(error);
+    expect(info.isServerError).toBe(true);
+    expect(info.shouldStopIndexer).toBe(true);
+  });
+
+  it('classifies any 5xx status code as a server error', () => {
+    for (const status of [500, 502, 503, 504, 599]) {
+      const error: any = new Error('Request failed');
+      error.response = { status };
+      expect(analyzeError(error).isServerError).toBe(true);
+    }
+  });
+
+  it('does not classify a 4xx status code as a server error', () => {
+    const error: any = new Error('Not Found');
+    error.response = { status: 404, statusText: 'Not Found' };
+    const info = analyzeError(error);
+    expect(info.isServerError).toBe(false);
+    expect(info.shouldStopIndexer).toBe(false);
+  });
+
+  it('bounds server errors to the 5xx range and ignores out-of-range status codes', () => {
+    const highest5xx: any = new Error('Server error');
+    highest5xx.response = { status: 599 };
+    expect(analyzeError(highest5xx).isServerError).toBe(true);
+
+    for (const status of [600, 700, 880]) {
+      const error: any = new Error('Weird status');
+      error.response = { status };
+      const info = analyzeError(error);
+      expect(info.isServerError).toBe(false);
+      expect(info.shouldStopIndexer).toBe(false);
+    }
+  });
+
+  it('still classifies textual server errors', () => {
+    expect(analyzeError(new Error('Internal Server Error')).isServerError).toBe(true);
+    expect(analyzeError(new Error('upstream returned Bad Gateway')).isServerError).toBe(true);
+  });
+});


### PR DESCRIPTION
idx.testnet has been frozen for days on a duplicate `block_pkey` insert, which is harmless (the block's already indexed after a restart or overlapping crawl). but `analyzeError` misread it as a fatal HTTP 5xx: the failing bulk insert has `$500`/`$502`/`$503`/`$504` placeholders and the server-error check substring-matched `'500'` in the message, so the indexer kept stopping and restarting into the same range.
