### PR TITLE
fix: extention files problems

### DIFF
--- a/src/modules/de-height-sync/de_height_sync_helpers.ts
+++ b/src/modules/de-height-sync/de_height_sync_helpers.ts
@@ -10,11 +10,15 @@ import type {
   ParticipantAuthorizationRecord as LedgerParticipantAuthorizationRecord,
   VSOperatorAuthorization as LedgerVSOperatorAuthorization,
 } from '@verana-labs/verana-types/codec/verana/de/v1/types'
-import { AllowedMsgAllowance, BasicAllowance, PeriodicAllowance } from 'cosmjs-types/cosmos/feegrant/v1beta1/feegrant'
+import {
+  AllowedMsgAllowance,
+  BasicAllowance,
+  PeriodicAllowance,
+} from 'cosmjs-types/cosmos/feegrant/v1beta1/feegrant.js'
 import {
   QueryClientImpl as FeegrantQueryClientImpl,
   QueryAllowanceRequest,
-} from 'cosmjs-types/cosmos/feegrant/v1beta1/query'
+} from 'cosmjs-types/cosmos/feegrant/v1beta1/query.js'
 import { dateToIsoOrNull } from '../../common/utils/date_utils'
 import { withAbciQueryClient } from '../../common/utils/grpc_query'
 


### PR DESCRIPTION
> @lotharking, I think this broke the indexer, the new dev indexer image (v2.0.0-dev.44, from this PR) crashes at startup: ERR_MODULE_NOT_FOUND for cosmjs-types/cosmos/feegrant/v1beta1/feegrant. The deep imports in de_height_sync_helpers.ts need the .js extension for ESM (feegrant and query both). It broke the vs-agent e2e CI, which pulls the dev tag.