### PR TITLE
fix: ecs ecosystem allowlist per wl ecs

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -151,6 +151,7 @@
     "disableDigestSriVerification": false,
     "txPrefilterEnabled": true,
     "verifiablePublicRegistries": [],
+    "ecsEcosystems": [],
     "trustEvaluationTtlSeconds": 3600,
     "pollObjectCachingRetryDays": 7
   },

--- a/src/config.json
+++ b/src/config.json
@@ -150,7 +150,6 @@
     "useEmbeddedRegistryAdapter": true,
     "disableDigestSriVerification": false,
     "txPrefilterEnabled": true,
-    "verifiablePublicRegistries": [],
     "ecsEcosystems": [],
     "trustEvaluationTtlSeconds": 3600,
     "pollObjectCachingRetryDays": 7

--- a/src/services/resolver/ecs-allowlist.ts
+++ b/src/services/resolver/ecs-allowlist.ts
@@ -1,27 +1,19 @@
 import knex from '../../common/utils/db_connection'
 import config from '../../config.json' with { type: 'json' }
 
-export type EcsEcosystem = {
-  did: string
-  vpr: string
-}
-
 const ALLOWED_ECOSYSTEM_IDS_TTL_MS = 30_000
 
 let cachedAllowedEcosystemIds: { ids: Set<number>; expiresAt: number } | null = null
 
-function ecsEcosystemsFromEnv(): EcsEcosystem[] {
-  const chainId = (process.env.CHAIN_ID ?? '').trim()
-  const dids = (process.env.ECS_ECOSYSTEM_DIDS ?? '')
+function ecsEcosystemsFromEnv(): string[] {
+  return (process.env.ECS_ECOSYSTEM_DIDS ?? '')
     .split(',')
     .map((did) => did.trim())
     .filter(Boolean)
-  if (!chainId || dids.length === 0) return []
-  return dids.map((did) => ({ did, vpr: `vpr:verana:${chainId}` }))
 }
 
-export function getEcsEcosystems(): EcsEcosystem[] {
-  const c = config as unknown as { resolver?: { ecsEcosystems?: EcsEcosystem[] } }
+export function getEcsEcosystems(): string[] {
+  const c = config as unknown as { resolver?: { ecsEcosystems?: string[] } }
   const declared = c.resolver?.ecsEcosystems
   return declared && declared.length > 0 ? declared : ecsEcosystemsFromEnv()
 }
@@ -34,7 +26,7 @@ export async function getAllowedEcsEcosystemIds(): Promise<Set<number>> {
   const now = Date.now()
   if (cachedAllowedEcosystemIds && cachedAllowedEcosystemIds.expiresAt > now) return cachedAllowedEcosystemIds.ids
 
-  const dids = getEcsEcosystems().map((ecosystem) => ecosystem.did)
+  const dids = getEcsEcosystems()
   const ids = new Set<number>()
   if (dids.length > 0) {
     const rows = (await knex('ecosystem').whereIn('did', dids).select('id')) as Array<{ id: number }>

--- a/src/services/resolver/ecs-allowlist.ts
+++ b/src/services/resolver/ecs-allowlist.ts
@@ -1,0 +1,55 @@
+import knex from '../../common/utils/db_connection'
+import config from '../../config.json' with { type: 'json' }
+
+export type EcsEcosystem = {
+  did: string
+  vpr: string
+}
+
+const ALLOWED_ECOSYSTEM_IDS_TTL_MS = 30_000
+
+let cachedAllowedEcosystemIds: { ids: Set<number>; expiresAt: number } | null = null
+
+function ecsEcosystemsFromEnv(): EcsEcosystem[] {
+  const chainId = (process.env.CHAIN_ID ?? '').trim()
+  const dids = (process.env.ECS_ECOSYSTEM_DIDS ?? '')
+    .split(',')
+    .map((did) => did.trim())
+    .filter(Boolean)
+  if (!chainId || dids.length === 0) return []
+  return dids.map((did) => ({ did, vpr: `vpr:verana:${chainId}` }))
+}
+
+export function getEcsEcosystems(): EcsEcosystem[] {
+  const c = config as unknown as { resolver?: { ecsEcosystems?: EcsEcosystem[] } }
+  const declared = c.resolver?.ecsEcosystems
+  return declared && declared.length > 0 ? declared : ecsEcosystemsFromEnv()
+}
+
+export function isEcsAllowlistEnforced(): boolean {
+  return getEcsEcosystems().length > 0
+}
+
+export async function getAllowedEcsEcosystemIds(): Promise<Set<number>> {
+  const now = Date.now()
+  if (cachedAllowedEcosystemIds && cachedAllowedEcosystemIds.expiresAt > now) return cachedAllowedEcosystemIds.ids
+
+  const dids = getEcsEcosystems().map((ecosystem) => ecosystem.did)
+  const ids = new Set<number>()
+  if (dids.length > 0) {
+    const rows = (await knex('ecosystem').whereIn('did', dids).select('id')) as Array<{ id: number }>
+    for (const row of rows) {
+      const id = Number(row.id)
+      if (Number.isFinite(id) && id > 0) ids.add(id)
+    }
+  }
+
+  cachedAllowedEcosystemIds = { ids, expiresAt: now + ALLOWED_ECOSYSTEM_IDS_TTL_MS }
+  return ids
+}
+
+export async function isEcosystemEcsAllowlisted(ecosystemId: number): Promise<boolean> {
+  if (!isEcsAllowlistEnforced()) return true
+  if (!Number.isFinite(ecosystemId) || ecosystemId <= 0) return false
+  return (await getAllowedEcsEcosystemIds()).has(ecosystemId)
+}

--- a/src/services/resolver/trust-resolve-v4.builders.ts
+++ b/src/services/resolver/trust-resolve-v4.builders.ts
@@ -4,6 +4,7 @@ import { canonicalizeJson, toCoin } from '../../common'
 import { ALL_PARTICIPANT_ROLES, type ParticipantRole, type ParticipantState } from '../../common/types/types'
 import { toDate, toIso } from '../../common/utils/date_utils'
 import knex from '../../common/utils/db_connection'
+import { isEcosystemEcsAllowlisted, isEcsAllowlistEnforced } from './ecs-allowlist'
 
 /**
  * Derives the single `participant_state` enum from a permission row's
@@ -424,6 +425,7 @@ type EcsSchemaResolution = {
   credentialSchemaId: number
   ecosystemId: number
   isEcs: boolean
+  ecsSchemaTitle: string | null
 }
 
 const IS_PG = String((knex as { client?: { config?: { client?: string } } }).client?.config?.client || '').includes(
@@ -498,10 +500,13 @@ async function resolveSchemaByUri(uri: string): Promise<EcsSchemaResolution | nu
   if (!row) return null
 
   const title = parseSchemaJson(row.json_schema)?.title
+  const ecosystemId = Number(row.ecosystem_id) || 0
+  const ecsSchemaTitle = isEcsSchemaTitle(title) ? (title as string) : null
   return {
     credentialSchemaId: Number(row.id) || 0,
-    ecosystemId: Number(row.ecosystem_id) || 0,
-    isEcs: isEcsSchemaTitle(title),
+    ecosystemId,
+    isEcs: ecsSchemaTitle !== null && (await isEcosystemEcsAllowlisted(ecosystemId)),
+    ecsSchemaTitle,
   }
 }
 
@@ -511,6 +516,21 @@ async function resolveParticipantId(did: string, credentialSchemaId: number): Pr
     | { id?: number }
     | undefined
   return row?.id != null ? Number(row.id) || 0 : 0
+}
+
+export async function hasAllowlistedEcsServiceCredential(resolveResult: unknown): Promise<boolean> {
+  const serviceSchemaTitle = ECS_SCHEMA_TITLE_BY_TYPE['ecs-service']
+
+  for (const svc of didDocumentServices(resolveResult)) {
+    if (!isLinkedVpType(svc.type)) continue
+    const endpoint = typeof svc.serviceEndpoint === 'string' ? svc.serviceEndpoint : ''
+    for (const cred of await fetchVpCredentials(endpoint)) {
+      const schemaUri = credentialSchemaUri(cred)
+      const schema = schemaUri ? await resolveSchemaByUri(schemaUri) : null
+      if (schema?.isEcs && schema.ecsSchemaTitle === serviceSchemaTitle) return true
+    }
+  }
+  return false
 }
 
 export async function buildPresentations(
@@ -622,7 +642,11 @@ async function resolveEcsSchemaLink(subjectDid: string, ecsSchemaTitle: string):
 
   for (const p of participants) {
     const cs = schemas.find((s) => Number(s.id) === Number(p.schema_id))
-    if (cs && parseSchemaJson(cs.json_schema)?.title === ecsSchemaTitle) {
+    if (
+      cs &&
+      parseSchemaJson(cs.json_schema)?.title === ecsSchemaTitle &&
+      (await isEcosystemEcsAllowlisted(Number(cs.ecosystem_id) || 0))
+    ) {
       return {
         participantId: Number(p.id) || 0,
         credentialSchemaId: Number(cs.id) || 0,
@@ -658,6 +682,8 @@ export async function buildEcsCredentials(resolveResult: unknown): Promise<Array
     const subjectDid = typeof c.id === 'string' ? c.id : null
     const issuerDid = typeof c.issuer === 'string' ? c.issuer : null
     const link = subjectDid ? await resolveEcsSchemaLink(subjectDid, ecsSchema) : null
+    if (isEcsAllowlistEnforced() && !link) continue
+
     const credentialSchemaId = link?.credentialSchemaId ?? 0
     const issuerParticipantId = issuerDid ? await resolveIssuerParticipantId(issuerDid, credentialSchemaId) : 0
 

--- a/src/services/resolver/trust-resolve.ts
+++ b/src/services/resolver/trust-resolve.ts
@@ -30,7 +30,6 @@ export type ResolverRuntimeConfig = {
   millisecondPoll?: number
   millisecondCrawl?: number
   blocksPerCall?: number
-  verifiablePublicRegistries?: VerifiablePublicRegistry[]
   useEmbeddedRegistryAdapter?: boolean
   disableDigestSriVerification?: boolean
   trustEvaluationTtlSeconds?: number
@@ -58,7 +57,6 @@ export function getResolverRuntimeConfig(): ResolverRuntimeConfig | null {
     enabled: next?.enabled ?? legacy?.enabled,
     millisecondPoll: next?.millisecondPoll ?? next?.millisecondCrawl ?? legacy?.millisecondCrawl,
     blocksPerCall: next?.blocksPerCall ?? legacy?.blocksPerCall,
-    verifiablePublicRegistries: next?.verifiablePublicRegistries,
     useEmbeddedRegistryAdapter: next?.useEmbeddedRegistryAdapter ?? legacy?.useEmbeddedRegistryAdapter,
     disableDigestSriVerification: next?.disableDigestSriVerification,
     trustEvaluationTtlSeconds: next?.trustEvaluationTtlSeconds ?? legacy?.trustEvaluationTtlSeconds,
@@ -88,12 +86,7 @@ export function getVerreTrustEvaluationCallOptions(): {
   skipDigestSRICheck: boolean
 } {
   const cfg = getResolverRuntimeConfig()
-  const registriesRaw =
-    cfg?.verifiablePublicRegistries && cfg.verifiablePublicRegistries.length > 0
-      ? cfg.verifiablePublicRegistries
-      : defaultVprRegistriesFromEnv()
-
-  const registries = attachRegistryAdapters(registriesRaw, {
+  const registries = attachRegistryAdapters(defaultVprRegistriesFromEnv(), {
     enabled: cfg?.useEmbeddedRegistryAdapter !== false,
   })
 

--- a/src/services/resolver/trust-resolve.ts
+++ b/src/services/resolver/trust-resolve.ts
@@ -1,4 +1,9 @@
-import { resolveDID, type TrustResolution, type VerifiablePublicRegistry } from '@verana-labs/verre'
+import {
+  resolveDID,
+  type TrustResolution,
+  TrustResolutionOutcome,
+  type VerifiablePublicRegistry,
+} from '@verana-labs/verre'
 import { BULL_JOB_NAME } from '../../common'
 import {
   applySpeedToBatchSize,
@@ -8,7 +13,9 @@ import {
 import knex from '../../common/utils/db_connection'
 import { detectStartMode } from '../../common/utils/start_mode_detector'
 import config from '../../config.json' with { type: 'json' }
+import { isEcsAllowlistEnforced } from './ecs-allowlist'
 import { defaultVprRegistriesFromEnv, readBoolFromEnv } from './trust-resolve.helpers'
+import { hasAllowlistedEcsServiceCredential } from './trust-resolve-v4.builders'
 import { attachRegistryAdapters } from './verre-registry-adapter'
 
 export type ResolverTierConfig = {
@@ -460,6 +467,12 @@ export async function resolveTrustForDidAtHeight(did: string, blockHeight: numbe
       verifiablePublicRegistries,
       skipDigestSRICheck,
     })) as TrustResolution
+
+    // WL-ECS is not enforced by verre; drop the verdict until it is (see verre ResolverConfig.ecsEcosystems).
+    if (isEcsAllowlistEnforced() && result.verified && !(await hasAllowlistedEcsServiceCredential(result))) {
+      result.verified = false
+      result.outcome = TrustResolutionOutcome.NOT_TRUSTED
+    }
 
     const snap = snapshotFromResolution(result)
     await saveTrustResults({


### PR DESCRIPTION
## Changes

- `ecs-allowlist.ts`: new `resolver.ecsEcosystems` config (`{ did, vpr }[]`), `ECS_ECOSYSTEM_DIDS` env fallback; resolves DIDs to a set of `ecosystem_id`.
- `trust-resolve.ts`: gate at ingestion: no allowlisted `ECS-SERVICE` - stored as `verified: false`.
- `trust-resolve-v4.builders.ts`; `isEcs` now requires an ECS title **and** an allowlisted Ecosystem; non-allowlisted ones degrade to ordinary VTCs.
- `config.json`: ships devnet + testnet ECS Ecosystem DIDs.

> Note: Temporary. `verre@0.3.0` classifies ECS by schema digest with `$id` stripped, and its `ResolverConfig` has no WL-ECS allowlist; proper fix is upstream (https://github.com/verana-labs/verre/issues/116).
