### PR TITLE
fix: delegation authorization events missing

### DIFF
--- a/src/migrations/20231121021951_create_table_event_partition.ts
+++ b/src/migrations/20231121021951_create_table_event_partition.ts
@@ -1,4 +1,5 @@
 import { Knex } from 'knex'
+import config from '../config.json' with { type: 'json' }
 
 export async function up(knex: Knex): Promise<void> {
   await knex.transaction(async (trx) => {
@@ -24,9 +25,28 @@ export async function up(knex: Knex): Promise<void> {
         ON event_partition USING BTREE (block_height ASC NULLS LAST);`
     )
 
+    const startId = config.migrationEventToPartition.startId
+    const endId = config.migrationEventToPartition.endId
+    const step = config.migrationEventToPartition.step
+    for (let i = startId; i < endId; i += step) {
+      const partitionName = `event_partition_${i}_${i + step}`
+      await knex.raw(`CREATE TABLE IF NOT EXISTS ${partitionName} (LIKE event_partition INCLUDING ALL)`).transacting(trx)
+      await knex
+        .raw(`ALTER TABLE event_partition ATTACH PARTITION ${partitionName} FOR VALUES FROM (${i}) TO (${i + step})`)
+        .transacting(trx)
+    }
+
     // Change table name if no data exist on event
     const isExistEventData = await knex.raw(`SELECT * FROM event LIMIT 1`)
     if (isExistEventData.rows.length === 0 && process.env.NODE_ENV !== 'test') {
+      await knex
+        .raw(
+          `
+          ALTER TABLE event_attribute DROP CONSTRAINT IF EXISTS event_attribute_partition_event_id_foreign CASCADE;
+          ALTER TABLE smart_contract_event DROP CONSTRAINT IF EXISTS smart_contract_event_event_id_foreign CASCADE;
+        `
+        )
+        .transacting(trx)
       await knex.raw('ALTER TABLE event RENAME TO event_backup;').transacting(trx)
       await knex.raw('ALTER TABLE event_partition RENAME TO event;').transacting(trx)
     }

--- a/src/migrations/20231121021951_create_table_event_partition.ts
+++ b/src/migrations/20231121021951_create_table_event_partition.ts
@@ -30,7 +30,9 @@ export async function up(knex: Knex): Promise<void> {
     const step = config.migrationEventToPartition.step
     for (let i = startId; i < endId; i += step) {
       const partitionName = `event_partition_${i}_${i + step}`
-      await knex.raw(`CREATE TABLE IF NOT EXISTS ${partitionName} (LIKE event_partition INCLUDING ALL)`).transacting(trx)
+      await knex
+        .raw(`CREATE TABLE IF NOT EXISTS ${partitionName} (LIKE event_partition INCLUDING ALL)`)
+        .transacting(trx)
       await knex
         .raw(`ALTER TABLE event_partition ATTACH PARTITION ${partitionName} FOR VALUES FROM (${i}) TO (${i + step})`)
         .transacting(trx)

--- a/src/migrations/20231121021951_create_table_event_partition.ts
+++ b/src/migrations/20231121021951_create_table_event_partition.ts
@@ -25,22 +25,21 @@ export async function up(knex: Knex): Promise<void> {
         ON event_partition USING BTREE (block_height ASC NULLS LAST);`
     )
 
-    const startId = config.migrationEventToPartition.startId
-    const endId = config.migrationEventToPartition.endId
-    const step = config.migrationEventToPartition.step
-    for (let i = startId; i < endId; i += step) {
-      const partitionName = `event_partition_${i}_${i + step}`
-      await knex
-        .raw(`CREATE TABLE IF NOT EXISTS ${partitionName} (LIKE event_partition INCLUDING ALL)`)
-        .transacting(trx)
-      await knex
-        .raw(`ALTER TABLE event_partition ATTACH PARTITION ${partitionName} FOR VALUES FROM (${i}) TO (${i + step})`)
-        .transacting(trx)
-    }
-
-    // Change table name if no data exist on event
     const isExistEventData = await knex.raw(`SELECT * FROM event LIMIT 1`)
     if (isExistEventData.rows.length === 0 && process.env.NODE_ENV !== 'test') {
+      const startId = config.migrationEventToPartition.startId
+      const endId = config.migrationEventToPartition.endId
+      const step = config.migrationEventToPartition.step
+      for (let i = startId; i < endId; i += step) {
+        const partitionName = `event_partition_${i}_${i + step}`
+        await knex
+          .raw(`CREATE TABLE IF NOT EXISTS ${partitionName} (LIKE event_partition INCLUDING ALL)`)
+          .transacting(trx)
+        await knex
+          .raw(`ALTER TABLE event_partition ATTACH PARTITION ${partitionName} FOR VALUES FROM (${i}) TO (${i + step})`)
+          .transacting(trx)
+      }
+
       await knex
         .raw(
           `

--- a/src/migrations/20260420000000_create_indexer_events.ts
+++ b/src/migrations/20260420000000_create_indexer_events.ts
@@ -7,7 +7,7 @@ export async function up(knex: Knex): Promise<void> {
   await knex.schema.createTable('indexer_events', (table) => {
     table.bigIncrements('id').primary()
     table.text('event_type').notNullable()
-    table.text('did').notNullable()
+    table.text('did').nullable()
     table.bigInteger('block_height').notNullable()
     table.text('tx_hash').notNullable()
     table.integer('tx_index').notNullable().defaultTo(0)

--- a/src/services/api/api_shared.ts
+++ b/src/services/api/api_shared.ts
@@ -84,7 +84,7 @@ export function parseSubscribeMembership(
 }
 
 export type MembershipTarget = {
-  did: string
+  did: string | null
   relatedDids?: Iterable<string>
   corporationIds?: Iterable<number>
 }
@@ -96,7 +96,7 @@ export function matchesMembership(
 ): boolean {
   const didOk =
     dids === null ||
-    dids.has(target.did) ||
+    (target.did !== null && dids.has(target.did)) ||
     (target.relatedDids ? [...target.relatedDids].some((d) => dids.has(d)) : false)
   const corpOk =
     corporationId === null ||

--- a/src/services/api/indexer_event_chain_lookup.ts
+++ b/src/services/api/indexer_event_chain_lookup.ts
@@ -17,10 +17,7 @@ function toCorporationId(value: unknown): number | undefined {
   return Number.isInteger(id) && id > 0 ? id : undefined
 }
 
-export async function fetchCorporationById(
-  corporationId: number,
-  blockHeight?: number
-): Promise<ChainCorporation> {
+export async function fetchCorporationById(corporationId: number, blockHeight?: number): Promise<ChainCorporation> {
   try {
     return await withAbciQueryClient(blockHeight, async (rpc) => {
       const query = new CoQueryClientImpl(rpc)

--- a/src/services/api/indexer_event_chain_lookup.ts
+++ b/src/services/api/indexer_event_chain_lookup.ts
@@ -1,7 +1,6 @@
 import {
   QueryClientImpl as CoQueryClientImpl,
   QueryGetCorporationRequest,
-  QueryListCorporationsRequest,
 } from '@verana-labs/verana-types/codec/verana/co/v1/query'
 import { withAbciQueryClient } from '../../common/utils/grpc_query'
 import { fetchParticipant } from '../../modules/pp-height-sync/pp_height_sync_helpers'
@@ -31,39 +30,6 @@ export async function fetchCorporationById(corporationId: number, blockHeight?: 
   } catch {
     return {}
   }
-}
-
-let corporationsByAddressCache: { blockHeight?: number; corporations: Map<string, ChainCorporation> } | null = null
-
-async function listCorporationsByAddress(blockHeight?: number): Promise<Map<string, ChainCorporation>> {
-  const cached = corporationsByAddressCache
-  if (cached && cached.blockHeight === blockHeight) return cached.corporations
-
-  const corporations = new Map<string, ChainCorporation>()
-  try {
-    await withAbciQueryClient(blockHeight, async (rpc) => {
-      const query = new CoQueryClientImpl(rpc)
-      const response = await query.ListCorporations(
-        QueryListCorporationsRequest.fromPartial({ activeGfOnly: false, preferredLanguage: '', responseMaxSize: 0 })
-      )
-      for (const corporation of response?.corporations ?? []) {
-        corporations.set(corporation.policyAddress, {
-          corporationId: toCorporationId(corporation.id),
-          did: normalizeDid(corporation.did),
-        })
-      }
-    })
-  } catch {
-    return corporations
-  }
-
-  corporationsByAddressCache = { blockHeight, corporations }
-  return corporations
-}
-
-export async function fetchCorporationByAddress(address: string, blockHeight?: number): Promise<ChainCorporation> {
-  const corporations = await listCorporationsByAddress(blockHeight)
-  return corporations.get(address) ?? {}
 }
 
 export async function fetchParticipantDid(participantId: number, blockHeight?: number): Promise<string | undefined> {

--- a/src/services/api/indexer_event_chain_lookup.ts
+++ b/src/services/api/indexer_event_chain_lookup.ts
@@ -1,0 +1,75 @@
+import {
+  QueryClientImpl as CoQueryClientImpl,
+  QueryGetCorporationRequest,
+  QueryListCorporationsRequest,
+} from '@verana-labs/verana-types/codec/verana/co/v1/query'
+import { withAbciQueryClient } from '../../common/utils/grpc_query'
+import { fetchParticipant } from '../../modules/pp-height-sync/pp_height_sync_helpers'
+import { normalizeDid } from './indexer_event_utils'
+
+export type ChainCorporation = {
+  corporationId?: number
+  did?: string
+}
+
+function toCorporationId(value: unknown): number | undefined {
+  const id = Number(value)
+  return Number.isInteger(id) && id > 0 ? id : undefined
+}
+
+export async function fetchCorporationById(
+  corporationId: number,
+  blockHeight?: number
+): Promise<ChainCorporation> {
+  try {
+    return await withAbciQueryClient(blockHeight, async (rpc) => {
+      const query = new CoQueryClientImpl(rpc)
+      const response = await query.GetCorporation(
+        QueryGetCorporationRequest.fromPartial({ corporationId, activeGfOnly: false, preferredLanguage: '' })
+      )
+      const corporation = response?.corporation
+      if (!corporation) return {}
+      return { corporationId: toCorporationId(corporation.id), did: normalizeDid(corporation.did) }
+    })
+  } catch {
+    return {}
+  }
+}
+
+let corporationsByAddressCache: { blockHeight?: number; corporations: Map<string, ChainCorporation> } | null = null
+
+async function listCorporationsByAddress(blockHeight?: number): Promise<Map<string, ChainCorporation>> {
+  const cached = corporationsByAddressCache
+  if (cached && cached.blockHeight === blockHeight) return cached.corporations
+
+  const corporations = new Map<string, ChainCorporation>()
+  try {
+    await withAbciQueryClient(blockHeight, async (rpc) => {
+      const query = new CoQueryClientImpl(rpc)
+      const response = await query.ListCorporations(
+        QueryListCorporationsRequest.fromPartial({ activeGfOnly: false, preferredLanguage: '', responseMaxSize: 0 })
+      )
+      for (const corporation of response?.corporations ?? []) {
+        corporations.set(corporation.policyAddress, {
+          corporationId: toCorporationId(corporation.id),
+          did: normalizeDid(corporation.did),
+        })
+      }
+    })
+  } catch {
+    return corporations
+  }
+
+  corporationsByAddressCache = { blockHeight, corporations }
+  return corporations
+}
+
+export async function fetchCorporationByAddress(address: string, blockHeight?: number): Promise<ChainCorporation> {
+  const corporations = await listCorporationsByAddress(blockHeight)
+  return corporations.get(address) ?? {}
+}
+
+export async function fetchParticipantDid(participantId: number, blockHeight?: number): Promise<string | undefined> {
+  const result = await fetchParticipant(participantId, blockHeight)
+  return normalizeDid(result?.participant?.did)
+}

--- a/src/services/api/indexer_events_query.ts
+++ b/src/services/api/indexer_events_query.ts
@@ -4,14 +4,13 @@ import { extractController } from '../../common/utils/extract_controller'
 import {
   VeranaCorporationMessageTypes,
   VeranaCredentialSchemaMessageTypes,
-  VeranaDelegationMessageTypes,
   VeranaDiMessageTypes,
   VeranaEcosystemMessageTypes,
   VeranaGovernanceFrameworkMessageTypes,
   VeranaParticipantMessageTypes,
 } from '../../common/verana-message-types'
 import { applyBlockHeightFilter, toIsoSeconds } from './api_shared'
-import { fetchCorporationByAddress, fetchCorporationById, fetchParticipantDid } from './indexer_event_chain_lookup'
+import { fetchCorporationById, fetchParticipantDid } from './indexer_event_chain_lookup'
 import {
   collectDidsDeep,
   firstNormalizedDid,
@@ -43,7 +42,6 @@ export type IndexerTxEvent = {
   corporationId?: number
   relatedCorporationIds: number[]
   grantee?: string
-  operator?: string
   vsOperator?: string
   withFeegrant?: boolean
   timestamp: string
@@ -72,7 +70,6 @@ export type IndexerEventRecord = {
     corporation_id?: number
     related_corporation_ids?: number[]
     grantee?: string
-    operator?: string
     vs_operator?: string
     with_feegrant?: boolean
   }
@@ -203,16 +200,6 @@ const EVENT_META: Record<string, EventMeta> = {
     action: 'StoreDigest',
     entityType: 'DigitalIdentityDigest',
   },
-  [VeranaDelegationMessageTypes.GrantOperatorAuthorization]: {
-    module: 'delegation',
-    action: 'GrantOperatorAuthorization',
-    entityType: 'OperatorAuthorization',
-  },
-  [VeranaDelegationMessageTypes.RevokeOperatorAuthorization]: {
-    module: 'delegation',
-    action: 'RevokeOperatorAuthorization',
-    entityType: 'OperatorAuthorization',
-  },
   [VeranaCorporationMessageTypes.CreateCorporation]: {
     module: 'corporation',
     action: 'CreateNewCorporation',
@@ -242,11 +229,6 @@ const ID_ALIASES = {
 } as const
 
 async function getEntityId(row: EventRow, meta: EventMeta): Promise<string | undefined> {
-  if (meta.module === 'delegation') {
-    const content = row.content && typeof row.content === 'object' ? (row.content as Record<string, unknown>) : {}
-    return readAddress(content.grantee) ?? readAddress(content.operator)
-  }
-
   if (meta.module === 'participant') {
     const participantId = readNumber(row.content, ['id', ...ID_ALIASES.participant])
     return participantId ? String(participantId) : resolveEntityIdFromDomain(row, meta)
@@ -431,9 +413,6 @@ async function toIndexerEvent(row: EventRow): Promise<IndexerTxEvent | null> {
   let schemaId: string | undefined
   let participantId: string | undefined
   let corporationId: number | undefined
-  let grantee: string | undefined
-  let operator: string | undefined
-  let withFeegrant: boolean | undefined
   const relatedCorporationIds = new Set<number>()
   const explicitPrimaryDid = firstNormalizedDid([
     content.did,
@@ -522,40 +501,12 @@ async function toIndexerEvent(row: EventRow): Promise<IndexerTxEvent | null> {
     if (relation.did) collected.add(relation.did)
   }
 
-  if (meta.module === 'delegation') {
-    grantee = readAddress(content.grantee)
-    operator = readAddress(content.operator)
-    if (typeof content.with_feegrant === 'boolean') withFeegrant = content.with_feegrant
-    else if (typeof content.withFeegrant === 'boolean') withFeegrant = content.withFeegrant
-    const corporationAddress = readAddress(content.corporation)
-    if (corporationAddress) {
-      const corp = await loadCorporation({ address: corporationAddress })
-      const chainCorp = corp.did ? {} : await fetchCorporationByAddress(corporationAddress, Number(row.block_height))
-      corporationId = corp.corporationId ?? chainCorp.corporationId
-      const corpDid = corp.did ?? chainCorp.did
-      if (corpDid) collected.add(corpDid)
-    }
-    for (const account of [grantee, operator]) {
-      const participants = await loadParticipantsByAccount(account)
-      for (const participantDid of participants.dids) collected.add(participantDid)
-      for (const participantCorporationId of participants.corporationIds) {
-        if (corporationId === undefined) corporationId = participantCorporationId
-        else if (participantCorporationId !== corporationId) relatedCorporationIds.add(participantCorporationId)
-      }
-    }
-  }
-
   const relatedDids = uniqueNormalizedDids(collected)
   const primaryDid =
     explicitPrimaryDid ??
     (meta.module === 'participant' ? firstNormalizedDid(relatedDids) : undefined) ??
     firstNormalizedDid(relatedDids)
-  if (!primaryDid) {
-    if (meta.module !== 'delegation') return null
-    console.warn(
-      `[IndexerEvents] ${meta.action} at block_height=${row.block_height} tx_hash=${row.tx_hash} has no resolvable DID; emitting with did=null`
-    )
-  }
+  if (!primaryDid) return null
 
   return {
     type: 'transaction-executed',
@@ -567,7 +518,7 @@ async function toIndexerEvent(row: EventRow): Promise<IndexerTxEvent | null> {
     txIndex: Number(row.tx_index),
     messageIndex: Number(row.message_index),
     sender: row.sender,
-    did: primaryDid ?? null,
+    did: primaryDid,
     relatedDids,
     entityType: meta.entityType,
     entityId,
@@ -576,9 +527,6 @@ async function toIndexerEvent(row: EventRow): Promise<IndexerTxEvent | null> {
     participantId,
     corporationId,
     relatedCorporationIds: [...relatedCorporationIds],
-    grantee,
-    operator,
-    withFeegrant,
     timestamp: toIsoSeconds(row.timestamp),
   }
 }
@@ -613,7 +561,6 @@ function toEventRow(event: IndexerTxEvent): Record<string, unknown> {
       corporation_id: event.corporationId,
       related_corporation_ids: event.relatedCorporationIds,
       grantee: event.grantee,
-      operator: event.operator,
       vs_operator: event.vsOperator,
       with_feegrant: event.withFeegrant,
     },
@@ -659,7 +606,6 @@ function fromStoredRow(row: Record<string, any>): IndexerEventRecord {
               .filter((n: number) => Number.isInteger(n) && n > 0)
           : undefined,
       grantee: row.payload?.grantee ?? undefined,
-      operator: row.payload?.operator ?? undefined,
       vs_operator: row.payload?.vs_operator ?? row.payload?.vsOperator ?? undefined,
       with_feegrant:
         typeof row.payload?.with_feegrant === 'boolean'
@@ -708,7 +654,15 @@ async function buildIndexerTxEvents(args: {
   return (await Promise.all(rows.map((row) => toIndexerEvent(row)))).filter(Boolean) as IndexerTxEvent[]
 }
 
-const VSOA_EVENT_META: Record<string, { action: string; entityType: string }> = {
+const DELEGATION_EVENT_META: Record<string, { action: string; entityType: string }> = {
+  grant_operator_authorization: {
+    action: 'GrantOperatorAuthorization',
+    entityType: 'OperatorAuthorization',
+  },
+  revoke_operator_authorization: {
+    action: 'RevokeOperatorAuthorization',
+    entityType: 'OperatorAuthorization',
+  },
   grant_vs_operator_authorization: {
     action: 'GrantVSOperatorAuthorization',
     entityType: 'VSOperatorAuthorization',
@@ -723,9 +677,19 @@ const VSOA_EVENT_META: Record<string, { action: string; entityType: string }> = 
   },
 }
 
-const VSOA_EVENT_TYPES = Object.keys(VSOA_EVENT_META)
+const DELEGATION_EVENT_TYPES = Object.keys(DELEGATION_EVENT_META)
 
-type VsoaEventRow = {
+const DELEGATION_ATTRIBUTE_KEYS = [
+  'authz_id',
+  'vsoa_id',
+  'corporation_id',
+  'participant_id',
+  'grantee',
+  'vs_operator',
+  'with_feegrant',
+]
+
+type DelegationEventRow = {
   event_id: number
   type: string
   tx_msg_index: number | null
@@ -736,7 +700,13 @@ type VsoaEventRow = {
   timestamp: Date | string
 }
 
-async function buildVsoaEvents(blockHeight: number): Promise<IndexerTxEvent[]> {
+async function resolveCorporationDid(corporationId: number, blockHeight: number): Promise<string | undefined> {
+  const corporation = await loadCorporationById(corporationId)
+  if (corporation.did) return corporation.did
+  return (await fetchCorporationById(corporationId, blockHeight)).did
+}
+
+async function buildDelegationEvents(blockHeight: number): Promise<IndexerTxEvent[]> {
   const eventRows = (await knex('event as e')
     .innerJoin('transaction as tx', 'tx.id', 'e.tx_id')
     .leftJoin('transaction_message as tm', function () {
@@ -744,7 +714,7 @@ async function buildVsoaEvents(blockHeight: number): Promise<IndexerTxEvent[]> {
     })
     .where('e.block_height', blockHeight)
     .andWhere('tx.code', 0)
-    .whereIn('e.type', VSOA_EVENT_TYPES)
+    .whereIn('e.type', DELEGATION_EVENT_TYPES)
     .select(
       'e.id as event_id',
       'e.type',
@@ -756,7 +726,7 @@ async function buildVsoaEvents(blockHeight: number): Promise<IndexerTxEvent[]> {
       'tx.timestamp'
     )
     .orderBy('tx.index', 'asc')
-    .orderBy('e.id', 'asc')) as VsoaEventRow[]
+    .orderBy('e.id', 'asc')) as DelegationEventRow[]
 
   if (eventRows.length === 0) return []
 
@@ -764,7 +734,7 @@ async function buildVsoaEvents(blockHeight: number): Promise<IndexerTxEvent[]> {
   const attributeRows = (await knex('event_attribute')
     .where('block_height', blockHeight)
     .whereIn('event_id', eventIds)
-    .whereIn('key', ['vs_operator', 'participant_id', 'corporation_id'])
+    .whereIn('key', DELEGATION_ATTRIBUTE_KEYS)
     .select('event_id', 'key', 'value')) as Array<{ event_id: number; key: string; value: string }>
 
   const attributesByEvent = new Map<number, Record<string, string>>()
@@ -776,40 +746,42 @@ async function buildVsoaEvents(blockHeight: number): Promise<IndexerTxEvent[]> {
 
   const events: IndexerTxEvent[] = []
   for (const row of eventRows) {
-    const meta = VSOA_EVENT_META[row.type]
+    const meta = DELEGATION_EVENT_META[row.type]
     const attributes = attributesByEvent.get(row.event_id) ?? {}
+    const entityId = attributes.authz_id ?? attributes.vsoa_id
+    const grantee = readAddress(attributes.grantee)
     const vsOperator = readAddress(attributes.vs_operator)
     const rawParticipantId = readPositiveInteger(attributes.participant_id)
     const corporationId = toCorporationId(attributes.corporation_id)
+    const withFeegrant = attributes.with_feegrant === undefined ? undefined : attributes.with_feegrant === 'true'
 
     const collected = new Set<string>()
+    const relatedCorporationIds = new Set<number>()
     let did: string | undefined
+
     if (rawParticipantId) {
       const participant = await loadParticipantRelation(rawParticipantId)
       if (participant.participantDid) collected.add(participant.participantDid)
       if (participant.ecosystemDid) collected.add(participant.ecosystemDid)
-      did = participant.participantDid
+      did = participant.participantDid ?? (await fetchParticipantDid(rawParticipantId, blockHeight))
+      if (did) collected.add(did)
     }
-    if (!did && corporationId) {
-      const corporation = await loadCorporationById(corporationId)
-      if (corporation.did) collected.add(corporation.did)
-      did = corporation.did
+
+    if (corporationId) {
+      const corporationDid = await resolveCorporationDid(corporationId, blockHeight)
+      if (corporationDid) collected.add(corporationDid)
+      did = did ?? corporationDid
     }
-    if (vsOperator) {
-      const participants = await loadParticipantsByAccount(vsOperator)
+
+    for (const account of [grantee, vsOperator]) {
+      const participants = await loadParticipantsByAccount(account)
       for (const participantDid of participants.dids) collected.add(participantDid)
+      for (const participantCorporationId of participants.corporationIds) {
+        if (participantCorporationId !== corporationId) relatedCorporationIds.add(participantCorporationId)
+      }
       did = did ?? participants.dids[0]
     }
-    if (!did && rawParticipantId) {
-      const participantDid = await fetchParticipantDid(rawParticipantId, blockHeight)
-      if (participantDid) collected.add(participantDid)
-      did = did ?? participantDid
-    }
-    if (!did && corporationId) {
-      const corporation = await fetchCorporationById(corporationId, blockHeight)
-      if (corporation.did) collected.add(corporation.did)
-      did = did ?? corporation.did
-    }
+
     if (!did) {
       console.warn(
         `[IndexerEvents] ${meta.action} at block_height=${blockHeight} tx_hash=${row.tx_hash} has no resolvable DID; emitting with did=null`
@@ -829,11 +801,13 @@ async function buildVsoaEvents(blockHeight: number): Promise<IndexerTxEvent[]> {
       did: did ?? null,
       relatedDids: uniqueNormalizedDids(collected),
       entityType: meta.entityType,
-      entityId: rawParticipantId ? String(rawParticipantId) : vsOperator,
+      entityId,
       participantId: rawParticipantId ? String(rawParticipantId) : undefined,
       corporationId,
-      relatedCorporationIds: [],
+      relatedCorporationIds: [...relatedCorporationIds],
+      grantee,
       vsOperator,
+      withFeegrant,
       timestamp: toIsoSeconds(row.timestamp),
     })
   }
@@ -850,8 +824,8 @@ export async function persistIndexerEventsForBlock(blockHeight: number): Promise
     if (txEvents.length < pageSize) break
     offset += pageSize
   }
-  const vsoaEvents = await buildVsoaEvents(blockHeight)
-  rows.push(...vsoaEvents.map(toEventRow))
+  const delegationEvents = await buildDelegationEvents(blockHeight)
+  rows.push(...delegationEvents.map(toEventRow))
   let insertedIds: number[] = []
 
   if (rows.length > 0) {

--- a/src/services/api/indexer_events_query.ts
+++ b/src/services/api/indexer_events_query.ts
@@ -731,12 +731,16 @@ type VsoaEventRow = {
   tx_hash: string
   tx_index: number
   block_height: number
+  sender: string | null
   timestamp: Date | string
 }
 
 async function buildVsoaEvents(blockHeight: number): Promise<IndexerTxEvent[]> {
   const eventRows = (await knex('event as e')
     .innerJoin('transaction as tx', 'tx.id', 'e.tx_id')
+    .leftJoin('transaction_message as tm', function () {
+      this.on('tm.tx_id', '=', 'e.tx_id').andOn(knex.raw('tm.index = COALESCE(e.tx_msg_index, 0)'))
+    })
     .where('e.block_height', blockHeight)
     .andWhere('tx.code', 0)
     .whereIn('e.type', VSOA_EVENT_TYPES)
@@ -747,6 +751,7 @@ async function buildVsoaEvents(blockHeight: number): Promise<IndexerTxEvent[]> {
       'tx.hash as tx_hash',
       'tx.index as tx_index',
       'tx.height as block_height',
+      'tm.sender as sender',
       'tx.timestamp'
     )
     .orderBy('tx.index', 'asc')
@@ -814,12 +819,12 @@ async function buildVsoaEvents(blockHeight: number): Promise<IndexerTxEvent[]> {
       type: 'transaction-executed',
       module: 'delegation',
       action: meta.action,
-      messageType: `/verana.de.v1.${meta.action}`,
+      messageType: row.type,
       blockHeight: Number(row.block_height),
       txHash: row.tx_hash,
       txIndex: Number(row.tx_index),
       messageIndex: Number(row.tx_msg_index ?? 0),
-      sender: vsOperator ?? '',
+      sender: row.sender ?? '',
       did: did ?? null,
       relatedDids: uniqueNormalizedDids(collected),
       entityType: meta.entityType,

--- a/src/services/api/indexer_events_query.ts
+++ b/src/services/api/indexer_events_query.ts
@@ -529,10 +529,11 @@ async function toIndexerEvent(row: EventRow): Promise<IndexerTxEvent | null> {
     else if (typeof content.withFeegrant === 'boolean') withFeegrant = content.withFeegrant
     const corporationAddress = readAddress(content.corporation)
     if (corporationAddress) {
-      let corp = await loadCorporation({ address: corporationAddress })
-      if (!corp.did) corp = await fetchCorporationByAddress(corporationAddress, Number(row.block_height))
-      if (corp.corporationId !== undefined) corporationId = corp.corporationId
-      if (corp.did) collected.add(corp.did)
+      const corp = await loadCorporation({ address: corporationAddress })
+      const chainCorp = corp.did ? {} : await fetchCorporationByAddress(corporationAddress, Number(row.block_height))
+      corporationId = corp.corporationId ?? chainCorp.corporationId
+      const corpDid = corp.did ?? chainCorp.did
+      if (corpDid) collected.add(corpDid)
     }
     for (const account of [grantee, operator]) {
       const participants = await loadParticipantsByAccount(account)

--- a/src/services/api/indexer_events_query.ts
+++ b/src/services/api/indexer_events_query.ts
@@ -332,18 +332,20 @@ async function loadCorporationById(corporationId: number | null | undefined): Pr
   return { did: normalizeDid(row.did), corporationId: toCorporationId(row.id) }
 }
 
-async function loadParticipantByAccount(account: string | null | undefined): Promise<{
-  participantId?: string
-  did?: string
-  corporationId?: number
+async function loadParticipantsByAccount(account: string | null | undefined): Promise<{
+  dids: string[]
+  corporationIds: number[]
 }> {
-  if (!account || typeof account !== 'string' || !account.trim()) return {}
-  const row = await knex('participants').select('id', 'did', 'corporation_id').where({ vs_operator: account }).first()
-  if (!row) return {}
+  if (!account || typeof account !== 'string' || !account.trim()) return { dids: [], corporationIds: [] }
+  const rows = await knex('participants')
+    .select('id', 'did', 'corporation_id')
+    .where({ vs_operator: account })
+    .orderBy('id', 'asc')
   return {
-    participantId: row.id != null ? String(row.id) : undefined,
-    did: normalizeDid(row.did),
-    corporationId: toCorporationId(row.corporation_id),
+    dids: uniqueNormalizedDids(rows.map((row) => row.did)),
+    corporationIds: rows
+      .map((row) => toCorporationId(row.corporation_id))
+      .filter((corporationId): corporationId is number => corporationId !== undefined),
   }
 }
 
@@ -529,11 +531,11 @@ async function toIndexerEvent(row: EventRow): Promise<IndexerTxEvent | null> {
       if (corp.did) collected.add(corp.did)
     }
     for (const account of [grantee, operator]) {
-      const participant = await loadParticipantByAccount(account)
-      if (participant.did) collected.add(participant.did)
-      if (participant.corporationId !== undefined) {
-        if (corporationId === undefined) corporationId = participant.corporationId
-        else if (participant.corporationId !== corporationId) relatedCorporationIds.add(participant.corporationId)
+      const participants = await loadParticipantsByAccount(account)
+      for (const participantDid of participants.dids) collected.add(participantDid)
+      for (const participantCorporationId of participants.corporationIds) {
+        if (corporationId === undefined) corporationId = participantCorporationId
+        else if (participantCorporationId !== corporationId) relatedCorporationIds.add(participantCorporationId)
       }
     }
   }
@@ -784,9 +786,9 @@ async function buildVsoaEvents(blockHeight: number): Promise<IndexerTxEvent[]> {
       did = corporation.did
     }
     if (vsOperator) {
-      const participant = await loadParticipantByAccount(vsOperator)
-      if (participant.did) collected.add(participant.did)
-      did = did ?? participant.did
+      const participants = await loadParticipantsByAccount(vsOperator)
+      for (const participantDid of participants.dids) collected.add(participantDid)
+      did = did ?? participants.dids[0]
     }
     if (!did && rawParticipantId) {
       const participantDid = await fetchParticipantDid(rawParticipantId, blockHeight)

--- a/src/services/api/indexer_events_query.ts
+++ b/src/services/api/indexer_events_query.ts
@@ -16,6 +16,7 @@ import {
   firstNormalizedDid,
   normalizeDid,
   readFirstPositiveInteger,
+  readPositiveInteger,
   toProtoModule,
   toShortMessageType,
   uniqueNormalizedDids,
@@ -40,6 +41,10 @@ export type IndexerTxEvent = {
   participantId?: string
   corporationId?: number
   relatedCorporationIds: number[]
+  grantee?: string
+  operator?: string
+  vsOperator?: string
+  withFeegrant?: boolean
   timestamp: string
 }
 
@@ -65,6 +70,10 @@ export type IndexerEventRecord = {
     participant_id?: string
     corporation_id?: number
     related_corporation_ids?: number[]
+    grantee?: string
+    operator?: string
+    vs_operator?: string
+    with_feegrant?: boolean
   }
 }
 
@@ -296,12 +305,46 @@ async function loadCorporation(opts: { did?: string; address?: string }): Promis
   corporationId?: number
 }> {
   const query = knex('corporation').select('id', 'did')
-  if (opts.address) query.where({ corporation: opts.address })
-  else if (opts.did) query.where({ did: opts.did })
+  if (opts.address) {
+    query.where(function () {
+      this.where('corporation', opts.address).orWhere('policy_address', opts.address)
+    })
+  } else if (opts.did) query.where({ did: opts.did })
   else return {}
   const row = await query.first()
   if (!row) return {}
   return { did: normalizeDid(row.did), corporationId: toCorporationId(row.id) }
+}
+
+async function loadCorporationById(corporationId: number | null | undefined): Promise<{
+  did?: string
+  corporationId?: number
+}> {
+  if (!corporationId) return {}
+  const row = await knex('corporation').select('id', 'did').where({ id: corporationId }).first()
+  if (!row) return {}
+  return { did: normalizeDid(row.did), corporationId: toCorporationId(row.id) }
+}
+
+async function loadParticipantByAccount(account: string | null | undefined): Promise<{
+  participantId?: string
+  did?: string
+  corporationId?: number
+}> {
+  if (!account || typeof account !== 'string' || !account.trim()) return {}
+  const row = await knex('participants').select('id', 'did', 'corporation_id').where({ vs_operator: account }).first()
+  if (!row) return {}
+  return {
+    participantId: row.id != null ? String(row.id) : undefined,
+    did: normalizeDid(row.did),
+    corporationId: toCorporationId(row.corporation_id),
+  }
+}
+
+function readAddress(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed ? trimmed : undefined
 }
 
 async function loadSchemaRelation(schemaId: number | null | undefined): Promise<{
@@ -376,6 +419,9 @@ async function toIndexerEvent(row: EventRow): Promise<IndexerTxEvent | null> {
   let schemaId: string | undefined
   let participantId: string | undefined
   let corporationId: number | undefined
+  let grantee: string | undefined
+  let operator: string | undefined
+  let withFeegrant: boolean | undefined
   const relatedCorporationIds = new Set<number>()
   const explicitPrimaryDid = firstNormalizedDid([
     content.did,
@@ -464,6 +510,27 @@ async function toIndexerEvent(row: EventRow): Promise<IndexerTxEvent | null> {
     if (relation.did) collected.add(relation.did)
   }
 
+  if (meta.module === 'delegation') {
+    grantee = readAddress(content.grantee)
+    operator = readAddress(content.operator)
+    if (typeof content.with_feegrant === 'boolean') withFeegrant = content.with_feegrant
+    else if (typeof content.withFeegrant === 'boolean') withFeegrant = content.withFeegrant
+    const corporationAddress = readAddress(content.corporation)
+    if (corporationAddress) {
+      const corp = await loadCorporation({ address: corporationAddress })
+      if (corp.corporationId !== undefined) corporationId = corp.corporationId
+      if (corp.did) collected.add(corp.did)
+    }
+    for (const account of [grantee, operator]) {
+      const participant = await loadParticipantByAccount(account)
+      if (participant.did) collected.add(participant.did)
+      if (participant.corporationId !== undefined) {
+        if (corporationId === undefined) corporationId = participant.corporationId
+        else if (participant.corporationId !== corporationId) relatedCorporationIds.add(participant.corporationId)
+      }
+    }
+  }
+
   const relatedDids = uniqueNormalizedDids(collected)
   const primaryDid =
     explicitPrimaryDid ??
@@ -490,6 +557,9 @@ async function toIndexerEvent(row: EventRow): Promise<IndexerTxEvent | null> {
     participantId,
     corporationId,
     relatedCorporationIds: [...relatedCorporationIds],
+    grantee,
+    operator,
+    withFeegrant,
     timestamp: toIsoSeconds(row.timestamp),
   }
 }
@@ -523,6 +593,10 @@ function toEventRow(event: IndexerTxEvent): Record<string, unknown> {
       participant_id: event.participantId,
       corporation_id: event.corporationId,
       related_corporation_ids: event.relatedCorporationIds,
+      grantee: event.grantee,
+      operator: event.operator,
+      vs_operator: event.vsOperator,
+      with_feegrant: event.withFeegrant,
     },
   }
 }
@@ -563,6 +637,15 @@ function fromStoredRow(row: Record<string, any>): IndexerEventRecord {
               .map((v: unknown) => Number(v))
               .filter((n: number) => Number.isInteger(n) && n > 0)
           : undefined,
+      grantee: row.payload?.grantee ?? undefined,
+      operator: row.payload?.operator ?? undefined,
+      vs_operator: row.payload?.vs_operator ?? row.payload?.vsOperator ?? undefined,
+      with_feegrant:
+        typeof row.payload?.with_feegrant === 'boolean'
+          ? row.payload.with_feegrant
+          : typeof row.payload?.withFeegrant === 'boolean'
+            ? row.payload.withFeegrant
+            : undefined,
     },
   }
 }
@@ -604,6 +687,119 @@ async function buildIndexerTxEvents(args: {
   return (await Promise.all(rows.map((row) => toIndexerEvent(row)))).filter(Boolean) as IndexerTxEvent[]
 }
 
+const VSOA_EVENT_META: Record<string, { action: string; entityType: string }> = {
+  grant_vs_operator_authorization: {
+    action: 'GrantVSOperatorAuthorization',
+    entityType: 'VSOperatorAuthorization',
+  },
+  revoke_vs_operator_authorization: {
+    action: 'RevokeVSOperatorAuthorization',
+    entityType: 'VSOperatorAuthorization',
+  },
+  update_vs_operator_authorization: {
+    action: 'UpdateVSOperatorAuthorization',
+    entityType: 'VSOperatorAuthorization',
+  },
+}
+
+const VSOA_EVENT_TYPES = Object.keys(VSOA_EVENT_META)
+
+type VsoaEventRow = {
+  event_id: number
+  type: string
+  tx_msg_index: number | null
+  tx_hash: string
+  tx_index: number
+  block_height: number
+  timestamp: Date | string
+}
+
+async function buildVsoaEvents(blockHeight: number): Promise<IndexerTxEvent[]> {
+  const eventRows = (await knex('event as e')
+    .innerJoin('transaction as tx', 'tx.id', 'e.tx_id')
+    .where('e.block_height', blockHeight)
+    .andWhere('tx.code', 0)
+    .whereIn('e.type', VSOA_EVENT_TYPES)
+    .select(
+      'e.id as event_id',
+      'e.type',
+      'e.tx_msg_index',
+      'tx.hash as tx_hash',
+      'tx.index as tx_index',
+      'tx.height as block_height',
+      'tx.timestamp'
+    )
+    .orderBy('tx.index', 'asc')
+    .orderBy('e.id', 'asc')) as VsoaEventRow[]
+
+  if (eventRows.length === 0) return []
+
+  const eventIds = eventRows.map((row) => row.event_id)
+  const attributeRows = (await knex('event_attribute')
+    .where('block_height', blockHeight)
+    .whereIn('event_id', eventIds)
+    .whereIn('key', ['vs_operator', 'participant_id', 'corporation_id'])
+    .select('event_id', 'key', 'value')) as Array<{ event_id: number; key: string; value: string }>
+
+  const attributesByEvent = new Map<number, Record<string, string>>()
+  for (const attribute of attributeRows) {
+    const bucket = attributesByEvent.get(attribute.event_id) ?? {}
+    bucket[attribute.key] = attribute.value
+    attributesByEvent.set(attribute.event_id, bucket)
+  }
+
+  const events: IndexerTxEvent[] = []
+  for (const row of eventRows) {
+    const meta = VSOA_EVENT_META[row.type]
+    const attributes = attributesByEvent.get(row.event_id) ?? {}
+    const vsOperator = readAddress(attributes.vs_operator)
+    const rawParticipantId = readPositiveInteger(attributes.participant_id)
+    const corporationId = toCorporationId(attributes.corporation_id)
+
+    const collected = new Set<string>()
+    let did: string | undefined
+    if (rawParticipantId) {
+      const participant = await loadParticipantRelation(rawParticipantId)
+      if (participant.participantDid) collected.add(participant.participantDid)
+      if (participant.ecosystemDid) collected.add(participant.ecosystemDid)
+      did = participant.participantDid
+    }
+    if (!did && corporationId) {
+      const corporation = await loadCorporationById(corporationId)
+      if (corporation.did) collected.add(corporation.did)
+      did = corporation.did
+    }
+    if (vsOperator) {
+      const participant = await loadParticipantByAccount(vsOperator)
+      if (participant.did) collected.add(participant.did)
+      did = did ?? participant.did
+    }
+    if (!did) continue
+
+    events.push({
+      type: 'transaction-executed',
+      module: 'delegation',
+      action: meta.action,
+      messageType: `/verana.de.v1.${meta.action}`,
+      blockHeight: Number(row.block_height),
+      txHash: row.tx_hash,
+      txIndex: Number(row.tx_index),
+      messageIndex: Number(row.tx_msg_index ?? 0),
+      sender: vsOperator ?? '',
+      did,
+      relatedDids: uniqueNormalizedDids(collected),
+      entityType: meta.entityType,
+      entityId: rawParticipantId ? String(rawParticipantId) : vsOperator,
+      participantId: rawParticipantId ? String(rawParticipantId) : undefined,
+      corporationId,
+      relatedCorporationIds: [],
+      vsOperator,
+      timestamp: toIsoSeconds(row.timestamp),
+    })
+  }
+  return events
+}
+
 export async function persistIndexerEventsForBlock(blockHeight: number): Promise<IndexerEventRecord[]> {
   const rows: Array<Record<string, unknown>> = []
   const pageSize = 500
@@ -614,6 +810,8 @@ export async function persistIndexerEventsForBlock(blockHeight: number): Promise
     if (txEvents.length < pageSize) break
     offset += pageSize
   }
+  const vsoaEvents = await buildVsoaEvents(blockHeight)
+  rows.push(...vsoaEvents.map(toEventRow))
   let insertedIds: number[] = []
 
   if (rows.length > 0) {

--- a/src/services/api/indexer_events_query.ts
+++ b/src/services/api/indexer_events_query.ts
@@ -241,6 +241,11 @@ const ID_ALIASES = {
 } as const
 
 async function getEntityId(row: EventRow, meta: EventMeta): Promise<string | undefined> {
+  if (meta.module === 'delegation') {
+    const content = row.content && typeof row.content === 'object' ? (row.content as Record<string, unknown>) : {}
+    return readAddress(content.grantee) ?? readAddress(content.operator)
+  }
+
   if (meta.module === 'participant') {
     const participantId = readNumber(row.content, ['id', ...ID_ALIASES.participant])
     return participantId ? String(participantId) : resolveEntityIdFromDomain(row, meta)

--- a/src/services/api/indexer_events_query.ts
+++ b/src/services/api/indexer_events_query.ts
@@ -341,12 +341,16 @@ async function loadParticipantsByAccount(account: string | null | undefined): Pr
     .select('id', 'did', 'corporation_id')
     .where({ vs_operator: account })
     .orderBy('id', 'asc')
-  return {
-    dids: uniqueNormalizedDids(rows.map((row) => row.did)),
-    corporationIds: rows
-      .map((row) => toCorporationId(row.corporation_id))
-      .filter((corporationId): corporationId is number => corporationId !== undefined),
+
+  const dids: string[] = []
+  const corporationIds: number[] = []
+  for (const row of rows) {
+    const did = normalizeDid(row.did)
+    if (did && !dids.includes(did)) dids.push(did)
+    const corporationId = toCorporationId(row.corporation_id)
+    if (corporationId !== undefined && !corporationIds.includes(corporationId)) corporationIds.push(corporationId)
   }
+  return { dids, corporationIds }
 }
 
 function readAddress(value: unknown): string | undefined {

--- a/src/services/api/indexer_events_query.ts
+++ b/src/services/api/indexer_events_query.ts
@@ -11,6 +11,7 @@ import {
   VeranaParticipantMessageTypes,
 } from '../../common/verana-message-types'
 import { applyBlockHeightFilter, toIsoSeconds } from './api_shared'
+import { fetchCorporationByAddress, fetchCorporationById, fetchParticipantDid } from './indexer_event_chain_lookup'
 import {
   collectDidsDeep,
   firstNormalizedDid,
@@ -32,7 +33,7 @@ export type IndexerTxEvent = {
   txIndex: number
   messageIndex: number
   sender: string
-  did: string
+  did: string | null
   relatedDids: string[]
   entityType?: string
   entityId?: string
@@ -51,7 +52,7 @@ export type IndexerTxEvent = {
 export type IndexerEventRecord = {
   type: 'indexer-event'
   event_type: string
-  did: string
+  did: string | null
   block_height: number
   tx_hash: string
   timestamp: string
@@ -522,7 +523,8 @@ async function toIndexerEvent(row: EventRow): Promise<IndexerTxEvent | null> {
     else if (typeof content.withFeegrant === 'boolean') withFeegrant = content.withFeegrant
     const corporationAddress = readAddress(content.corporation)
     if (corporationAddress) {
-      const corp = await loadCorporation({ address: corporationAddress })
+      let corp = await loadCorporation({ address: corporationAddress })
+      if (!corp.did) corp = await fetchCorporationByAddress(corporationAddress, Number(row.block_height))
       if (corp.corporationId !== undefined) corporationId = corp.corporationId
       if (corp.did) collected.add(corp.did)
     }
@@ -541,7 +543,12 @@ async function toIndexerEvent(row: EventRow): Promise<IndexerTxEvent | null> {
     explicitPrimaryDid ??
     (meta.module === 'participant' ? firstNormalizedDid(relatedDids) : undefined) ??
     firstNormalizedDid(relatedDids)
-  if (!primaryDid) return null
+  if (!primaryDid) {
+    if (meta.module !== 'delegation') return null
+    console.warn(
+      `[IndexerEvents] ${meta.action} at block_height=${row.block_height} tx_hash=${row.tx_hash} has no resolvable DID; emitting with did=null`
+    )
+  }
 
   return {
     type: 'transaction-executed',
@@ -553,7 +560,7 @@ async function toIndexerEvent(row: EventRow): Promise<IndexerTxEvent | null> {
     txIndex: Number(row.tx_index),
     messageIndex: Number(row.message_index),
     sender: row.sender,
-    did: primaryDid,
+    did: primaryDid ?? null,
     relatedDids,
     entityType: meta.entityType,
     entityId,
@@ -610,7 +617,7 @@ function fromStoredRow(row: Record<string, any>): IndexerEventRecord {
   return {
     type: 'indexer-event',
     event_type: String(row.event_type),
-    did: String(row.did),
+    did: row.did != null ? String(row.did) : null,
     block_height: Number(row.block_height),
     tx_hash: String(row.tx_hash),
     timestamp: toIsoSeconds(row.timestamp),
@@ -626,7 +633,9 @@ function fromStoredRow(row: Record<string, any>): IndexerEventRecord {
         ? row.payload.related_dids
         : Array.isArray(row.payload?.relatedDids)
           ? row.payload.relatedDids
-          : [String(row.did)],
+          : row.did != null
+            ? [String(row.did)]
+            : [],
       entity_type: row.payload?.entity_type ?? row.payload?.entityType ?? row.entity_type ?? undefined,
       entity_id: row.payload?.entity_id ?? row.payload?.entityId ?? row.entity_id ?? undefined,
       ecosystem_id: row.payload?.ecosystem_id ?? row.payload?.ecosystemId ?? undefined,
@@ -779,7 +788,21 @@ async function buildVsoaEvents(blockHeight: number): Promise<IndexerTxEvent[]> {
       if (participant.did) collected.add(participant.did)
       did = did ?? participant.did
     }
-    if (!did) continue
+    if (!did && rawParticipantId) {
+      const participantDid = await fetchParticipantDid(rawParticipantId, blockHeight)
+      if (participantDid) collected.add(participantDid)
+      did = did ?? participantDid
+    }
+    if (!did && corporationId) {
+      const corporation = await fetchCorporationById(corporationId, blockHeight)
+      if (corporation.did) collected.add(corporation.did)
+      did = did ?? corporation.did
+    }
+    if (!did) {
+      console.warn(
+        `[IndexerEvents] ${meta.action} at block_height=${blockHeight} tx_hash=${row.tx_hash} has no resolvable DID; emitting with did=null`
+      )
+    }
 
     events.push({
       type: 'transaction-executed',
@@ -791,7 +814,7 @@ async function buildVsoaEvents(blockHeight: number): Promise<IndexerTxEvent[]> {
       txIndex: Number(row.tx_index),
       messageIndex: Number(row.tx_msg_index ?? 0),
       sender: vsOperator ?? '',
-      did,
+      did: did ?? null,
       relatedDids: uniqueNormalizedDids(collected),
       entityType: meta.entityType,
       entityId: rawParticipantId ? String(rawParticipantId) : vsOperator,
@@ -914,5 +937,23 @@ export async function listIndexerEvents(args: {
   applyBlockHeightFilter(query, args, 'ie.block_height')
 
   const rows = (await query) as Array<Record<string, any>>
+  await resolveMissingDids(rows)
   return rows.map(fromStoredRow)
+}
+
+async function resolveMissingDids(rows: Array<Record<string, any>>): Promise<void> {
+  for (const row of rows) {
+    if (row.did != null) continue
+
+    const participantId = readPositiveInteger(row.payload?.participant_id ?? row.payload?.participantId)
+    const corporationId = toCorporationId(row.payload?.corporation_id ?? row.payload?.corporationId)
+
+    let did: string | undefined
+    if (participantId) did = (await loadParticipantRelation(participantId)).participantDid
+    if (!did && corporationId) did = (await loadCorporationById(corporationId)).did
+    if (!did) continue
+
+    row.did = did
+    await knex('indexer_events').where({ id: row.id }).update({ did })
+  }
 }

--- a/src/services/crawl-proposal/crawl_proposal.service.ts
+++ b/src/services/crawl-proposal/crawl_proposal.service.ts
@@ -137,7 +137,10 @@ export default class CrawlProposalService extends BullableService {
       .andWhere('key', EventAttribute.ATTRIBUTE_KEY.PROPOSAL_ID)
       .select('value')
 
-    if (resultTx.length > 0) proposalIds = Array.from(new Set(resultTx.map((res: any) => parseInt(res.value, 10))))
+    if (resultTx.length > 0)
+      proposalIds = Array.from(
+        new Set(resultTx.map((res: any) => parseInt(res.value, 10)).filter((id: number) => Number.isInteger(id)))
+      )
 
     await knex
       .transaction(async (trx) => {

--- a/src/services/crawl-tx/crawl_tx.service.ts
+++ b/src/services/crawl-tx/crawl_tx.service.ts
@@ -1355,23 +1355,34 @@ export default class CrawlTxService extends BullableService {
   }
 
   public createListEventWithMsgIndex(tx: any): any[] {
-    const returnEvents: any[] = []
-    // if this is failed tx, then no need to set index msg
-    if (!tx.tx_response.logs) {
-      this.logger.warn('Failed tx, no need to set index msg')
-      return []
+    const events: any[] = tx?.tx_response?.events ?? []
+
+    // Since Cosmos SDK v0.50 `tx_response.logs` is empty and the message index is
+    // carried as a `msg_index` attribute on every event emitted while that message ran.
+    const eventsWithMsgIndexAttribute = events.map((event: any) => {
+      const msgIndex = this.readMsgIndexAttribute(event)
+      return msgIndex === undefined ? event : { ...event, msg_index: msgIndex }
+    })
+    if (eventsWithMsgIndexAttribute.some((event: any) => event.msg_index !== undefined)) {
+      return eventsWithMsgIndexAttribute
     }
+
+    if (!tx.tx_response.logs?.length) {
+      return eventsWithMsgIndexAttribute
+    }
+
+    const returnEvents: any[] = []
     let reachLastEventTypeTx = false
     // last event type in event field which belongs to tx event
     const listTxEventType = config.handleTransaction.lastEventsTypeTx
-    for (let i = 0; i < tx?.tx_response?.events?.length; i += 1) {
-      if (listTxEventType.includes(tx.tx_response.events[i].type)) {
+    for (let i = 0; i < events.length; i += 1) {
+      if (listTxEventType.includes(events[i].type)) {
         reachLastEventTypeTx = true
       }
-      if (reachLastEventTypeTx && !listTxEventType.includes(tx.tx_response.events[i].type)) {
+      if (reachLastEventTypeTx && !listTxEventType.includes(events[i].type)) {
         break
       }
-      returnEvents.push(tx.tx_response.events[i])
+      returnEvents.push(events[i])
     }
     // get messages log and append to list event
     tx.tx_response.logs.forEach((log: any, index: number) => {
@@ -1389,6 +1400,16 @@ export default class CrawlTxService extends BullableService {
     this.checkMappingEventToLog(cloneTx)
 
     return returnEvents
+  }
+
+  private readMsgIndexAttribute(event: any): number | undefined {
+    const decode = this._registry.decodeAttribute ?? ((input: string) => input)
+    for (const attribute of event?.attributes ?? []) {
+      if (!attribute?.key || decode(attribute.key) !== 'msg_index') continue
+      const msgIndex = Number(decode(attribute.value ?? ''))
+      return Number.isInteger(msgIndex) && msgIndex >= 0 ? msgIndex : undefined
+    }
+    return undefined
   }
 
   private _findAttribute(events: any, eventType: string, attributeKey: string): string {

--- a/src/services/crawl-tx/crawl_tx.service.ts
+++ b/src/services/crawl-tx/crawl_tx.service.ts
@@ -1357,8 +1357,6 @@ export default class CrawlTxService extends BullableService {
   public createListEventWithMsgIndex(tx: any): any[] {
     const events: any[] = tx?.tx_response?.events ?? []
 
-    // Since Cosmos SDK v0.50 `tx_response.logs` is empty and the message index is
-    // carried as a `msg_index` attribute on every event emitted while that message ran.
     const eventsWithMsgIndexAttribute = events.map((event: any) => {
       const msgIndex = this.readMsgIndexAttribute(event)
       return msgIndex === undefined ? event : { ...event, msg_index: msgIndex }

--- a/test/unit/services/api/indexer_events_query.spec.ts
+++ b/test/unit/services/api/indexer_events_query.spec.ts
@@ -1,5 +1,8 @@
 import knex from '../../../../src/common/utils/db_connection'
-import { VeranaDelegationMessageTypes, VeranaParticipantMessageTypes } from '../../../../src/common/verana-message-types'
+import {
+  VeranaDelegationMessageTypes,
+  VeranaParticipantMessageTypes,
+} from '../../../../src/common/verana-message-types'
 import { up as createIndexerEventsTable } from '../../../../src/migrations/20260420000000_create_indexer_events'
 import { up as hardenIndexerEventsTable } from '../../../../src/migrations/20260421000000_harden_indexer_events_replay'
 import { listIndexerEvents, persistIndexerEventsForBlock } from '../../../../src/services/api/indexer_events_query'
@@ -90,6 +93,7 @@ describe('indexer_events_query', () => {
       await knex.schema.createTable('participants', (table) => {
         table.bigInteger('id').primary()
         table.bigInteger('schema_id').nullable()
+        table.text('role').nullable()
         table.text('did').nullable()
         table.bigInteger('corporation_id').nullable()
         table.text('vs_operator').nullable()
@@ -104,6 +108,9 @@ describe('indexer_events_query', () => {
         table.text('did').nullable()
         table.text('corporation').nullable()
         table.text('policy_address').nullable()
+        table.timestamp('created').nullable()
+        table.timestamp('modified').nullable()
+        table.bigInteger('height').nullable()
       })
       createdTables.push('corporation')
     }
@@ -584,6 +591,9 @@ describe('indexer_events_query', () => {
       did: args.did,
       corporation: args.corporation ?? null,
       policy_address: args.policyAddress ?? null,
+      created: new Date('2025-01-15T10:30:00Z'),
+      modified: new Date('2025-01-15T10:30:00Z'),
+      height: args.id,
     })
   }
 
@@ -596,9 +606,10 @@ describe('indexer_events_query', () => {
     participantIds.push(args.id)
     await knex('participants').insert({
       id: args.id,
-      schema_id: null,
+      schema_id: 0,
+      role: 'ISSUER',
       did: args.did ?? null,
-      corporation_id: args.corporationId ?? null,
+      corporation_id: args.corporationId ?? 0,
       vs_operator: args.vsOperator ?? null,
       validator_participant_id: null,
     })

--- a/test/unit/services/api/indexer_events_query.spec.ts
+++ b/test/unit/services/api/indexer_events_query.spec.ts
@@ -1,6 +1,5 @@
 import knex from '../../../../src/common/utils/db_connection'
 import {
-  VeranaDelegationMessageTypes,
   VeranaParticipantMessageTypes,
 } from '../../../../src/common/verana-message-types'
 import { up as createIndexerEventsTable } from '../../../../src/migrations/20260420000000_create_indexer_events'
@@ -615,43 +614,6 @@ describe('indexer_events_query', () => {
     })
   }
 
-  async function insertDelegationMessage(args: {
-    height: number
-    txIndex: number
-    messageIndex: number
-    hash: string
-    type: string
-    content: Record<string, unknown>
-  }): Promise<void> {
-    txHashes.push(args.hash)
-    const txId = nextId++
-    const messageId = nextId++
-    const [tx] = await knex('transaction')
-      .insert({
-        id: txId,
-        height: args.height,
-        hash: args.hash,
-        codespace: '',
-        code: 0,
-        gas_used: 1,
-        gas_wanted: 1,
-        gas_limit: 1,
-        fee: {},
-        timestamp: new Date('2025-01-15T10:30:00Z'),
-        data: {},
-        index: args.txIndex,
-      })
-      .returning('id')
-    await knex('transaction_message').insert({
-      id: messageId,
-      tx_id: typeof tx === 'object' ? tx.id : tx,
-      index: args.messageIndex,
-      type: args.type,
-      sender: (args.content.corporation as string) ?? '',
-      content: args.content,
-    })
-  }
-
   async function insertKeeperEvent(args: {
     height: number
     txIndex: number
@@ -659,6 +621,7 @@ describe('indexer_events_query', () => {
     hash: string
     type: string
     attributes: Record<string, string>
+    sender?: string
   }): Promise<void> {
     txHashes.push(args.hash)
     const txId = nextId++
@@ -679,6 +642,16 @@ describe('indexer_events_query', () => {
         index: args.txIndex,
       })
       .returning('id')
+    if (args.sender) {
+      await knex('transaction_message').insert({
+        id: nextId++,
+        tx_id: typeof tx === 'object' ? tx.id : tx,
+        index: args.txMsgIndex,
+        type: '/cosmos.group.v1.MsgExec',
+        sender: args.sender,
+        content: {},
+      })
+    }
     await knex('event').insert({
       id: eventId,
       tx_id: typeof tx === 'object' ? tx.id : tx,
@@ -711,18 +684,18 @@ describe('indexer_events_query', () => {
       corporationId: corpId,
       vsOperator: 'verana1grantee',
     })
-    await insertDelegationMessage({
+    await insertKeeperEvent({
       height,
       txIndex: 0,
-      messageIndex: 0,
+      txMsgIndex: 0,
       hash: `tx-${runId}-oa`,
-      type: VeranaDelegationMessageTypes.GrantOperatorAuthorization,
-      content: {
-        corporation: 'verana1corp',
-        operator: '',
+      type: 'grant_operator_authorization',
+      sender: 'verana1signer',
+      attributes: {
+        authz_id: '7',
+        corporation_id: String(corpId),
         grantee: 'verana1grantee',
-        msgTypes: ['/verana.pp.v1.MsgStartParticipantOP'],
-        withFeegrant: true,
+        with_feegrant: 'true',
       },
     })
 
@@ -730,11 +703,13 @@ describe('indexer_events_query', () => {
 
     expect(record.event_type).toBe('GrantOperatorAuthorization')
     expect(record.payload.module).toBe('de')
+    expect(record.payload.message_type).toBe('grant_operator_authorization')
     expect(record.payload.corporation_id).toBe(corpId)
     expect(record.payload.grantee).toBe('verana1grantee')
     expect(record.payload.with_feegrant).toBe(true)
+    expect(record.payload.sender).toBe('verana1signer')
     expect(record.payload.entity_type).toBe('OperatorAuthorization')
-    expect(record.payload.entity_id).toBe('verana1grantee')
+    expect(record.payload.entity_id).toBe('7')
     expect(record.did).toBe(corpDid)
     expect(record.payload.related_dids).toEqual(expect.arrayContaining([corpDid, granteeParticipantDid]))
   })
@@ -745,6 +720,7 @@ describe('indexer_events_query', () => {
     const participantId = nextId++
     const participantDid = `did:web:vsoa-${runId}.example`
     await insertBlock(height)
+    await insertCorporation({ id: corpId, did: `did:web:vsoa-corp-${runId}.example`, policyAddress: 'verana1vsoacorp' })
     await insertParticipant({ id: participantId, did: participantDid, corporationId: corpId })
     await insertKeeperEvent({
       height,
@@ -752,7 +728,9 @@ describe('indexer_events_query', () => {
       txMsgIndex: 0,
       hash: `tx-${runId}-vsoa`,
       type: 'grant_vs_operator_authorization',
+      sender: 'verana1signer',
       attributes: {
+        vsoa_id: '3',
         vs_operator: 'verana1vsoperator',
         participant_id: String(participantId),
         corporation_id: String(corpId),
@@ -763,10 +741,14 @@ describe('indexer_events_query', () => {
 
     expect(record.event_type).toBe('GrantVSOperatorAuthorization')
     expect(record.payload.module).toBe('de')
+    expect(record.payload.message_type).toBe('grant_vs_operator_authorization')
     expect(record.did).toBe(participantDid)
     expect(record.payload.participant_id).toBe(String(participantId))
     expect(record.payload.corporation_id).toBe(corpId)
     expect(record.payload.vs_operator).toBe('verana1vsoperator')
+    expect(record.payload.entity_type).toBe('VSOperatorAuthorization')
+    expect(record.payload.entity_id).toBe('3')
+    expect(record.payload.sender).toBe('verana1signer')
 
     const byCorp = await listIndexerEvents({ corporationId: corpId, afterBlockHeight: height - 1, limit: 10 })
     expect(byCorp.map((event) => event.event_type)).toContain('GrantVSOperatorAuthorization')

--- a/test/unit/services/api/indexer_events_query.spec.ts
+++ b/test/unit/services/api/indexer_events_query.spec.ts
@@ -1,7 +1,5 @@
 import knex from '../../../../src/common/utils/db_connection'
-import {
-  VeranaParticipantMessageTypes,
-} from '../../../../src/common/verana-message-types'
+import { VeranaParticipantMessageTypes } from '../../../../src/common/verana-message-types'
 import { up as createIndexerEventsTable } from '../../../../src/migrations/20260420000000_create_indexer_events'
 import { up as hardenIndexerEventsTable } from '../../../../src/migrations/20260421000000_harden_indexer_events_replay'
 import { listIndexerEvents, persistIndexerEventsForBlock } from '../../../../src/services/api/indexer_events_query'

--- a/test/unit/services/api/indexer_events_query.spec.ts
+++ b/test/unit/services/api/indexer_events_query.spec.ts
@@ -1,5 +1,5 @@
 import knex from '../../../../src/common/utils/db_connection'
-import { VeranaParticipantMessageTypes } from '../../../../src/common/verana-message-types'
+import { VeranaDelegationMessageTypes, VeranaParticipantMessageTypes } from '../../../../src/common/verana-message-types'
 import { up as createIndexerEventsTable } from '../../../../src/migrations/20260420000000_create_indexer_events'
 import { up as hardenIndexerEventsTable } from '../../../../src/migrations/20260421000000_harden_indexer_events_replay'
 import { listIndexerEvents, persistIndexerEventsForBlock } from '../../../../src/services/api/indexer_events_query'
@@ -12,6 +12,8 @@ describe('indexer_events_query', () => {
   const otherDid = `did:web:indexer-events-other-${runId}.example`
   const txHashes: string[] = []
   const heights: number[] = []
+  const corporationIds: number[] = []
+  const participantIds: number[] = []
   const createdTables: string[] = []
 
   beforeAll(async () => {
@@ -89,9 +91,45 @@ describe('indexer_events_query', () => {
         table.bigInteger('id').primary()
         table.bigInteger('schema_id').nullable()
         table.text('did').nullable()
+        table.bigInteger('corporation_id').nullable()
+        table.text('vs_operator').nullable()
         table.bigInteger('validator_participant_id').nullable()
       })
       createdTables.push('participants')
+    }
+
+    if (!(await knex.schema.hasTable('corporation'))) {
+      await knex.schema.createTable('corporation', (table) => {
+        table.bigInteger('id').primary()
+        table.text('did').nullable()
+        table.text('corporation').nullable()
+        table.text('policy_address').nullable()
+      })
+      createdTables.push('corporation')
+    }
+
+    if (!(await knex.schema.hasTable('event'))) {
+      await knex.schema.createTable('event', (table) => {
+        table.bigInteger('id').primary()
+        table.bigInteger('tx_id').notNullable()
+        table.integer('tx_msg_index').nullable()
+        table.text('type').notNullable()
+        table.bigInteger('block_height').notNullable()
+        table.text('source').nullable()
+      })
+      createdTables.push('event')
+    }
+
+    if (!(await knex.schema.hasTable('event_attribute'))) {
+      await knex.schema.createTable('event_attribute', (table) => {
+        table.bigInteger('event_id').notNullable()
+        table.integer('index').notNullable().defaultTo(0)
+        table.bigInteger('block_height').notNullable()
+        table.text('composite_key').nullable()
+        table.text('key').nullable()
+        table.text('value').nullable()
+      })
+      createdTables.push('event_attribute')
     }
   }
 
@@ -184,12 +222,25 @@ describe('indexer_events_query', () => {
   }
 
   afterEach(async () => {
+    if (heights.length > 0) {
+      await knex('event_attribute').whereIn('block_height', heights).delete()
+      await knex('event').whereIn('block_height', heights).delete()
+    }
     if (txHashes.length > 0) {
       await knex('indexer_events').whereIn('tx_hash', txHashes).delete()
       const txIds = await knex('transaction').whereIn('hash', txHashes).pluck('id')
       if (txIds.length > 0) await knex('transaction_message').whereIn('tx_id', txIds).delete()
       await knex('transaction').whereIn('hash', txHashes).delete()
       txHashes.length = 0
+    }
+
+    if (corporationIds.length > 0) {
+      await knex('corporation').whereIn('id', corporationIds).delete()
+      corporationIds.length = 0
+    }
+    if (participantIds.length > 0) {
+      await knex('participants').whereIn('id', participantIds).delete()
+      participantIds.length = 0
     }
 
     if (heights.length > 0) {
@@ -519,6 +570,193 @@ describe('indexer_events_query', () => {
     const events = await listIndexerEvents({ afterBlockHeight: height - 1, limit: 10 })
 
     expect(events.map((event) => event.tx_hash)).toEqual([`tx-${runId}-wild-1`, `tx-${runId}-wild-2`])
+  })
+
+  async function insertCorporation(args: {
+    id: number
+    did: string
+    corporation?: string
+    policyAddress?: string
+  }): Promise<void> {
+    corporationIds.push(args.id)
+    await knex('corporation').insert({
+      id: args.id,
+      did: args.did,
+      corporation: args.corporation ?? null,
+      policy_address: args.policyAddress ?? null,
+    })
+  }
+
+  async function insertParticipant(args: {
+    id: number
+    did?: string
+    corporationId?: number
+    vsOperator?: string
+  }): Promise<void> {
+    participantIds.push(args.id)
+    await knex('participants').insert({
+      id: args.id,
+      schema_id: null,
+      did: args.did ?? null,
+      corporation_id: args.corporationId ?? null,
+      vs_operator: args.vsOperator ?? null,
+      validator_participant_id: null,
+    })
+  }
+
+  async function insertDelegationMessage(args: {
+    height: number
+    txIndex: number
+    messageIndex: number
+    hash: string
+    type: string
+    content: Record<string, unknown>
+  }): Promise<void> {
+    txHashes.push(args.hash)
+    const txId = nextId++
+    const messageId = nextId++
+    const [tx] = await knex('transaction')
+      .insert({
+        id: txId,
+        height: args.height,
+        hash: args.hash,
+        codespace: '',
+        code: 0,
+        gas_used: 1,
+        gas_wanted: 1,
+        gas_limit: 1,
+        fee: {},
+        timestamp: new Date('2025-01-15T10:30:00Z'),
+        data: {},
+        index: args.txIndex,
+      })
+      .returning('id')
+    await knex('transaction_message').insert({
+      id: messageId,
+      tx_id: typeof tx === 'object' ? tx.id : tx,
+      index: args.messageIndex,
+      type: args.type,
+      sender: (args.content.corporation as string) ?? '',
+      content: args.content,
+    })
+  }
+
+  async function insertKeeperEvent(args: {
+    height: number
+    txIndex: number
+    txMsgIndex: number
+    hash: string
+    type: string
+    attributes: Record<string, string>
+  }): Promise<void> {
+    txHashes.push(args.hash)
+    const txId = nextId++
+    const eventId = nextId++
+    const [tx] = await knex('transaction')
+      .insert({
+        id: txId,
+        height: args.height,
+        hash: args.hash,
+        codespace: '',
+        code: 0,
+        gas_used: 1,
+        gas_wanted: 1,
+        gas_limit: 1,
+        fee: {},
+        timestamp: new Date('2025-01-15T10:30:00Z'),
+        data: {},
+        index: args.txIndex,
+      })
+      .returning('id')
+    await knex('event').insert({
+      id: eventId,
+      tx_id: typeof tx === 'object' ? tx.id : tx,
+      tx_msg_index: args.txMsgIndex,
+      type: args.type,
+      block_height: args.height,
+      source: 'TX_EVENT',
+    })
+    const attributeRows = Object.entries(args.attributes).map(([key, value], index) => ({
+      event_id: eventId,
+      index,
+      block_height: args.height,
+      composite_key: `${args.type}.${key}`,
+      key,
+      value,
+    }))
+    if (attributeRows.length > 0) await knex('event_attribute').insert(attributeRows)
+  }
+
+  it('enriches GrantOperatorAuthorization with corporation and grantee (gap 2)', async () => {
+    const height = baseHeight + 200
+    const corpId = 51_000 + Math.floor(Math.random() * 1000)
+    const corpDid = `did:web:corp-${runId}.example`
+    const granteeParticipantDid = `did:web:grantee-${runId}.example`
+    await insertBlock(height)
+    await insertCorporation({ id: corpId, did: corpDid, policyAddress: 'verana1corp' })
+    await insertParticipant({
+      id: nextId++,
+      did: granteeParticipantDid,
+      corporationId: corpId,
+      vsOperator: 'verana1grantee',
+    })
+    await insertDelegationMessage({
+      height,
+      txIndex: 0,
+      messageIndex: 0,
+      hash: `tx-${runId}-oa`,
+      type: VeranaDelegationMessageTypes.GrantOperatorAuthorization,
+      content: {
+        corporation: 'verana1corp',
+        operator: '',
+        grantee: 'verana1grantee',
+        msgTypes: ['/verana.pp.v1.MsgStartParticipantOP'],
+        withFeegrant: true,
+      },
+    })
+
+    const [record] = await persistIndexerEventsForBlock(height)
+
+    expect(record.event_type).toBe('GrantOperatorAuthorization')
+    expect(record.payload.module).toBe('de')
+    expect(record.payload.corporation_id).toBe(corpId)
+    expect(record.payload.grantee).toBe('verana1grantee')
+    expect(record.payload.with_feegrant).toBe(true)
+    expect(record.did).toBe(corpDid)
+    expect(record.payload.related_dids).toEqual(expect.arrayContaining([corpDid, granteeParticipantDid]))
+  })
+
+  it('forwards VSOA keeper events with vs_operator/participant/corporation (gap 1)', async () => {
+    const height = baseHeight + 220
+    const corpId = 53_000 + Math.floor(Math.random() * 1000)
+    const participantId = nextId++
+    const participantDid = `did:web:vsoa-${runId}.example`
+    await insertBlock(height)
+    await insertParticipant({ id: participantId, did: participantDid, corporationId: corpId })
+    await insertKeeperEvent({
+      height,
+      txIndex: 0,
+      txMsgIndex: 0,
+      hash: `tx-${runId}-vsoa`,
+      type: 'grant_vs_operator_authorization',
+      attributes: {
+        vs_operator: 'verana1vsoperator',
+        participant_id: String(participantId),
+        corporation_id: String(corpId),
+      },
+    })
+
+    const [record] = await persistIndexerEventsForBlock(height)
+
+    expect(record.event_type).toBe('GrantVSOperatorAuthorization')
+    expect(record.payload.module).toBe('de')
+    expect(record.did).toBe(participantDid)
+    expect(record.payload.participant_id).toBe(String(participantId))
+    expect(record.payload.corporation_id).toBe(corpId)
+    expect(record.payload.vs_operator).toBe('verana1vsoperator')
+
+    const byCorp = await listIndexerEvents({ corporationId: corpId, afterBlockHeight: height - 1, limit: 10 })
+    expect(byCorp.map((event) => event.event_type)).toContain('GrantVSOperatorAuthorization')
   })
 
   it('persists v4 payload values while keeping event_type as the Cosmos action name', async () => {

--- a/test/unit/services/api/indexer_events_query.spec.ts
+++ b/test/unit/services/api/indexer_events_query.spec.ts
@@ -733,6 +733,8 @@ describe('indexer_events_query', () => {
     expect(record.payload.corporation_id).toBe(corpId)
     expect(record.payload.grantee).toBe('verana1grantee')
     expect(record.payload.with_feegrant).toBe(true)
+    expect(record.payload.entity_type).toBe('OperatorAuthorization')
+    expect(record.payload.entity_id).toBe('verana1grantee')
     expect(record.did).toBe(corpDid)
     expect(record.payload.related_dids).toEqual(expect.arrayContaining([corpDid, granteeParticipantDid]))
   })


### PR DESCRIPTION
**Changes**
- Forward `de` keeper events from `event`/`event_attribute` as VSOA events with `vs_operator`/`participant_id`/`corporation_id` (gap 1).
- Add `delegation` branch in `toIndexerEvent`: resolves DID + `corporation_id` and surfaces `grantee`/`operator`/`with_feegrant`, so OA events stop being dropped (gap 2).
