### PR TITLE
feat: implement idx de qry 3 get operator authorization

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4101,6 +4101,54 @@
         }
       }
     },
+    "/v4/delegation/operator-authorization/{id}": {
+      "get": {
+        "tags": [
+          "Delegation"
+        ],
+        "summary": "Get Operator Authorization",
+        "description": "Retrieve a specific OperatorAuthorization entry by its id. Aligned with VPR MOD-DE-QRY-3.",
+        "operationId": "getOperatorAuthorization",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint64"
+            },
+            "description": "The OperatorAuthorization ID"
+          },
+          {
+            "$ref": "#/components/parameters/At-Block-Height"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operator authorization found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "authorization": {
+                      "$ref": "#/components/schemas/OperatorAuthorization"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
     "/v4/trust-deposit/get/{corporation}": {
       "get": {
         "tags": [
@@ -7155,6 +7203,31 @@
           "created": { "type": "string", "format": "date-time" }
         }
       },
+      "DenomAmount": {
+        "type": "object",
+        "required": ["denom", "amount"],
+        "properties": {
+          "denom": { "type": "string" },
+          "amount": { "type": "string" }
+        }
+      },
+      "OperatorAuthorization": {
+        "type": "object",
+        "description": "A corporation's authorization granted to a specific operator account for one or more module message types (IDX-DE-QRY-3).",
+        "required": ["id", "corporation_id", "operator", "msg_types"],
+        "properties": {
+          "id": { "type": "integer", "format": "uint64" },
+          "corporation_id": { "type": "integer", "format": "uint64" },
+          "operator": { "type": "string" },
+          "msg_types": { "type": "array", "items": { "type": "string" } },
+          "spend_limit": { "type": "array", "items": { "$ref": "#/components/schemas/DenomAmount" } },
+          "remaining_spend": { "type": "array", "items": { "$ref": "#/components/schemas/DenomAmount" }, "description": "Present when spend_limit is set." },
+          "fee_spend_limit": { "type": "array", "items": { "$ref": "#/components/schemas/DenomAmount" } },
+          "remaining_fee_spend": { "type": "array", "items": { "$ref": "#/components/schemas/DenomAmount" }, "description": "Present when fee_spend_limit is set." },
+          "expiration": { "type": "string", "format": "date-time" },
+          "period": { "type": "string", "description": "Reset period for spend_limit, as a duration (e.g. \"86400s\")." }
+        }
+      },
       "ResolutionResponse": {
         "type": "object",
         "required": ["did", "trusted", "evaluatedAtTime", "evaluatedAtBlock", "expiresAtTime", "corporationId"],
@@ -7358,6 +7431,20 @@
             }
           }
         }
+      },
+      "NotFound": {
+        "description": "Not Found - The requested resource does not exist",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            },
+            "example": {
+              "error": "Resource not found",
+              "code": 404
+            }
+          }
+        }
       }
     }
   },
@@ -7400,6 +7487,10 @@
     {
       "name": "Digest",
       "description": "Digest lookup queries"
+    },
+    {
+      "name": "Delegation",
+      "description": "Operator and VS-operator authorization queries"
     },
     {
       "name": "Statistics",

--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -498,3 +498,56 @@
 | `entity_id`  | Entity identifier (null for GLOBAL)                                                                                    |
 | `type`       | Participant role type: 0=ANY, 1=ECOSYSTEM, 2=ISSUER_GRANTOR, 3=ISSUER, 4=VERIFIER_GRANTOR, 5=VERIFIER, 6=HOLDER        |
 | `value`      | Current number of participants for the given entity_kind/entity_id/type combination at the specified `height`          |
+
+### `operator_authorizations`
+
+Latest on-chain state of each `OperatorAuthorization` from the `verana.de.v1` (delegation) module. One row per authorization; `(corporation_id, operator)` is unique. Rows are deleted when the authorization is revoked on-chain.
+
+| Column                | Description                                                                                              |
+| --------------------- | -------------------------------------------------------------------------------------------------------- |
+| `id`                  | Primary key — the on-chain uint64 id of the OperatorAuthorization                                        |
+| `corporation_id`      | Id of the corporation granting the authorization                                                        |
+| `operator`            | Grantee operator account receiving the authorization                                                    |
+| `msg_types`           | jsonb array of module message types this authorization applies to                                       |
+| `spend_limit`         | jsonb array of `{denom, amount}` — max spendable amount (nullable)                                       |
+| `remaining_spend`     | jsonb array of `{denom, amount}` — runtime balance for `spend_limit` (present when `spend_limit` is set) |
+| `fee_spend_limit`     | jsonb array of `{denom, amount}` — fee allowance ceiling, hydrated from the mirrored `x/feegrant` grant (nullable) |
+| `remaining_fee_spend` | jsonb array of `{denom, amount}` — runtime fee balance from the `x/feegrant` grant (present when a fee allowance exists) |
+| `expiration`          | Timestamp after which the authorization is no longer valid (nullable)                                   |
+| `period`              | Reset period for `spend_limit`, stored as a duration string (nullable)                                  |
+| `height`              | Block height at which this state was captured                                                           |
+| `created_at`          | Timestamp when this row was first inserted                                                              |
+
+### `operator_authorization_history`
+
+Append-only history of `OperatorAuthorization` changes, used to serve `At-Block-Height` queries. A `revoked` row records the deletion.
+
+| Column                      | Description                                                                          |
+| --------------------------- | ------------------------------------------------------------------------------------ |
+| `id`                        | Primary key of the history record (auto-increment)                                   |
+| `operator_authorization_id` | The OperatorAuthorization id this record refers to                                   |
+| `corporation_id`            | Id of the corporation granting the authorization                                     |
+| `operator`                  | Grantee operator account                                                             |
+| `msg_types`                 | jsonb array of module message types (nullable for revoke records)                    |
+| `spend_limit`               | jsonb array of `{denom, amount}` (nullable)                                           |
+| `remaining_spend`           | jsonb array of `{denom, amount}` (nullable)                                           |
+| `fee_spend_limit`           | jsonb array of `{denom, amount}` (nullable)                                           |
+| `remaining_fee_spend`       | jsonb array of `{denom, amount}` (nullable)                                           |
+| `expiration`                | Timestamp after which the authorization expires (nullable)                           |
+| `period`                    | Reset period as a duration string (nullable)                                         |
+| `revoked`                   | `true` when this record captures an on-chain revocation (deletion)                   |
+| `height`                    | Block height of this change                                                          |
+| `created_at`                | Timestamp when this row was inserted                                                 |
+
+### `vs_operator_authorizations`
+
+Latest on-chain state of each `VSOperatorAuthorization` from the `verana.de.v1` (delegation) module. One row per authorization; `(corporation_id, vs_operator)` is unique. The row is deleted when the authorization no longer exists on-chain (its last record was revoked).
+
+| Column           | Description                                                                                                    |
+| ---------------- | -------------------------------------------------------------------------------------------------------------- |
+| `id`             | Primary key — the on-chain uint64 id of the VSOperatorAuthorization                                            |
+| `corporation_id` | Id of the corporation granting the authorization                                                              |
+| `vs_operator`    | Grantee VS-operator account receiving the authorization                                                       |
+| `records`        | jsonb array of `ParticipantAuthorizationRecord` — one per controlled participant, each carrying `participant_id`, `msg_types`, `spend_limit`, `remaining_spend`, `fee_spend_limit`, `remaining_fee_spend`, `with_feegrant`, `expiration`, `period` |
+| `height`         | Block height at which this state was captured                                                                 |
+| `created_at`     | Timestamp when this row was first inserted                                                                    |

--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -40,6 +40,7 @@ export const BULL_JOB_NAME = {
   CRAWL_VALIDATOR: 'crawl:validator',
   HANDLE_TRUST_DEPOSIT: 'handle:trust-deposit',
   HANDLE_DIGEST: 'handle:digest',
+  HANDLE_DELEGATION: 'handle:delegation',
   CRAWL_GENESIS_VALIDATOR: 'crawl:genesis-validator',
   CRAWL_SIGNING_INFO: 'crawl:signing-info',
   HANDLE_ADDRESS: 'handle:address',
@@ -300,6 +301,18 @@ export const SERVICE = {
     DigestProcessorService: {
       key: 'DigestProcessorService',
       path: 'v1.DigestProcessorService',
+    },
+    DelegationApiService: {
+      key: 'DelegationApiService',
+      path: 'v1.DelegationApiService',
+    },
+    DelegationDatabaseService: {
+      key: 'DelegationDatabaseService',
+      path: 'v1.DelegationDatabaseService',
+    },
+    DelegationProcessorService: {
+      key: 'DelegationProcessorService',
+      path: 'v1.DelegationProcessorService',
     },
     CrawlAccountService: {
       key: 'CrawlAccountService',

--- a/src/common/utils/helper.ts
+++ b/src/common/utils/helper.ts
@@ -21,3 +21,7 @@ export function toCoin(value: unknown, denom = 'uvna'): string {
   if (!Number.isFinite(n) || n < 0) return `0${denom}`
   return `${Math.trunc(n)}${denom}`
 }
+
+export function toJsonbColumn(value: unknown): string | null {
+  return value === null || value === undefined ? null : JSON.stringify(value)
+}

--- a/src/config.json
+++ b/src/config.json
@@ -84,6 +84,11 @@
     "millisecondCrawl": 300,
     "chunkSize": 500
   },
+  "crawlDelegation": {
+    "key": "crawlDelegation",
+    "millisecondCrawl": 300,
+    "chunkSize": 500
+  },
   "crawlAccounts": {
     "key": "crawlAccounts",
     "freshStart": {

--- a/src/migrations/20260710000000_create_delegation_tables.ts
+++ b/src/migrations/20260710000000_create_delegation_tables.ts
@@ -1,0 +1,63 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('operator_authorizations', (table) => {
+    table.bigInteger('id').primary()
+    table.bigInteger('corporation_id').notNullable()
+    table.string('operator', 255).notNullable()
+    table.jsonb('msg_types').notNullable()
+    table.jsonb('spend_limit').nullable()
+    table.jsonb('remaining_spend').nullable()
+    table.jsonb('fee_spend_limit').nullable()
+    table.jsonb('remaining_fee_spend').nullable()
+    table.timestamp('expiration').nullable()
+    table.text('period').nullable()
+    table.integer('height').notNullable()
+    table.timestamp('created_at').defaultTo(knex.fn.now())
+
+    table.unique(['corporation_id', 'operator'])
+    table.index(['corporation_id'])
+    table.index(['operator'])
+    table.index(['height'])
+  })
+
+  await knex.schema.createTable('operator_authorization_history', (table) => {
+    table.increments('id').primary()
+    table.bigInteger('operator_authorization_id').notNullable()
+    table.bigInteger('corporation_id').notNullable()
+    table.string('operator', 255).notNullable()
+    table.jsonb('msg_types').nullable()
+    table.jsonb('spend_limit').nullable()
+    table.jsonb('remaining_spend').nullable()
+    table.jsonb('fee_spend_limit').nullable()
+    table.jsonb('remaining_fee_spend').nullable()
+    table.timestamp('expiration').nullable()
+    table.text('period').nullable()
+    table.boolean('revoked').notNullable().defaultTo(false)
+    table.integer('height').notNullable()
+    table.timestamp('created_at').defaultTo(knex.fn.now())
+
+    table.index(['operator_authorization_id', 'height'])
+    table.index(['height'])
+  })
+
+  await knex.schema.createTable('vs_operator_authorizations', (table) => {
+    table.bigInteger('id').primary()
+    table.bigInteger('corporation_id').notNullable()
+    table.string('vs_operator', 255).notNullable()
+    table.jsonb('records').notNullable()
+    table.integer('height').notNullable()
+    table.timestamp('created_at').defaultTo(knex.fn.now())
+
+    table.unique(['corporation_id', 'vs_operator'])
+    table.index(['corporation_id'])
+    table.index(['vs_operator'])
+    table.index(['height'])
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('vs_operator_authorizations')
+  await knex.schema.dropTableIfExists('operator_authorization_history')
+  await knex.schema.dropTableIfExists('operator_authorizations')
+}

--- a/src/models/operator_authorization.ts
+++ b/src/models/operator_authorization.ts
@@ -1,0 +1,42 @@
+import BaseModel from './base'
+
+export interface DenomAmount {
+  denom: string
+  amount: string
+}
+
+export default class OperatorAuthorization extends BaseModel {
+  static tableName = 'operator_authorizations'
+
+  id!: number
+  corporation_id!: number
+  operator!: string
+  msg_types!: string[]
+  spend_limit!: DenomAmount[] | null
+  remaining_spend!: DenomAmount[] | null
+  fee_spend_limit!: DenomAmount[] | null
+  remaining_fee_spend!: DenomAmount[] | null
+  expiration!: string | null
+  period!: string | null
+  height!: number
+
+  static get jsonSchema() {
+    return {
+      type: 'object',
+      required: ['id', 'corporation_id', 'operator', 'msg_types', 'height'],
+      properties: {
+        id: { type: 'integer' },
+        corporation_id: { type: 'integer' },
+        operator: { type: 'string', maxLength: 255 },
+        msg_types: { type: 'array', items: { type: 'string' } },
+        spend_limit: { type: ['array', 'null'] },
+        remaining_spend: { type: ['array', 'null'] },
+        fee_spend_limit: { type: ['array', 'null'] },
+        remaining_fee_spend: { type: ['array', 'null'] },
+        expiration: { type: ['string', 'null'] },
+        period: { type: ['string', 'null'] },
+        height: { type: 'integer' },
+      },
+    }
+  }
+}

--- a/src/models/operator_authorization_history.ts
+++ b/src/models/operator_authorization_history.ts
@@ -1,0 +1,41 @@
+import BaseModel from './base'
+import type { DenomAmount } from './operator_authorization'
+
+export default class OperatorAuthorizationHistory extends BaseModel {
+  static tableName = 'operator_authorization_history'
+
+  id!: number
+  operator_authorization_id!: number
+  corporation_id!: number
+  operator!: string
+  msg_types!: string[] | null
+  spend_limit!: DenomAmount[] | null
+  remaining_spend!: DenomAmount[] | null
+  fee_spend_limit!: DenomAmount[] | null
+  remaining_fee_spend!: DenomAmount[] | null
+  expiration!: string | null
+  period!: string | null
+  revoked!: boolean
+  height!: number
+
+  static get jsonSchema() {
+    return {
+      type: 'object',
+      required: ['operator_authorization_id', 'corporation_id', 'operator', 'height'],
+      properties: {
+        operator_authorization_id: { type: 'integer' },
+        corporation_id: { type: 'integer' },
+        operator: { type: 'string', maxLength: 255 },
+        msg_types: { type: ['array', 'null'], items: { type: 'string' } },
+        spend_limit: { type: ['array', 'null'] },
+        remaining_spend: { type: ['array', 'null'] },
+        fee_spend_limit: { type: ['array', 'null'] },
+        remaining_fee_spend: { type: ['array', 'null'] },
+        expiration: { type: ['string', 'null'] },
+        period: { type: ['string', 'null'] },
+        revoked: { type: 'boolean' },
+        height: { type: 'integer' },
+      },
+    }
+  }
+}

--- a/src/models/vs_operator_authorization.ts
+++ b/src/models/vs_operator_authorization.ts
@@ -1,0 +1,38 @@
+import BaseModel from './base'
+import type { DenomAmount } from './operator_authorization'
+
+export interface ParticipantAuthorizationRecord {
+  participant_id: number
+  msg_types: string[]
+  spend_limit: DenomAmount[] | null
+  remaining_spend: DenomAmount[] | null
+  fee_spend_limit: DenomAmount[] | null
+  remaining_fee_spend: DenomAmount[] | null
+  with_feegrant: boolean
+  expiration: string | null
+  period: string | null
+}
+
+export default class VSOperatorAuthorization extends BaseModel {
+  static tableName = 'vs_operator_authorizations'
+
+  id!: number
+  corporation_id!: number
+  vs_operator!: string
+  records!: ParticipantAuthorizationRecord[]
+  height!: number
+
+  static get jsonSchema() {
+    return {
+      type: 'object',
+      required: ['id', 'corporation_id', 'vs_operator', 'records', 'height'],
+      properties: {
+        id: { type: 'integer' },
+        corporation_id: { type: 'integer' },
+        vs_operator: { type: 'string', maxLength: 255 },
+        records: { type: 'array' },
+        height: { type: 'integer' },
+      },
+    }
+  }
+}

--- a/src/modules/de-height-sync/de_height_sync_helpers.ts
+++ b/src/modules/de-height-sync/de_height_sync_helpers.ts
@@ -1,0 +1,179 @@
+import type { Coin } from '@verana-labs/verana-types/codec/cosmos/base/v1beta1/coin'
+import type { Duration } from '@verana-labs/verana-types/codec/google/protobuf/duration'
+import {
+  QueryClientImpl as DeQueryClientImpl,
+  QueryGetOperatorAuthorizationRequest,
+  QueryGetVSOperatorAuthorizationRequest,
+} from '@verana-labs/verana-types/codec/verana/de/v1/query'
+import type {
+  OperatorAuthorization as LedgerOperatorAuthorization,
+  ParticipantAuthorizationRecord as LedgerParticipantAuthorizationRecord,
+  VSOperatorAuthorization as LedgerVSOperatorAuthorization,
+} from '@verana-labs/verana-types/codec/verana/de/v1/types'
+import { AllowedMsgAllowance, BasicAllowance, PeriodicAllowance } from 'cosmjs-types/cosmos/feegrant/v1beta1/feegrant'
+import {
+  QueryClientImpl as FeegrantQueryClientImpl,
+  QueryAllowanceRequest,
+} from 'cosmjs-types/cosmos/feegrant/v1beta1/query'
+import { dateToIsoOrNull } from '../../common/utils/date_utils'
+import { withAbciQueryClient } from '../../common/utils/grpc_query'
+
+const ALLOWED_MSG_ALLOWANCE_TYPE_URL = '/cosmos.feegrant.v1beta1.AllowedMsgAllowance'
+const BASIC_ALLOWANCE_TYPE_URL = '/cosmos.feegrant.v1beta1.BasicAllowance'
+const PERIODIC_ALLOWANCE_TYPE_URL = '/cosmos.feegrant.v1beta1.PeriodicAllowance'
+
+export interface DenomAmount {
+  denom: string
+  amount: string
+}
+
+export interface OperatorAuthorizationRow {
+  id: number
+  corporation_id: number
+  operator: string
+  msg_types: string[]
+  spend_limit: DenomAmount[] | null
+  remaining_spend: DenomAmount[] | null
+  expiration: string | null
+  period: string | null
+}
+
+export interface ParticipantAuthorizationRecordRow {
+  participant_id: number
+  msg_types: string[]
+  spend_limit: DenomAmount[] | null
+  remaining_spend: DenomAmount[] | null
+  fee_spend_limit: DenomAmount[] | null
+  remaining_fee_spend: DenomAmount[] | null
+  with_feegrant: boolean
+  expiration: string | null
+  period: string | null
+}
+
+export interface VSOperatorAuthorizationRow {
+  id: number
+  corporation_id: number
+  vs_operator: string
+  records: ParticipantAuthorizationRecordRow[]
+}
+
+export interface FeeAllowanceSnapshot {
+  fee_spend_limit: DenomAmount[] | null
+  remaining_fee_spend: DenomAmount[] | null
+}
+
+function serializeCoins(coins: Coin[] | undefined): DenomAmount[] | null {
+  if (!coins || coins.length === 0) return null
+  return coins.map((coin) => ({ denom: coin.denom, amount: String(coin.amount) }))
+}
+
+function serializeDuration(duration: Duration | undefined): string | null {
+  if (!duration) return null
+  const seconds = Number(duration.seconds ?? 0)
+  const nanos = Number(duration.nanos ?? 0)
+  if (seconds === 0 && nanos === 0) return null
+  return `${seconds + nanos / 1e9}s`
+}
+
+export function serializeLedgerOperatorAuthorization(
+  authorization: LedgerOperatorAuthorization
+): OperatorAuthorizationRow {
+  return {
+    id: Number(authorization.id),
+    corporation_id: Number(authorization.corporationId),
+    operator: authorization.operator,
+    msg_types: authorization.msgTypes ?? [],
+    spend_limit: serializeCoins(authorization.spendLimit),
+    remaining_spend: serializeCoins(authorization.remainingSpend),
+    expiration: dateToIsoOrNull(authorization.expiration),
+    period: serializeDuration(authorization.period),
+  }
+}
+
+function serializeLedgerParticipantRecord(
+  record: LedgerParticipantAuthorizationRecord
+): ParticipantAuthorizationRecordRow {
+  return {
+    participant_id: Number(record.participantId),
+    msg_types: record.msgTypes ?? [],
+    spend_limit: serializeCoins(record.spendLimit),
+    remaining_spend: serializeCoins(record.remainingSpend),
+    fee_spend_limit: serializeCoins(record.feeSpendLimit),
+    remaining_fee_spend: serializeCoins(record.remainingFeeSpend),
+    with_feegrant: Boolean(record.withFeegrant),
+    expiration: dateToIsoOrNull(record.expiration),
+    period: serializeDuration(record.period),
+  }
+}
+
+export function serializeLedgerVSOperatorAuthorization(
+  authorization: LedgerVSOperatorAuthorization
+): VSOperatorAuthorizationRow {
+  return {
+    id: Number(authorization.id),
+    corporation_id: Number(authorization.corporationId),
+    vs_operator: authorization.vsOperator,
+    records: (authorization.records ?? []).map(serializeLedgerParticipantRecord),
+  }
+}
+
+export async function fetchOperatorAuthorization(
+  id: number,
+  blockHeight: number | undefined
+): Promise<LedgerOperatorAuthorization | undefined> {
+  return withAbciQueryClient(blockHeight, async (rpc) => {
+    const query = new DeQueryClientImpl(rpc)
+    const res = await query.GetOperatorAuthorization(QueryGetOperatorAuthorizationRequest.fromPartial({ id }))
+    return res?.operatorAuthorization ?? undefined
+  })
+}
+
+export async function fetchVSOperatorAuthorization(
+  id: number,
+  blockHeight: number | undefined
+): Promise<LedgerVSOperatorAuthorization | undefined> {
+  return withAbciQueryClient(blockHeight, async (rpc) => {
+    const query = new DeQueryClientImpl(rpc)
+    const res = await query.GetVSOperatorAuthorization(QueryGetVSOperatorAuthorizationRequest.fromPartial({ id }))
+    return res?.vsOperatorAuthorization ?? undefined
+  })
+}
+
+function unwrapFeeAllowance(typeUrl: string, value: Uint8Array): FeeAllowanceSnapshot | undefined {
+  if (typeUrl === PERIODIC_ALLOWANCE_TYPE_URL) {
+    const periodic = PeriodicAllowance.decode(value)
+    return {
+      fee_spend_limit: serializeCoins(periodic.periodSpendLimit as Coin[]),
+      remaining_fee_spend: serializeCoins(periodic.periodCanSpend as Coin[]),
+    }
+  }
+  if (typeUrl === BASIC_ALLOWANCE_TYPE_URL) {
+    const basic = BasicAllowance.decode(value)
+    const limit = serializeCoins(basic.spendLimit as Coin[])
+    return { fee_spend_limit: limit, remaining_fee_spend: limit }
+  }
+  return undefined
+}
+
+export async function fetchFeeAllowance(
+  granter: string,
+  grantee: string,
+  blockHeight: number | undefined
+): Promise<FeeAllowanceSnapshot | undefined> {
+  const grant = await withAbciQueryClient(blockHeight, async (rpc) => {
+    const query = new FeegrantQueryClientImpl(rpc)
+    const res = await query.Allowance(QueryAllowanceRequest.fromPartial({ granter, grantee }))
+    return res?.allowance ?? undefined
+  })
+
+  const allowance = grant?.allowance
+  if (!allowance) return undefined
+
+  if (allowance.typeUrl !== ALLOWED_MSG_ALLOWANCE_TYPE_URL) {
+    return unwrapFeeAllowance(allowance.typeUrl, allowance.value)
+  }
+
+  const allowed = AllowedMsgAllowance.decode(allowance.value)
+  if (!allowed.allowance) return undefined
+  return unwrapFeeAllowance(allowed.allowance.typeUrl, allowed.allowance.value)
+}

--- a/src/modules/de-height-sync/de_height_sync_service.ts
+++ b/src/modules/de-height-sync/de_height_sync_service.ts
@@ -1,0 +1,197 @@
+import { Buffer } from 'node:buffer'
+import type { ServiceBroker } from 'moleculer'
+import { SERVICE } from '../../common'
+import { Corporation } from '../../models/corporation'
+import type { FeeAllowanceSnapshot } from './de_height_sync_helpers'
+import {
+  fetchFeeAllowance,
+  fetchOperatorAuthorization,
+  fetchVSOperatorAuthorization,
+  serializeLedgerOperatorAuthorization,
+  serializeLedgerVSOperatorAuthorization,
+} from './de_height_sync_helpers'
+
+export const DE_EVENT_TYPES = {
+  GRANT_OPERATOR_AUTHORIZATION: 'grant_operator_authorization',
+  REVOKE_OPERATOR_AUTHORIZATION: 'revoke_operator_authorization',
+  GRANT_VS_OPERATOR_AUTHORIZATION: 'grant_vs_operator_authorization',
+  REVOKE_VS_OPERATOR_AUTHORIZATION: 'revoke_vs_operator_authorization',
+  UPDATE_VS_OPERATOR_AUTHORIZATION: 'update_vs_operator_authorization',
+} as const
+
+const DE_EVENT_TYPE_SET = new Set<string>(Object.values(DE_EVENT_TYPES))
+
+const OPERATOR_AUTHORIZATION_EVENTS = new Set<string>([
+  DE_EVENT_TYPES.GRANT_OPERATOR_AUTHORIZATION,
+  DE_EVENT_TYPES.REVOKE_OPERATOR_AUTHORIZATION,
+])
+
+const VS_OPERATOR_AUTHORIZATION_EVENTS = new Set<string>([
+  DE_EVENT_TYPES.GRANT_VS_OPERATOR_AUTHORIZATION,
+  DE_EVENT_TYPES.REVOKE_VS_OPERATOR_AUTHORIZATION,
+  DE_EVENT_TYPES.UPDATE_VS_OPERATOR_AUTHORIZATION,
+])
+
+interface BlockEventAttribute {
+  key?: string
+  value?: string
+}
+
+interface BlockEvent {
+  type?: string
+  attributes?: BlockEventAttribute[]
+}
+
+function decodeAttr(value: string | undefined): string {
+  if (value === undefined || value === null) return ''
+  try {
+    const decoded = Buffer.from(value, 'base64').toString('utf8')
+    if (Buffer.from(decoded, 'utf8').toString('base64') === value) {
+      return decoded
+    }
+  } catch {
+    // value was not base64-encoded
+  }
+  return value
+}
+
+function getAttr(event: BlockEvent, key: string): string | undefined {
+  for (const attr of event.attributes ?? []) {
+    if (decodeAttr(attr.key) === key) return decodeAttr(attr.value)
+  }
+  return undefined
+}
+
+function parseId(value: string | undefined): number | undefined {
+  if (!value) return undefined
+  const parsed = Number(value)
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined
+}
+
+export function hasDelegationEvents(events: BlockEvent[]): boolean {
+  return events.some((event) => event.type !== undefined && DE_EVENT_TYPE_SET.has(event.type))
+}
+
+interface OperatorAuthorizationTouch {
+  authzId: number
+  corporationId: number
+  grantee: string
+  revoked: boolean
+}
+
+export function extractOperatorAuthorizationTouches(events: BlockEvent[]): OperatorAuthorizationTouch[] {
+  const touches = new Map<number, OperatorAuthorizationTouch>()
+  for (const event of events) {
+    if (!event.type || !OPERATOR_AUTHORIZATION_EVENTS.has(event.type)) continue
+    const authzId = parseId(getAttr(event, 'authz_id'))
+    const corporationId = parseId(getAttr(event, 'corporation_id'))
+    const grantee = getAttr(event, 'grantee')
+    if (authzId === undefined || corporationId === undefined || !grantee) continue
+    touches.set(authzId, {
+      authzId,
+      corporationId,
+      grantee,
+      revoked: event.type === DE_EVENT_TYPES.REVOKE_OPERATOR_AUTHORIZATION,
+    })
+  }
+  return [...touches.values()]
+}
+
+export function extractVSOperatorAuthorizationIds(events: BlockEvent[]): number[] {
+  const ids = new Set<number>()
+  for (const event of events) {
+    if (!event.type || !VS_OPERATOR_AUTHORIZATION_EVENTS.has(event.type)) continue
+    const vsoaId = parseId(getAttr(event, 'vsoa_id'))
+    if (vsoaId !== undefined) ids.add(vsoaId)
+  }
+  return [...ids]
+}
+
+async function resolveCorporationPolicyAddress(corporationId: number): Promise<string | undefined> {
+  const corporation = await Corporation.query().findById(corporationId)
+  return corporation?.policy_address ?? undefined
+}
+
+async function syncOperatorAuthorization(
+  broker: ServiceBroker,
+  touch: OperatorAuthorizationTouch,
+  blockHeight: number
+): Promise<void> {
+  if (touch.revoked) {
+    await broker.call(`${SERVICE.V1.DelegationDatabaseService.path}.revokeOperatorAuthorization`, {
+      id: touch.authzId,
+      corporationId: touch.corporationId,
+      operator: touch.grantee,
+      blockHeight,
+    })
+    return
+  }
+
+  const ledgerAuthorization = await fetchOperatorAuthorization(touch.authzId, blockHeight)
+  if (!ledgerAuthorization) return
+
+  const authorization = serializeLedgerOperatorAuthorization(ledgerAuthorization)
+
+  let feeAllowance: FeeAllowanceSnapshot | undefined
+  const policyAddress = await resolveCorporationPolicyAddress(authorization.corporation_id)
+  if (policyAddress) {
+    try {
+      feeAllowance = await fetchFeeAllowance(policyAddress, authorization.operator, blockHeight)
+    } catch (err: any) {
+      broker.logger.warn(
+        `[DE Height Sync] Failed to fetch fee allowance granter=${policyAddress} grantee=${authorization.operator} at block=${blockHeight}: ${err?.message || String(err)}`
+      )
+    }
+  }
+
+  await broker.call(`${SERVICE.V1.DelegationDatabaseService.path}.syncOperatorAuthorization`, {
+    authorization,
+    feeAllowance: feeAllowance ?? null,
+    blockHeight,
+  })
+}
+
+async function syncVSOperatorAuthorization(broker: ServiceBroker, vsoaId: number, blockHeight: number): Promise<void> {
+  const ledgerAuthorization = await fetchVSOperatorAuthorization(vsoaId, blockHeight)
+
+  if (!ledgerAuthorization) {
+    await broker.call(`${SERVICE.V1.DelegationDatabaseService.path}.deleteVSOperatorAuthorization`, { id: vsoaId })
+    return
+  }
+
+  await broker.call(`${SERVICE.V1.DelegationDatabaseService.path}.syncVSOperatorAuthorization`, {
+    authorization: serializeLedgerVSOperatorAuthorization(ledgerAuthorization),
+    blockHeight,
+  })
+}
+
+export async function runHeightSyncDE(
+  broker: ServiceBroker,
+  payload: { events: BlockEvent[] },
+  blockHeight: number
+): Promise<void> {
+  const events = payload.events ?? []
+  if (!hasDelegationEvents(events) || typeof blockHeight !== 'number' || blockHeight <= 0) {
+    return
+  }
+
+  for (const touch of extractOperatorAuthorizationTouches(events)) {
+    try {
+      await syncOperatorAuthorization(broker, touch, blockHeight)
+    } catch (err: any) {
+      broker.logger.warn(
+        `[DE Height Sync] Sync failed operator_authorization=${touch.authzId} at block=${blockHeight}: ${err?.message || String(err)}`
+      )
+    }
+  }
+
+  for (const vsoaId of extractVSOperatorAuthorizationIds(events)) {
+    try {
+      await syncVSOperatorAuthorization(broker, vsoaId, blockHeight)
+    } catch (err: any) {
+      broker.logger.warn(
+        `[DE Height Sync] Sync failed vs_operator_authorization=${vsoaId} at block=${blockHeight}: ${err?.message || String(err)}`
+      )
+    }
+  }
+}

--- a/src/modules/de-height-sync/de_height_sync_service.ts
+++ b/src/modules/de-height-sync/de_height_sync_service.ts
@@ -42,22 +42,15 @@ interface BlockEvent {
   attributes?: BlockEventAttribute[]
 }
 
-function decodeAttr(value: string | undefined): string {
-  if (value === undefined || value === null) return ''
-  try {
-    const decoded = Buffer.from(value, 'base64').toString('utf8')
-    if (Buffer.from(decoded, 'utf8').toString('base64') === value) {
-      return decoded
-    }
-  } catch {
-    // value was not base64-encoded
-  }
-  return value
+function decodeBase64(value: string): string {
+  return Buffer.from(value, 'base64').toString('utf8')
 }
 
 function getAttr(event: BlockEvent, key: string): string | undefined {
   for (const attr of event.attributes ?? []) {
-    if (decodeAttr(attr.key) === key) return decodeAttr(attr.value)
+    if (attr.key === undefined) continue
+    if (attr.key === key) return attr.value
+    if (decodeBase64(attr.key) === key) return attr.value === undefined ? undefined : decodeBase64(attr.value)
   }
   return undefined
 }

--- a/src/services/api/api.service.ts
+++ b/src/services/api/api.service.ts
@@ -361,6 +361,9 @@ function createRoute(path: string, aliases: Record<string, string>, requireBlock
       createRoute('/v4/di', {
         'GET get/:digest': `${SERVICE.V1.DigestApiService.path}.getDigest`,
       }),
+      createRoute('/v4/delegation', {
+        'GET operator-authorization/:id': `${SERVICE.V1.DelegationApiService.path}.getOperatorAuthorization`,
+      }),
       createRoute('/v4/trust-deposit', {
         'GET get/:corporation': `${SERVICE.V1.TrustDepositApiService.path}.getTrustDeposit`,
         'GET params': `${SERVICE.V1.TrustDepositApiService.path}.getModuleParams`,

--- a/src/services/crawl-de/de_apis.service.ts
+++ b/src/services/crawl-de/de_apis.service.ts
@@ -1,0 +1,77 @@
+import { Action, Service } from '@ourparentcenter/moleculer-decorators-extended'
+import { Context, ServiceBroker } from 'moleculer'
+import BaseService from '../../base/base.service'
+import { SERVICE } from '../../common'
+import ApiResponder from '../../common/utils/apiResponse'
+import { getBlockHeight } from '../../common/utils/blockHeight'
+import { dateToIsoOrNull } from '../../common/utils/date_utils'
+import OperatorAuthorization from '../../models/operator_authorization'
+import OperatorAuthorizationHistory from '../../models/operator_authorization_history'
+
+function serializeOperatorAuthorizationRow(row: any) {
+  const spendLimit = row.spend_limit ?? null
+  const feeSpendLimit = row.fee_spend_limit ?? null
+
+  return {
+    id: Number(row.id ?? row.operator_authorization_id),
+    corporation_id: Number(row.corporation_id),
+    operator: String(row.operator),
+    msg_types: row.msg_types ?? [],
+    ...(spendLimit ? { spend_limit: spendLimit, remaining_spend: row.remaining_spend ?? [] } : {}),
+    ...(feeSpendLimit ? { fee_spend_limit: feeSpendLimit, remaining_fee_spend: row.remaining_fee_spend ?? [] } : {}),
+    ...(row.expiration ? { expiration: dateToIsoOrNull(row.expiration) } : {}),
+    ...(row.period ? { period: String(row.period) } : {}),
+  }
+}
+
+interface GetOperatorAuthorizationParams {
+  id: number
+}
+
+@Service({
+  name: SERVICE.V1.DelegationApiService.key,
+  version: 1,
+})
+export default class DelegationApiService extends BaseService {
+  public constructor(public broker: ServiceBroker) {
+    super(broker)
+  }
+
+  private async resolveAtHeight(id: number, blockHeight: number): Promise<any | undefined> {
+    return OperatorAuthorizationHistory.query()
+      .where('operator_authorization_id', id)
+      .where('height', '<=', blockHeight)
+      .orderBy('height', 'desc')
+      .orderBy('id', 'desc')
+      .first()
+  }
+
+  @Action({
+    rest: 'GET operator-authorization/:id',
+    params: {
+      id: { type: 'number', integer: true, positive: true, convert: true },
+    },
+  })
+  async getOperatorAuthorization(ctx: Context<GetOperatorAuthorizationParams>) {
+    try {
+      const { id } = ctx.params
+      const blockHeight = getBlockHeight(ctx)
+
+      const row =
+        blockHeight !== undefined
+          ? await this.resolveAtHeight(id, blockHeight)
+          : await OperatorAuthorization.query().findById(id)
+
+      if (!row || row.revoked) {
+        return ApiResponder.error(ctx, 'Operator authorization not found', 404)
+      }
+
+      return ApiResponder.success(ctx, {
+        authorization: serializeOperatorAuthorizationRow(row),
+      })
+    } catch (err: any) {
+      this.logger.error('Error in Delegation.getOperatorAuthorization:', err)
+      return ApiResponder.error(ctx, `Failed to get operator authorization: ${err?.message || String(err)}`, 500)
+    }
+  }
+}

--- a/src/services/crawl-de/de_apis.service.ts
+++ b/src/services/crawl-de/de_apis.service.ts
@@ -13,7 +13,7 @@ function serializeOperatorAuthorizationRow(row: any) {
   const feeSpendLimit = row.fee_spend_limit ?? null
 
   return {
-    id: Number(row.id ?? row.operator_authorization_id),
+    id: Number(row.operator_authorization_id ?? row.id),
     corporation_id: Number(row.corporation_id),
     operator: String(row.operator),
     msg_types: row.msg_types ?? [],

--- a/src/services/crawl-de/de_database.service.ts
+++ b/src/services/crawl-de/de_database.service.ts
@@ -2,8 +2,8 @@ import { Action, Service } from '@ourparentcenter/moleculer-decorators-extended'
 import { ServiceBroker } from 'moleculer'
 import BaseService from '../../base/base.service'
 import { SERVICE } from '../../common'
-import { toJsonbColumn } from '../../common/utils/helper'
 import knex from '../../common/utils/db_connection'
+import { toJsonbColumn } from '../../common/utils/helper'
 import type {
   FeeAllowanceSnapshot,
   OperatorAuthorizationRow,

--- a/src/services/crawl-de/de_database.service.ts
+++ b/src/services/crawl-de/de_database.service.ts
@@ -1,0 +1,128 @@
+import { Action, Service } from '@ourparentcenter/moleculer-decorators-extended'
+import { ServiceBroker } from 'moleculer'
+import BaseService from '../../base/base.service'
+import { SERVICE } from '../../common'
+import { toJsonbColumn } from '../../common/utils/helper'
+import knex from '../../common/utils/db_connection'
+import type {
+  FeeAllowanceSnapshot,
+  OperatorAuthorizationRow,
+  VSOperatorAuthorizationRow,
+} from '../../modules/de-height-sync/de_height_sync_helpers'
+
+@Service({
+  name: SERVICE.V1.DelegationDatabaseService.key,
+  version: 1,
+})
+export default class DelegationDatabaseService extends BaseService {
+  public constructor(public broker: ServiceBroker) {
+    super(broker)
+  }
+
+  @Action({ name: 'syncOperatorAuthorization' })
+  async syncOperatorAuthorization(ctx: {
+    params: {
+      authorization: OperatorAuthorizationRow
+      feeAllowance: FeeAllowanceSnapshot | null
+      blockHeight: number
+    }
+  }): Promise<{ success: boolean }> {
+    const { authorization, feeAllowance, blockHeight } = ctx.params
+
+    const row = {
+      id: authorization.id,
+      corporation_id: authorization.corporation_id,
+      operator: authorization.operator,
+      msg_types: toJsonbColumn(authorization.msg_types),
+      spend_limit: toJsonbColumn(authorization.spend_limit),
+      remaining_spend: toJsonbColumn(authorization.remaining_spend),
+      fee_spend_limit: toJsonbColumn(feeAllowance?.fee_spend_limit ?? null),
+      remaining_fee_spend: toJsonbColumn(feeAllowance?.remaining_fee_spend ?? null),
+      expiration: authorization.expiration,
+      period: authorization.period,
+      height: blockHeight,
+    }
+
+    await knex.transaction(async (trx) => {
+      await trx('operator_authorizations')
+        .insert(row)
+        .onConflict('id')
+        .merge([
+          'corporation_id',
+          'operator',
+          'msg_types',
+          'spend_limit',
+          'remaining_spend',
+          'fee_spend_limit',
+          'remaining_fee_spend',
+          'expiration',
+          'period',
+          'height',
+        ])
+
+      await trx('operator_authorization_history').insert({
+        operator_authorization_id: row.id,
+        corporation_id: row.corporation_id,
+        operator: row.operator,
+        msg_types: row.msg_types,
+        spend_limit: row.spend_limit,
+        remaining_spend: row.remaining_spend,
+        fee_spend_limit: row.fee_spend_limit,
+        remaining_fee_spend: row.remaining_fee_spend,
+        expiration: row.expiration,
+        period: row.period,
+        revoked: false,
+        height: blockHeight,
+      })
+    })
+
+    return { success: true }
+  }
+
+  @Action({ name: 'revokeOperatorAuthorization' })
+  async revokeOperatorAuthorization(ctx: {
+    params: { id: number; corporationId: number; operator: string; blockHeight: number }
+  }): Promise<{ success: boolean }> {
+    const { id, corporationId, operator, blockHeight } = ctx.params
+
+    await knex.transaction(async (trx) => {
+      await trx('operator_authorizations').where('id', id).delete()
+
+      await trx('operator_authorization_history').insert({
+        operator_authorization_id: id,
+        corporation_id: corporationId,
+        operator,
+        revoked: true,
+        height: blockHeight,
+      })
+    })
+
+    return { success: true }
+  }
+
+  @Action({ name: 'syncVSOperatorAuthorization' })
+  async syncVSOperatorAuthorization(ctx: {
+    params: { authorization: VSOperatorAuthorizationRow; blockHeight: number }
+  }): Promise<{ success: boolean }> {
+    const { authorization, blockHeight } = ctx.params
+
+    await knex('vs_operator_authorizations')
+      .insert({
+        id: authorization.id,
+        corporation_id: authorization.corporation_id,
+        vs_operator: authorization.vs_operator,
+        records: toJsonbColumn(authorization.records),
+        height: blockHeight,
+      })
+      .onConflict('id')
+      .merge(['corporation_id', 'vs_operator', 'records', 'height'])
+
+    return { success: true }
+  }
+
+  @Action({ name: 'deleteVSOperatorAuthorization' })
+  async deleteVSOperatorAuthorization(ctx: { params: { id: number } }): Promise<{ success: boolean }> {
+    await knex('vs_operator_authorizations').where('id', ctx.params.id).delete()
+    return { success: true }
+  }
+}

--- a/src/services/crawl-de/de_processor.service.ts
+++ b/src/services/crawl-de/de_processor.service.ts
@@ -1,0 +1,150 @@
+import { Action, Service } from '@ourparentcenter/moleculer-decorators-extended'
+import { Context, ServiceBroker } from 'moleculer'
+import BullableService from '../../base/bullable.service'
+import { BULL_JOB_NAME, SERVICE } from '../../common'
+import { CheckpointManager } from '../../common/utils/checkpoint_manager'
+import knex from '../../common/utils/db_connection'
+import {
+  delay,
+  getDbQueryTimeoutMs,
+  isStatementTimeoutError,
+  queryWithAutoRetry,
+} from '../../common/utils/db_query_helper'
+import { detectStartMode } from '../../common/utils/start_mode_detector'
+import config from '../../config.json' with { type: 'json' }
+import { Block } from '../../models'
+import { BlockCheckpoint } from '../../models/block_checkpoint'
+import { hasDelegationEvents, runHeightSyncDE } from '../../modules/de-height-sync/de_height_sync_service'
+import { indexerStatusManager } from '../manager/indexer_status.manager'
+
+@Service({
+  name: SERVICE.V1.DelegationProcessorService.key,
+  version: 1,
+})
+export default class DelegationProcessorService extends BullableService {
+  private timer: NodeJS.Timeout | null = null
+  private checkpointManager: CheckpointManager
+  private isProcessing = false
+
+  public constructor(public broker: ServiceBroker) {
+    super(broker)
+    this.checkpointManager = new CheckpointManager(this.logger)
+  }
+
+  public async started() {
+    try {
+      await detectStartMode(BULL_JOB_NAME.HANDLE_DELEGATION)
+      await this.ensureCheckpoint()
+      const crawlInterval = config.crawlDelegation.millisecondCrawl
+
+      this.processBlocks().catch((err) => {
+        this.logger.error('[DelegationProcessorService] Error in initial processBlocks:', err)
+      })
+
+      this.timer = setInterval(() => {
+        if (!indexerStatusManager.isCrawlingActive()) return
+        if (!this.isProcessing) {
+          this.processBlocks().catch((err) => {
+            this.logger.error('[DelegationProcessorService] Error in scheduled processBlocks:', err)
+          })
+        }
+      }, crawlInterval)
+
+      this.logger.info(`[DelegationProcessorService] Service started | Interval: ${crawlInterval}ms`)
+    } catch (err) {
+      this.logger.error('[DelegationProcessorService] Failed to start', err)
+    }
+  }
+
+  public async stopped() {
+    if (this.timer) clearInterval(this.timer)
+    this.logger.info('[DelegationProcessorService] Service stopped')
+  }
+
+  private async ensureCheckpoint() {
+    const jobName = BULL_JOB_NAME.HANDLE_DELEGATION
+    const [startBlock] = await BlockCheckpoint.getCheckpoint(jobName, [])
+    return await this.checkpointManager.ensureCheckpoint(jobName, startBlock || 0)
+  }
+
+  @Action({ name: 'processBlocks' })
+  public async processBlocks() {
+    if (this.isProcessing) return
+    if (!indexerStatusManager.isCrawlingActive()) return
+
+    this.isProcessing = true
+    try {
+      const jobName = BULL_JOB_NAME.HANDLE_DELEGATION
+      const [startBlock] = await BlockCheckpoint.getCheckpoint(jobName, [])
+      let lastHeight = startBlock || 0
+      const maxBlockBatch = config.crawlDelegation.chunkSize || 500
+      const queryTimeoutMs = getDbQueryTimeoutMs()
+
+      let hasMore = true
+      while (hasMore) {
+        if (!indexerStatusManager.isCrawlingActive()) break
+
+        let nextBlocks: { height: number; block_result: any }[] = []
+        const currentLastHeight = lastHeight
+        try {
+          nextBlocks = await queryWithAutoRetry(
+            async () =>
+              knex('block')
+                .select('height', knex.raw("data->'block_result' as block_result"))
+                .where('height', '>', currentLastHeight)
+                .orderBy('height', 'asc')
+                .limit(maxBlockBatch)
+                .timeout(queryTimeoutMs),
+            { timeout: queryTimeoutMs, retries: 3 },
+            this.logger
+          )
+        } catch (queryError: any) {
+          if (isStatementTimeoutError(queryError)) {
+            await delay(5000)
+            continue
+          }
+          this.logger.error('[DelegationProcessorService] Error fetching blocks:', queryError)
+          break
+        }
+
+        if (!nextBlocks.length) break
+
+        for (const block of nextBlocks) {
+          if (!indexerStatusManager.isCrawlingActive()) break
+          await this.processBlockEventsInternal(block)
+        }
+
+        const newHeight = nextBlocks[nextBlocks.length - 1].height
+        if (newHeight > lastHeight) {
+          await this.checkpointManager.updateCheckpoint(jobName, newHeight, { logger: this.logger })
+          lastHeight = newHeight
+        }
+
+        if (nextBlocks.length < maxBlockBatch) hasMore = false
+      }
+    } catch (error) {
+      this.logger.error('[DelegationProcessorService] Fatal error in processBlocks:', error)
+    } finally {
+      this.isProcessing = false
+    }
+  }
+
+  @Action({ name: 'processBlockEvents' })
+  public async processBlockEvents(ctx: Context<{ block: Block }>) {
+    return this.processBlockEventsInternal(ctx.params.block)
+  }
+
+  private async processBlockEventsInternal(block: Block | { height: number; block_result: any }) {
+    const blockResult = (block as any).block_result ?? (block as any).data?.block_result
+    if (!blockResult) return
+
+    const finalizeBlockEvents = blockResult?.finalize_block_events || []
+    const endBlockEvents = blockResult?.end_block_events || []
+    const txEvents = blockResult?.txs_results?.flatMap((tx: any) => tx?.events || []) || []
+    const events = [...finalizeBlockEvents, ...txEvents, ...endBlockEvents]
+
+    if (!hasDelegationEvents(events)) return
+
+    await runHeightSyncDE(this.broker, { events }, block.height)
+  }
+}

--- a/test/unit/services/crawl-de/de_event_extraction.spec.ts
+++ b/test/unit/services/crawl-de/de_event_extraction.spec.ts
@@ -1,0 +1,83 @@
+import { Buffer } from 'node:buffer'
+import {
+  extractOperatorAuthorizationTouches,
+  extractVSOperatorAuthorizationIds,
+  hasDelegationEvents,
+} from '../../../../src/modules/de-height-sync/de_height_sync_service'
+
+const b64 = (value: string) => Buffer.from(value, 'utf8').toString('base64')
+
+function event(type: string, attributes: Record<string, string>, encoded = false) {
+  return {
+    type,
+    attributes: Object.entries(attributes).map(([key, value]) =>
+      encoded ? { key: b64(key), value: b64(value) } : { key, value }
+    ),
+  }
+}
+
+describe('de height-sync event extraction', () => {
+  it('detects delegation events among unrelated ones', () => {
+    expect(hasDelegationEvents([event('coin_spent', { amount: '1uvna' })])).toBe(false)
+    expect(hasDelegationEvents([event('grant_operator_authorization', { authz_id: '1' })])).toBe(true)
+  })
+
+  it('extracts an operator-authorization grant from a plain event', () => {
+    const events = [
+      event('grant_operator_authorization', {
+        authz_id: '42',
+        corporation_id: '7',
+        grantee: 'verana1operator',
+        with_feegrant: 'false',
+      }),
+    ]
+
+    expect(extractOperatorAuthorizationTouches(events)).toEqual([
+      { authzId: 42, corporationId: 7, grantee: 'verana1operator', revoked: false },
+    ])
+  })
+
+  it('decodes base64-encoded attributes as emitted in block_result', () => {
+    const events = [
+      event(
+        'grant_operator_authorization',
+        { authz_id: '5', corporation_id: '3', grantee: 'verana1abc' },
+        true
+      ),
+    ]
+
+    expect(extractOperatorAuthorizationTouches(events)).toEqual([
+      { authzId: 5, corporationId: 3, grantee: 'verana1abc', revoked: false },
+    ])
+  })
+
+  it('marks revoke events so the row is deleted, and last touch per id wins', () => {
+    const events = [
+      event('grant_operator_authorization', { authz_id: '9', corporation_id: '3', grantee: 'verana1abc' }),
+      event('revoke_operator_authorization', { authz_id: '9', corporation_id: '3', grantee: 'verana1abc' }),
+    ]
+
+    expect(extractOperatorAuthorizationTouches(events)).toEqual([
+      { authzId: 9, corporationId: 3, grantee: 'verana1abc', revoked: true },
+    ])
+  })
+
+  it('ignores touches with missing or invalid ids', () => {
+    const events = [
+      event('grant_operator_authorization', { corporation_id: '3', grantee: 'verana1abc' }),
+      event('grant_operator_authorization', { authz_id: '0', corporation_id: '3', grantee: 'verana1abc' }),
+    ]
+
+    expect(extractOperatorAuthorizationTouches(events)).toEqual([])
+  })
+
+  it('collects unique VS-operator authorization ids across grant/revoke/update', () => {
+    const events = [
+      event('grant_vs_operator_authorization', { vsoa_id: '1', participant_id: '10' }),
+      event('update_vs_operator_authorization', { vsoa_id: '1', participant_id: '11' }),
+      event('revoke_vs_operator_authorization', { vsoa_id: '2', participant_id: '12' }),
+    ]
+
+    expect(extractVSOperatorAuthorizationIds(events).sort()).toEqual([1, 2])
+  })
+})

--- a/test/unit/services/crawl-de/de_event_extraction.spec.ts
+++ b/test/unit/services/crawl-de/de_event_extraction.spec.ts
@@ -39,11 +39,7 @@ describe('de height-sync event extraction', () => {
 
   it('decodes base64-encoded attributes as emitted in block_result', () => {
     const events = [
-      event(
-        'grant_operator_authorization',
-        { authz_id: '5', corporation_id: '3', grantee: 'verana1abc' },
-        true
-      ),
+      event('grant_operator_authorization', { authz_id: '5', corporation_id: '3', grantee: 'verana1abc' }, true),
     ]
 
     expect(extractOperatorAuthorizationTouches(events)).toEqual([


### PR DESCRIPTION
**Changes:**

* Added an `OpenAPI.json` endpoint and implemented the logic for the new operator authorization endpoint.
* Added a new `crawlDelegation` process to map blockchain updates.
* Created the required database objects and migrations to initialize the table.
* Added new test cases.
