### PR TITLE
feat(pagination): implement limit, min_id and max_id across list and history methods

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1007,7 +1007,7 @@
             "description": "Preferred language for document content"
           },
           {
-            "name": "response_max_size",
+            "name": "limit",
             "in": "query",
             "required": false,
             "schema": {
@@ -1016,7 +1016,27 @@
               "maximum": 1024,
               "default": 64
             },
-            "description": "Maximum number of records to return"
+            "description": "Page size"
+          },
+          {
+            "name": "min_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]+$"
+            },
+            "description": "Cursor: id lower bound (inclusive)"
+          },
+          {
+            "name": "max_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]+$"
+            },
+            "description": "Cursor: id upper bound (exclusive)"
           },
           {
             "name": "modified_after",
@@ -1420,26 +1440,51 @@
             "description": "The Ecosystem ID to retrieve history for"
           },
           {
-            "name": "response_max_size",
+            "name": "limit",
             "in": "query",
             "required": false,
             "schema": {
               "type": "integer",
               "minimum": 1,
-              "maximum": 1000,
+              "maximum": 1024,
               "default": 64
             },
-            "description": "Maximum number of activity items to return (default: 64)"
+            "description": "Page size"
           },
           {
-            "name": "transaction_timestamp_older_than",
+            "name": "min_id",
             "in": "query",
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "pattern": "^[0-9]+$"
             },
-            "description": "ISO 8601 timestamp to paginate results. Returns only activities with timestamps older than this value."
+            "description": "Cursor: ActivityItem.id lower bound (inclusive)"
+          },
+          {
+            "name": "max_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]+$"
+            },
+            "description": "Cursor: ActivityItem.id upper bound (exclusive)"
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "id",
+                "+id",
+                "-id"
+              ],
+              "default": "-id"
+            },
+            "description": "Sort by ActivityItem.id ascending or descending"
           },
           {
             "$ref": "#/components/parameters/At-Block-Height"
@@ -2617,7 +2662,7 @@
             "description": "Filter by validation process state"
           },
           {
-            "name": "response_max_size",
+            "name": "limit",
             "in": "query",
             "required": false,
             "schema": {
@@ -2626,7 +2671,27 @@
               "maximum": 1024,
               "default": 64
             },
-            "description": "Maximum number of records to return"
+            "description": "Page size"
+          },
+          {
+            "name": "min_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]+$"
+            },
+            "description": "Cursor: id lower bound (inclusive)"
+          },
+          {
+            "name": "max_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]+$"
+            },
+            "description": "Cursor: id upper bound (exclusive)"
           },
           {
             "name": "when",
@@ -3582,26 +3647,51 @@
             "description": "Participant ID whose history will be returned"
           },
           {
-            "name": "response_max_size",
+            "name": "limit",
             "in": "query",
             "required": false,
             "schema": {
               "type": "integer",
               "minimum": 1,
-              "maximum": 1000,
+              "maximum": 1024,
               "default": 64
             },
-            "description": "Maximum number of activity items to return (default: 64)"
+            "description": "Page size"
           },
           {
-            "name": "transaction_timestamp_older_than",
+            "name": "min_id",
             "in": "query",
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "pattern": "^[0-9]+$"
             },
-            "description": "ISO 8601 timestamp to paginate results. Returns only activities with timestamps older than this value."
+            "description": "Cursor: ActivityItem.id lower bound (inclusive)"
+          },
+          {
+            "name": "max_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]+$"
+            },
+            "description": "Cursor: ActivityItem.id upper bound (exclusive)"
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "id",
+                "+id",
+                "-id"
+              ],
+              "default": "-id"
+            },
+            "description": "Sort by ActivityItem.id ascending or descending"
           },
           {
             "$ref": "#/components/parameters/At-Block-Height"
@@ -3691,6 +3781,53 @@
               "format": "uuid"
             },
             "description": "Participant Session ID to fetch history for"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1024,
+              "default": 64
+            },
+            "description": "Page size"
+          },
+          {
+            "name": "min_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]+$"
+            },
+            "description": "Cursor: ActivityItem.id lower bound (inclusive)"
+          },
+          {
+            "name": "max_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]+$"
+            },
+            "description": "Cursor: ActivityItem.id upper bound (exclusive)"
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "id",
+                "+id",
+                "-id"
+              ],
+              "default": "-id"
+            },
+            "description": "Sort by ActivityItem.id ascending or descending"
           },
           {
             "$ref": "#/components/parameters/At-Block-Height"
@@ -4533,26 +4670,51 @@
             "description": "Corporation  address to retrieve trust deposit history for"
           },
           {
-            "name": "response_max_size",
+            "name": "limit",
             "in": "query",
             "required": false,
             "schema": {
               "type": "integer",
               "minimum": 1,
-              "maximum": 1000,
+              "maximum": 1024,
               "default": 64
             },
-            "description": "Maximum number of activity items to return (default: 64)"
+            "description": "Page size"
           },
           {
-            "name": "transaction_timestamp_older_than",
+            "name": "min_id",
             "in": "query",
             "required": false,
             "schema": {
               "type": "string",
-              "format": "date-time"
+              "pattern": "^[0-9]+$"
             },
-            "description": "ISO 8601 timestamp to paginate results. Returns only activities with timestamps older than this value."
+            "description": "Cursor: ActivityItem.id lower bound (inclusive)"
+          },
+          {
+            "name": "max_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]+$"
+            },
+            "description": "Cursor: ActivityItem.id upper bound (exclusive)"
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "id",
+                "+id",
+                "-id"
+              ],
+              "default": "-id"
+            },
+            "description": "Sort by ActivityItem.id ascending or descending"
           },
           {
             "$ref": "#/components/parameters/At-Block-Height"
@@ -7968,7 +8130,7 @@
               "$ref": "#/components/schemas/Error"
             },
             "example": {
-              "error": "Invalid parameter: response_max_size must be between 1 and 1024",
+              "error": "Invalid parameter: limit must be between 1 and 1024",
               "code": 400
             }
           }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -169,7 +169,7 @@
               "maximum": 1024,
               "default": 64
             },
-            "description": "Page size"
+            "description": "Page size, 1..1024 (default 64), per the v4 Pagination spec"
           },
           {
             "name": "min_id",
@@ -256,7 +256,7 @@
               "maximum": 1024,
               "default": 64
             },
-            "description": "Page size"
+            "description": "Page size, 1..1024 (default 64), per the v4 Pagination spec"
           },
           {
             "name": "min_id",
@@ -1016,7 +1016,7 @@
               "maximum": 1024,
               "default": 64
             },
-            "description": "Page size"
+            "description": "Page size, 1..1024 (default 64), per the v4 Pagination spec"
           },
           {
             "name": "min_id",
@@ -1449,7 +1449,7 @@
               "maximum": 1024,
               "default": 64
             },
-            "description": "Page size"
+            "description": "Page size, 1..1024 (default 64), per the v4 Pagination spec"
           },
           {
             "name": "min_id",
@@ -1897,7 +1897,7 @@
               "maximum": 1024,
               "default": 64
             },
-            "description": "Page size"
+            "description": "Page size, 1..1024 (default 64), per the v4 Pagination spec"
           },
           {
             "name": "min_id",
@@ -2266,7 +2266,7 @@
               "maximum": 1024,
               "default": 64
             },
-            "description": "Page size"
+            "description": "Page size, 1..1024 (default 64), per the v4 Pagination spec"
           },
           {
             "name": "min_id",
@@ -2671,7 +2671,7 @@
               "maximum": 1024,
               "default": 64
             },
-            "description": "Page size"
+            "description": "Page size, 1..1024 (default 64), per the v4 Pagination spec"
           },
           {
             "name": "min_id",
@@ -3384,7 +3384,8 @@
             "name": "min_id",
             "in": "query",
             "schema": {
-              "type": "integer"
+              "type": "string",
+              "pattern": "^[0-9]+$"
             },
             "description": "Half-open range cursor on id (inclusive)"
           },
@@ -3392,7 +3393,8 @@
             "name": "max_id",
             "in": "query",
             "schema": {
-              "type": "integer"
+              "type": "string",
+              "pattern": "^[0-9]+$"
             },
             "description": "Half-open range cursor on id (exclusive)"
           },
@@ -3656,7 +3658,7 @@
               "maximum": 1024,
               "default": 64
             },
-            "description": "Page size"
+            "description": "Page size, 1..1024 (default 64), per the v4 Pagination spec"
           },
           {
             "name": "min_id",
@@ -3792,7 +3794,7 @@
               "maximum": 1024,
               "default": 64
             },
-            "description": "Page size"
+            "description": "Page size, 1..1024 (default 64), per the v4 Pagination spec"
           },
           {
             "name": "min_id",
@@ -4308,8 +4310,8 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "integer",
-              "format": "uint64"
+              "type": "string",
+              "pattern": "^[0-9]+$"
             },
             "description": "Inclusive lower bound of the id range cursor"
           },
@@ -4318,8 +4320,8 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "integer",
-              "format": "uint64"
+              "type": "string",
+              "pattern": "^[0-9]+$"
             },
             "description": "Exclusive upper bound of the id range cursor"
           },
@@ -4488,8 +4490,8 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "integer",
-              "format": "uint64"
+              "type": "string",
+              "pattern": "^[0-9]+$"
             },
             "description": "Inclusive lower bound of the id range cursor"
           },
@@ -4498,8 +4500,8 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "integer",
-              "format": "uint64"
+              "type": "string",
+              "pattern": "^[0-9]+$"
             },
             "description": "Exclusive upper bound of the id range cursor"
           },
@@ -4679,7 +4681,7 @@
               "maximum": 1024,
               "default": 64
             },
-            "description": "Page size"
+            "description": "Page size, 1..1024 (default 64), per the v4 Pagination spec"
           },
           {
             "name": "min_id",
@@ -5294,7 +5296,7 @@
               "maximum": 1024,
               "default": 64
             },
-            "description": "Page size"
+            "description": "Page size, 1..1024 (default 64), per the v4 Pagination spec"
           },
           {
             "name": "min_id",

--- a/src/services/crawl-co/co_stats.ts
+++ b/src/services/crawl-co/co_stats.ts
@@ -442,6 +442,38 @@ export function compareById(aId: unknown, bId: unknown, direction: 'asc' | 'desc
   return direction === 'asc' ? ascending : -ascending
 }
 
+// Apply the v4 id-cursor page to an in-memory activity timeline: half-open [minId, maxId) on
+// ActivityItem.id (inclusive lower, exclusive upper), ordered by id, capped at limit. Compares as
+// BigInt so uint64 ids stay exact.
+export function paginateActivityItems<T extends { id: unknown }>(
+  items: T[],
+  opts: { minId?: string; maxId?: string; limit: number; direction: 'asc' | 'desc' }
+): T[] {
+  const toBig = (v: unknown): bigint | null => {
+    try {
+      return BigInt(String(v))
+    } catch {
+      return null
+    }
+  }
+  let filtered = items
+  if (opts.minId !== undefined) {
+    const min = toBig(opts.minId)
+    filtered = filtered.filter((a) => {
+      const id = toBig(a.id)
+      return id !== null && id >= (min as bigint)
+    })
+  }
+  if (opts.maxId !== undefined) {
+    const max = toBig(opts.maxId)
+    filtered = filtered.filter((a) => {
+      const id = toBig(a.id)
+      return id !== null && id < (max as bigint)
+    })
+  }
+  return [...filtered].sort((a, b) => compareById(a.id, b.id, opts.direction)).slice(0, opts.limit)
+}
+
 export async function getResolvedBlockHeight(blockHeight?: number): Promise<number> {
   if (typeof blockHeight === 'number') return blockHeight
   const checkpoint = await knex('block_checkpoint').where('job_name', BULL_JOB_NAME.HANDLE_TRANSACTION).first()

--- a/src/services/crawl-cs/cs_database.service.ts
+++ b/src/services/crawl-cs/cs_database.service.ts
@@ -27,7 +27,7 @@ import {
   extractTitleDescriptionFromJsonSchema,
   normalizeCredentialSchemaV4LedgerFields,
 } from '../../modules/cs-height-sync/cs_height_sync_helpers'
-import { compareById, parseIdSortDirection } from '../crawl-co/co_stats'
+import { compareById, paginateActivityItems, parseCorporationListPagination } from '../crawl-co/co_stats'
 import { calculateEcosystemStats } from '../crawl-ec/ec_stats'
 import { calculateCredentialSchemaStats } from './cs_stats'
 
@@ -1487,7 +1487,6 @@ export default class CredentialSchemaDatabaseService extends BullableService {
       min_id: { type: 'number', optional: true },
       max_id: { type: 'number', optional: true },
       limit: { type: 'number', optional: true },
-      response_max_size: { type: 'number', optional: true, default: 64 },
       sort: { type: 'string', optional: true, default: '-id' },
       min_participants: { type: 'number', optional: true },
       max_participants: { type: 'number', optional: true },
@@ -1528,7 +1527,6 @@ export default class CredentialSchemaDatabaseService extends BullableService {
       min_id?: number
       max_id?: number
       limit?: number
-      response_max_size?: number
       sort?: string
       min_participants?: number
       max_participants?: number
@@ -1563,11 +1561,6 @@ export default class CredentialSchemaDatabaseService extends BullableService {
         modified_after: modifiedAfter,
         archived: archivedParam,
         only_active: onlyActive,
-        min_id: minId,
-        max_id: maxId,
-        limit: limitParam,
-        response_max_size: maxSize,
-        sort,
         min_participants: minParticipants,
         max_participants: maxParticipants,
         min_participants_ecosystem: minParticipantsEcosystem,
@@ -1613,17 +1606,13 @@ export default class CredentialSchemaDatabaseService extends BullableService {
       }
       const participantAccount = participantValidation.value
 
-      const sortParsed = parseIdSortDirection(sort)
-      if (!sortParsed.ok) {
-        return ApiResponder.error(ctx, sortParsed.message, 400)
+      const pageParsed = parseCorporationListPagination(ctx.params)
+      if (!pageParsed.ok) {
+        return ApiResponder.error(ctx, pageParsed.message, 400)
       }
-      const sortDirection = sortParsed.direction
+      const { limit, minId: idMin, maxId: idMax, direction: sortDirection } = pageParsed.value
 
       const blockHeight = (ctx.meta as any)?.blockHeight
-      const requestedLimit = limitParam ?? maxSize
-      const limit = Math.min(Math.max(Number(requestedLimit) || 64, 1), 1024)
-      const idMin = minId != null && Number.isFinite(Number(minId)) ? Number(minId) : undefined
-      const idMax = maxId != null && Number.isFinite(Number(maxId)) ? Number(maxId) : undefined
       let modifiedAfterIso: string | undefined
       if (modifiedAfter) {
         if (!isValidISO8601UTC(modifiedAfter)) {
@@ -2302,8 +2291,6 @@ export default class CredentialSchemaDatabaseService extends BullableService {
       max_id: { type: 'number', optional: true },
       limit: { type: 'number', optional: true },
       sort: { type: 'string', optional: true, default: '-id' },
-      response_max_size: { type: 'number', optional: true, default: 64 },
-      transaction_timestamp_older_than: { type: 'string', optional: true },
     },
   })
   async getHistory(
@@ -2313,43 +2300,15 @@ export default class CredentialSchemaDatabaseService extends BullableService {
       max_id?: number
       limit?: number
       sort?: string
-      response_max_size?: number
-      transaction_timestamp_older_than?: string
     }>
   ) {
     try {
-      const {
-        id,
-        min_id: minId,
-        max_id: maxId,
-        limit: limitParam,
-        sort: sortParam = '-id',
-        response_max_size: responseMaxSize = 64,
-        transaction_timestamp_older_than: transactionTimestampOlderThan,
-      } = ctx.params
-
-      const idMin = minId != null && Number.isFinite(Number(minId)) ? Number(minId) : undefined
-      const idMax = maxId != null && Number.isFinite(Number(maxId)) ? Number(maxId) : undefined
-      const effectiveLimit = Math.min(Math.max(Number(limitParam ?? responseMaxSize) || 64, 1), 1024)
-      const sortParsed = parseIdSortDirection(sortParam)
-      if (!sortParsed.ok) {
-        return ApiResponder.error(ctx, sortParsed.message, 400)
+      const { id } = ctx.params
+      const pageParsed = parseCorporationListPagination(ctx.params)
+      if (!pageParsed.ok) {
+        return ApiResponder.error(ctx, pageParsed.message, 400)
       }
-      const sortAscending = sortParsed.direction === 'asc'
-
-      if (transactionTimestampOlderThan) {
-        if (!isValidISO8601UTC(transactionTimestampOlderThan)) {
-          return ApiResponder.error(
-            ctx,
-            "Invalid transaction_timestamp_older_than format. Must be ISO 8601 UTC format (e.g., '2026-01-18T10:00:00Z' or '2026-01-18T10:00:00.000Z')",
-            400
-          )
-        }
-        const timestampDate = new Date(transactionTimestampOlderThan)
-        if (Number.isNaN(timestampDate.getTime())) {
-          return ApiResponder.error(ctx, 'Invalid transaction_timestamp_older_than format', 400)
-        }
-      }
+      const { limit, minId, maxId, direction } = pageParsed.value
 
       const atBlockHeight =
         (ctx.meta as any)?.$headers?.['at-block-height'] || (ctx.meta as any)?.$headers?.['At-Block-Height']
@@ -2359,7 +2318,7 @@ export default class CredentialSchemaDatabaseService extends BullableService {
         return ApiResponder.error(ctx, `Credential schema with id=${id} not found`, 404)
       }
 
-      const fetchSize = idMin !== undefined || idMax !== undefined ? Math.max(effectiveLimit * 4, 256) : effectiveLimit
+      const fetchSize = minId !== undefined || maxId !== undefined ? Math.max(limit * 4, 256) : limit
 
       const activity = await buildActivityTimeline(
         {
@@ -2371,16 +2330,16 @@ export default class CredentialSchemaDatabaseService extends BullableService {
         },
         {
           responseMaxSize: fetchSize,
-          transactionTimestampOlderThan,
           atBlockHeight,
         }
       )
 
-      let activityItems = Array.isArray(activity) ? activity : []
-      if (idMin !== undefined) activityItems = activityItems.filter((a: any) => Number(a.id) >= idMin)
-      if (idMax !== undefined) activityItems = activityItems.filter((a: any) => Number(a.id) < idMax)
-      activityItems = activityItems.sort((a: any, b: any) => compareById(a.id, b.id, sortAscending ? 'asc' : 'desc'))
-      activityItems = activityItems.slice(0, effectiveLimit)
+      const activityItems = paginateActivityItems(Array.isArray(activity) ? activity : [], {
+        minId,
+        maxId,
+        limit,
+        direction,
+      })
 
       const result = {
         entity_type: 'CredentialSchema',

--- a/src/services/crawl-cs/cs_database.service.ts
+++ b/src/services/crawl-cs/cs_database.service.ts
@@ -1484,8 +1484,8 @@ export default class CredentialSchemaDatabaseService extends BullableService {
       issuer_onboarding_mode: { type: 'string', optional: true },
       verifier_onboarding_mode: { type: 'string', optional: true },
       holder_onboarding_mode: { type: 'string', optional: true },
-      min_id: { type: 'number', optional: true },
-      max_id: { type: 'number', optional: true },
+      min_id: { type: 'string', optional: true },
+      max_id: { type: 'string', optional: true },
       limit: { type: 'number', optional: true },
       sort: { type: 'string', optional: true, default: '-id' },
       min_participants: { type: 'number', optional: true },
@@ -1524,8 +1524,8 @@ export default class CredentialSchemaDatabaseService extends BullableService {
       issuer_onboarding_mode?: string
       verifier_onboarding_mode?: string
       holder_onboarding_mode?: string
-      min_id?: number
-      max_id?: number
+      min_id?: string
+      max_id?: string
       limit?: number
       sort?: string
       min_participants?: number
@@ -2287,8 +2287,8 @@ export default class CredentialSchemaDatabaseService extends BullableService {
     name: 'getHistory',
     params: {
       id: { type: 'number', integer: true, positive: true },
-      min_id: { type: 'number', optional: true },
-      max_id: { type: 'number', optional: true },
+      min_id: { type: 'string', optional: true },
+      max_id: { type: 'string', optional: true },
       limit: { type: 'number', optional: true },
       sort: { type: 'string', optional: true, default: '-id' },
     },
@@ -2296,8 +2296,8 @@ export default class CredentialSchemaDatabaseService extends BullableService {
   async getHistory(
     ctx: Context<{
       id: number
-      min_id?: number
-      max_id?: number
+      min_id?: string
+      max_id?: string
       limit?: number
       sort?: string
     }>

--- a/src/services/crawl-de/de_apis.service.ts
+++ b/src/services/crawl-de/de_apis.service.ts
@@ -135,8 +135,8 @@ export default class DelegationApiService extends BaseService {
       only_active: { type: 'boolean', optional: true, convert: true },
       modified_after: { type: 'string', optional: true },
       limit: { type: 'number', integer: true, optional: true, convert: true },
-      min_id: { type: 'number', integer: true, optional: true, convert: true },
-      max_id: { type: 'number', integer: true, optional: true, convert: true },
+      min_id: { type: 'string', optional: true, convert: true },
+      max_id: { type: 'string', optional: true, convert: true },
       sort: { type: 'string', optional: true },
     },
   })
@@ -219,8 +219,8 @@ export default class DelegationApiService extends BaseService {
       only_active: { type: 'boolean', optional: true, convert: true },
       modified_after: { type: 'string', optional: true },
       limit: { type: 'number', integer: true, optional: true, convert: true },
-      min_id: { type: 'number', integer: true, optional: true, convert: true },
-      max_id: { type: 'number', integer: true, optional: true, convert: true },
+      min_id: { type: 'string', optional: true, convert: true },
+      max_id: { type: 'string', optional: true, convert: true },
       sort: { type: 'string', optional: true },
     },
   })

--- a/src/services/crawl-ec/ec_database.service.ts
+++ b/src/services/crawl-ec/ec_database.service.ts
@@ -1483,8 +1483,8 @@ export default class EcosystemDatabaseService extends BaseService {
       gf_data: { type: 'string', optional: true },
       preferred_language: { type: 'string', optional: true },
       limit: { type: 'number', optional: true },
-      min_id: { type: 'number', optional: true },
-      max_id: { type: 'number', optional: true },
+      min_id: { type: 'string', optional: true },
+      max_id: { type: 'string', optional: true },
       sort: { type: 'string', optional: true },
       min_active_schemas: { type: 'number', optional: true },
       max_active_schemas: { type: 'number', optional: true },
@@ -1527,8 +1527,8 @@ export default class EcosystemDatabaseService extends BaseService {
       gf_data?: string
       preferred_language?: string
       limit?: number
-      min_id?: number
-      max_id?: number
+      min_id?: string
+      max_id?: string
       sort?: string
       min_active_schemas?: number
       max_active_schemas?: number

--- a/src/services/crawl-ec/ec_database.service.ts
+++ b/src/services/crawl-ec/ec_database.service.ts
@@ -23,7 +23,7 @@ import {
 } from '../../common/utils/installed_table_columns'
 import { mapEcosystemApiFields } from '../../common/vpr-v4-mapping'
 import { Ecosystem } from '../../models/ecosystem'
-import { compareById, type GfDataMode, parseGfDataMode, parseIdSortDirection } from '../crawl-co/co_stats'
+import { compareById, type GfDataMode, parseCorporationListPagination, parseGfDataMode } from '../crawl-co/co_stats'
 import { resolveCorporationIdByAddress } from '../crawl-co/corporation_resolve'
 import { enrichTrustDataDeep, parseTrustDataMode } from '../resolver/trust-data-enrichment'
 import { calculateEcosystemStats, TR_STATS_FIELDS } from './ec_stats'
@@ -1482,7 +1482,9 @@ export default class EcosystemDatabaseService extends BaseService {
       active_gf_only: { type: 'any', optional: true },
       gf_data: { type: 'string', optional: true },
       preferred_language: { type: 'string', optional: true },
-      response_max_size: { type: 'number', optional: true, default: 64 },
+      limit: { type: 'number', optional: true },
+      min_id: { type: 'number', optional: true },
+      max_id: { type: 'number', optional: true },
       sort: { type: 'string', optional: true },
       min_active_schemas: { type: 'number', optional: true },
       max_active_schemas: { type: 'number', optional: true },
@@ -1524,7 +1526,9 @@ export default class EcosystemDatabaseService extends BaseService {
       active_gf_only?: string | boolean
       gf_data?: string
       preferred_language?: string
-      response_max_size?: number
+      limit?: number
+      min_id?: number
+      max_id?: number
       sort?: string
       min_active_schemas?: number
       max_active_schemas?: number
@@ -1564,8 +1568,6 @@ export default class EcosystemDatabaseService extends BaseService {
         preferred_language: preferredLanguage,
         archived: archivedRaw,
         only_active: onlyActiveRaw,
-        response_max_size: responseMaxSizeRaw,
-        sort,
         min_active_schemas: minActiveSchemas,
         max_active_schemas: maxActiveSchemas,
         min_participants: minParticipants,
@@ -1632,11 +1634,11 @@ export default class EcosystemDatabaseService extends BaseService {
         }
       }
 
-      const sortParsed = parseIdSortDirection(sort)
-      if (!sortParsed.ok) {
-        return ApiResponder.error(ctx, sortParsed.message, 400)
+      const pageParsed = parseCorporationListPagination(ctx.params)
+      if (!pageParsed.ok) {
+        return ApiResponder.error(ctx, pageParsed.message, 400)
       }
-      const sortDirection = sortParsed.direction
+      const { limit, minId: idMin, maxId: idMax, direction: sortDirection } = pageParsed.value
 
       const hasArchived = archivedRaw !== undefined && archivedRaw !== null && String(archivedRaw).trim() !== ''
       let hasOnlyActive: boolean
@@ -1650,12 +1652,6 @@ export default class EcosystemDatabaseService extends BaseService {
       }
       const activeGfOnly = gfDataMode === 'only_active'
       const blockHeight = (ctx.meta as any)?.blockHeight
-
-      const responseMaxSize = !responseMaxSizeRaw ? 64 : Math.min(Math.max(responseMaxSizeRaw, 1), 1024)
-
-      if (responseMaxSizeRaw && (responseMaxSizeRaw < 1 || responseMaxSizeRaw > 1024)) {
-        return ApiResponder.error(ctx, 'response_max_size must be between 1 and 1024', 400)
-      }
 
       const metricFilters = {
         minActiveSchemas,
@@ -1719,8 +1715,10 @@ export default class EcosystemDatabaseService extends BaseService {
             .select(knex.raw('ROW_NUMBER() OVER (PARTITION BY ecosystem_id ORDER BY height DESC, id DESC) as rn'))
             .from(snapshotBase.as('snap'))
           const snapshotListQuery = knex.from(ranked.as('r')).where('rn', 1)
+          if (idMin !== undefined) snapshotListQuery.where('ecosystem_id', '>=', idMin)
+          if (idMax !== undefined) snapshotListQuery.where('ecosystem_id', '<', idMax)
           snapshotListQuery.orderBy('ecosystem_id', sortDirection)
-          const latestSnapshots = await snapshotListQuery.limit(Math.max(responseMaxSize * 2, 256))
+          const latestSnapshots = await snapshotListQuery.limit(Math.max(limit * 2, 256))
           const registriesWithStats = (latestSnapshots as any[]).map((row: any) => {
             let versions = Array.isArray(row.versions_snapshot) ? row.versions_snapshot : []
             if (activeGfOnly) {
@@ -1771,7 +1769,7 @@ export default class EcosystemDatabaseService extends BaseService {
             }
           })
           const filteredRegistries = this.applyMetricFiltersToRegistries(registriesWithStats, metricFilters)
-          const sortedRegistries = this.sortRegistries(filteredRegistries, sortDirection, responseMaxSize)
+          const sortedRegistries = this.sortRegistries(filteredRegistries, sortDirection, limit)
           const responsePayload = this.applyGfDataModeToResponsePayload(
             {
               ecosystems: sortedRegistries.map((r) => mapEcosystemApiFields(r as Record<string, unknown>)),
@@ -1822,10 +1820,12 @@ export default class EcosystemDatabaseService extends BaseService {
           .as('ranked')
 
         const latestEcosystemHistoryQuery = knex.from(rankedSubquery).where('rn', 1)
+        if (idMin !== undefined) latestEcosystemHistoryQuery.where('ecosystem_id', '>=', idMin)
+        if (idMax !== undefined) latestEcosystemHistoryQuery.where('ecosystem_id', '<', idMax)
 
         const sortedHistory = (await latestEcosystemHistoryQuery
           .orderBy('ecosystem_id', sortDirection)
-          .limit(Math.max(responseMaxSize * 2, 256))) as any[]
+          .limit(Math.max(limit * 2, 256))) as any[]
 
         if (sortedHistory.length === 0) {
           return ApiResponder.success(ctx, { ecosystems: [] }, 200)
@@ -1880,7 +1880,7 @@ export default class EcosystemDatabaseService extends BaseService {
           metricFilters
         )
 
-        const sortedRegistries = this.sortRegistries(filteredRegistries, sortDirection, responseMaxSize)
+        const sortedRegistries = this.sortRegistries(filteredRegistries, sortDirection, limit)
 
         const responsePayload = this.applyGfDataModeToResponsePayload(
           {
@@ -1967,8 +1967,10 @@ export default class EcosystemDatabaseService extends BaseService {
           if (onlyActive) batchQuery = batchQuery.whereNull('archived')
           else batchQuery = batchQuery.whereNotNull('archived')
         }
+        if (idMin !== undefined) batchQuery = batchQuery.where('id', '>=', idMin)
+        if (idMax !== undefined) batchQuery = batchQuery.where('id', '<', idMax)
         batchQuery = batchQuery.orderBy('id', sortDirection)
-        const ecosystemRows = (await batchQuery.limit(Math.max(responseMaxSize * 2, 256))) as any[]
+        const ecosystemRows = (await batchQuery.limit(Math.max(limit * 2, 256))) as any[]
         if (ecosystemRows.length === 0) {
           return ApiResponder.success(ctx, { ecosystems: [] }, 200)
         }
@@ -2064,7 +2066,7 @@ export default class EcosystemDatabaseService extends BaseService {
           }
         })
         const filteredBatch = this.applyMetricFiltersToRegistries(batchRegistries, metricFilters)
-        const sortedBatch = this.sortRegistries(filteredBatch, sortDirection, responseMaxSize)
+        const sortedBatch = this.sortRegistries(filteredBatch, sortDirection, limit)
         const responsePayload = this.applyGfDataModeToResponsePayload(
           {
             ecosystems: sortedBatch.map((r) => mapEcosystemApiFields(r as Record<string, unknown>)),
@@ -2133,8 +2135,10 @@ export default class EcosystemDatabaseService extends BaseService {
         }
       }
 
+      if (idMin !== undefined) query = query.where('id', '>=', idMin)
+      if (idMax !== undefined) query = query.where('id', '<', idMax)
       query = query.orderBy('id', sortDirection)
-      const registries = await query.limit(Math.max(responseMaxSize * 2, 256))
+      const registries = await query.limit(Math.max(limit * 2, 256))
 
       const registriesWithStats = registries.map((ec) => {
         const plain = ec.toJSON()
@@ -2184,7 +2188,7 @@ export default class EcosystemDatabaseService extends BaseService {
         }
       })
 
-      const sortedRegistries = this.sortRegistries(registriesWithStats, sortDirection, responseMaxSize)
+      const sortedRegistries = this.sortRegistries(registriesWithStats, sortDirection, limit)
 
       const responsePayload = this.applyGfDataModeToResponsePayload(
         {

--- a/src/services/crawl-ec/ec_history.service.ts
+++ b/src/services/crawl-ec/ec_history.service.ts
@@ -409,7 +409,7 @@ export default class EcosystemHistoryService extends BaseService {
 
   @Action()
   public async getTRHistory(
-    ctx: Context<{ ecosystem_id: number; min_id?: number; max_id?: number; limit?: number; sort?: string }>
+    ctx: Context<{ ecosystem_id: number; min_id?: string; max_id?: string; limit?: number; sort?: string }>
   ) {
     try {
       const { ecosystem_id: ecosystemId } = ctx.params

--- a/src/services/crawl-ec/ec_history.service.ts
+++ b/src/services/crawl-ec/ec_history.service.ts
@@ -5,8 +5,8 @@ import BaseService from '../../base/base.service'
 import { SERVICE } from '../../common'
 import { buildActivityTimeline } from '../../common/utils/activity_timeline_helper'
 import ApiResponder from '../../common/utils/apiResponse'
-import { isValidISO8601UTC } from '../../common/utils/date_utils'
 import knex from '../../common/utils/db_connection'
+import { paginateActivityItems, parseCorporationListPagination } from '../crawl-co/co_stats'
 
 @Service({
   name: SERVICE.V1.EcosystemHistoryService.key,
@@ -240,25 +240,17 @@ export default class EcosystemHistoryService extends BaseService {
 
   private async getTRHistoryFromSnapshot(
     ecosystemId: number,
-    responseMaxSize: number,
-    transactionTimestampOlderThan?: string,
+    fetchSize: number,
     atBlockHeight?: string
   ): Promise<any[]> {
     let query = knex('ecosystem_snapshot')
       .where({ ecosystem_id: ecosystemId })
       .orderBy('height', 'desc')
-      .limit(responseMaxSize)
+      .limit(fetchSize)
 
     if (atBlockHeight) {
       const h = parseInt(String(atBlockHeight), 10)
       if (!Number.isNaN(h)) query = query.where('height', '<=', h)
-    }
-
-    if (transactionTimestampOlderThan) {
-      const ts = new Date(transactionTimestampOlderThan)
-      if (!Number.isNaN(ts.getTime())) {
-        query = query.where('created_at', '<', ts)
-      }
     }
 
     const rows = await query.select(
@@ -417,49 +409,32 @@ export default class EcosystemHistoryService extends BaseService {
 
   @Action()
   public async getTRHistory(
-    ctx: Context<{ ecosystem_id: number; response_max_size?: number; transaction_timestamp_older_than?: string }>
+    ctx: Context<{ ecosystem_id: number; min_id?: number; max_id?: number; limit?: number; sort?: string }>
   ) {
     try {
-      const {
-        ecosystem_id: ecosystemId,
-        response_max_size: responseMaxSize = 64,
-        transaction_timestamp_older_than: transactionTimestampOlderThan,
-      } = ctx.params
-
-      if (transactionTimestampOlderThan) {
-        if (!isValidISO8601UTC(transactionTimestampOlderThan)) {
-          return ApiResponder.error(
-            ctx,
-            "Invalid transaction_timestamp_older_than format. Must be ISO 8601 UTC format (e.g., '2026-01-18T10:00:00Z' or '2026-01-18T10:00:00.000Z')",
-            400
-          )
-        }
-        const timestampDate = new Date(transactionTimestampOlderThan)
-        if (Number.isNaN(timestampDate.getTime())) {
-          return ApiResponder.error(ctx, 'Invalid transaction_timestamp_older_than format', 400)
-        }
+      const { ecosystem_id: ecosystemId } = ctx.params
+      const pageParsed = parseCorporationListPagination(ctx.params)
+      if (!pageParsed.ok) {
+        return ApiResponder.error(ctx, pageParsed.message, 400)
       }
+      const { limit, minId, maxId, direction } = pageParsed.value
 
       const atBlockHeight =
         (ctx.meta as any)?.$headers?.['at-block-height'] || (ctx.meta as any)?.$headers?.['At-Block-Height']
       const useHeightSync = process.env.USE_HEIGHT_SYNC_TR === 'true'
+      const fetchSize = minId !== undefined || maxId !== undefined ? Math.max(limit * 4, 256) : limit
 
       const ec = await knex('ecosystem').where('id', ecosystemId).first()
       if (!ec) return ApiResponder.error(ctx, 'Trust Registry not found', 404)
 
       if (useHeightSync) {
-        const activity = await this.getTRHistoryFromSnapshot(
-          ecosystemId,
-          responseMaxSize,
-          transactionTimestampOlderThan,
-          atBlockHeight
-        )
+        const snapshotActivity = await this.getTRHistoryFromSnapshot(ecosystemId, fetchSize, atBlockHeight)
         return ApiResponder.success(
           ctx,
           {
             entity_type: 'Ecosystem',
             entity_id: String(ecosystemId),
-            activity,
+            activity: paginateActivityItems(snapshotActivity, { minId, maxId, limit, direction }),
           },
           200
         )
@@ -490,14 +465,15 @@ export default class EcosystemHistoryService extends BaseService {
           ],
         },
         {
-          responseMaxSize,
-          transactionTimestampOlderThan,
+          responseMaxSize: fetchSize,
           atBlockHeight,
         }
       )
 
+      const page = paginateActivityItems(Array.isArray(activity) ? activity : [], { minId, maxId, limit, direction })
+
       const enrichedActivity = await Promise.all(
-        (activity || []).map(async (item: any) => {
+        page.map(async (item: any) => {
           const blockHeight = item.block_height ? parseInt(item.block_height, 10) : null
 
           const originalChanges = item.changes || {}

--- a/src/services/crawl-pp/pp_apis.service.ts
+++ b/src/services/crawl-pp/pp_apis.service.ts
@@ -1384,8 +1384,8 @@ export default class ParticipantAPIService extends BullableService {
       modified_after: { type: 'string', optional: true },
       op_state: { type: 'string', optional: true },
       limit: { type: 'number', optional: true },
-      min_id: { type: 'number', optional: true },
-      max_id: { type: 'number', optional: true },
+      min_id: { type: 'string', optional: true },
+      max_id: { type: 'string', optional: true },
       when: { type: 'string', optional: true },
       sort: { type: 'string', optional: true },
       min_participants: { type: 'number', integer: true, optional: true },
@@ -2215,14 +2215,14 @@ export default class ParticipantAPIService extends BullableService {
     rest: 'GET history/:id',
     params: {
       id: { type: 'number', integer: true },
-      min_id: { type: 'number', optional: true },
-      max_id: { type: 'number', optional: true },
+      min_id: { type: 'string', optional: true },
+      max_id: { type: 'string', optional: true },
       limit: { type: 'number', optional: true },
       sort: { type: 'string', optional: true, default: '-id' },
     },
   })
   async getParticipantHistory(
-    ctx: Context<{ id: number; min_id?: number; max_id?: number; limit?: number; sort?: string }>
+    ctx: Context<{ id: number; min_id?: string; max_id?: string; limit?: number; sort?: string }>
   ) {
     try {
       const { id } = ctx.params
@@ -2409,14 +2409,14 @@ export default class ParticipantAPIService extends BullableService {
     rest: 'GET participant-session-history/:id',
     params: {
       id: { type: 'string', pattern: /^[0-9a-fA-F-]+$/ },
-      min_id: { type: 'number', optional: true },
-      max_id: { type: 'number', optional: true },
+      min_id: { type: 'string', optional: true },
+      max_id: { type: 'string', optional: true },
       limit: { type: 'number', optional: true },
       sort: { type: 'string', optional: true, default: '-id' },
     },
   })
   async getParticipantSessionHistory(
-    ctx: Context<{ id: string; min_id?: number; max_id?: number; limit?: number; sort?: string }>
+    ctx: Context<{ id: string; min_id?: string; max_id?: string; limit?: number; sort?: string }>
   ) {
     try {
       const { id } = ctx.params

--- a/src/services/crawl-pp/pp_apis.service.ts
+++ b/src/services/crawl-pp/pp_apis.service.ts
@@ -17,7 +17,7 @@ import {
 import { getModuleParams, getModuleParamsAction } from '../../common/utils/params_service'
 import { mapParticipantType, normalizeParticipantEmptyStringsToNull } from '../../common/utils/utils'
 import { mapParticipantApiFields } from '../../common/vpr-v4-mapping'
-import { compareById, parseIdSortDirection } from '../crawl-co/co_stats'
+import { compareById, paginateActivityItems, parseCorporationListPagination } from '../crawl-co/co_stats'
 import { resolveCorporationIdByAddress } from '../crawl-co/corporation_resolve'
 import { enrichTrustDataDeep, parseTrustDataMode, type TrustDataMode } from '../resolver/trust-data-enrichment'
 import {
@@ -1383,7 +1383,9 @@ export default class ParticipantAPIService extends BullableService {
       only_repaid: { type: 'any', optional: true },
       modified_after: { type: 'string', optional: true },
       op_state: { type: 'string', optional: true },
-      response_max_size: { type: 'number', optional: true, default: 64 },
+      limit: { type: 'number', optional: true },
+      min_id: { type: 'number', optional: true },
+      max_id: { type: 'number', optional: true },
       when: { type: 'string', optional: true },
       sort: { type: 'string', optional: true },
       min_participants: { type: 'number', integer: true, optional: true },
@@ -1457,7 +1459,12 @@ export default class ParticipantAPIService extends BullableService {
       const blockHeight = getBlockHeight(ctx)
       const useHistoryQuery = this.shouldUseHistoryQuery(ctx, blockHeight)
       const now = new Date().toISOString()
-      const limit = Math.min(Math.max(normalizedParams.response_max_size || 64, 1), 1024)
+
+      const pageParsed = parseCorporationListPagination(normalizedParams)
+      if (!pageParsed.ok) {
+        return ApiResponder.error(ctx, pageParsed.message, 400)
+      }
+      const { limit, minId: idMin, maxId: idMax, direction: sortDirection } = pageParsed.value
 
       perfMeta = {
         did: normalizedParams.did ? '[set]' : undefined,
@@ -1466,12 +1473,6 @@ export default class ParticipantAPIService extends BullableService {
         limit,
         blockHeight: useHistoryQuery ? blockHeight : undefined,
       }
-
-      const sortParsed = parseIdSortDirection(normalizedParams.sort)
-      if (!sortParsed.ok) {
-        return ApiResponder.error(ctx, sortParsed.message, 400)
-      }
-      const sortDirection = sortParsed.direction
 
       const onlyValid = normalizedParams.only_valid === 'true' || normalizedParams.only_valid === true
       const onlySlashed = normalizedParams.only_slashed === 'true' || normalizedParams.only_slashed === true
@@ -1682,6 +1683,8 @@ export default class ParticipantAPIService extends BullableService {
           historyRequiresMetricPostFilter
         const historyFetchLimit = needsPostEnrichFiltering ? Math.min(Math.max(limit * 10, 500), 5000) : limit
 
+        if (idMin !== undefined) historyQuery.where('id', '>=', idMin)
+        if (idMax !== undefined) historyQuery.where('id', '<', idMax)
         const orderedHistoryQuery = historyQuery.orderBy('id', sortDirection)
         const historyRows = await orderedHistoryQuery.limit(historyFetchLimit)
         perfMarks.dbQueryEnd = Date.now()
@@ -1919,6 +1922,8 @@ export default class ParticipantAPIService extends BullableService {
         (!liveParticipantStatePushdown.pushedDown && !!normalizedParams.participant_state) ||
         liveMetricPushdown.requiresPostFilter
       const liveFetchLimit = liveNeedsPostEnrich ? Math.min(Math.max(limit * 10, 500), 5000) : limit
+      if (idMin !== undefined) query.where('id', '>=', idMin)
+      if (idMax !== undefined) query.where('id', '<', idMax)
       const orderedQuery = query.orderBy('id', sortDirection)
       perfMarks.dbQueryStart = Date.now()
       const results = await orderedQuery.limit(liveFetchLimit)
@@ -2210,19 +2215,22 @@ export default class ParticipantAPIService extends BullableService {
     rest: 'GET history/:id',
     params: {
       id: { type: 'number', integer: true },
-      response_max_size: { type: 'number', optional: true, default: 64 },
-      transaction_timestamp_older_than: { type: 'string', optional: true },
+      min_id: { type: 'number', optional: true },
+      max_id: { type: 'number', optional: true },
+      limit: { type: 'number', optional: true },
+      sort: { type: 'string', optional: true, default: '-id' },
     },
   })
   async getParticipantHistory(
-    ctx: Context<{ id: number; response_max_size?: number; transaction_timestamp_older_than?: string }>
+    ctx: Context<{ id: number; min_id?: number; max_id?: number; limit?: number; sort?: string }>
   ) {
     try {
-      const {
-        id,
-        response_max_size: responseMaxSize = 64,
-        transaction_timestamp_older_than: transactionTimestampOlderThan,
-      } = ctx.params
+      const { id } = ctx.params
+      const pageParsed = parseCorporationListPagination(ctx.params)
+      if (!pageParsed.ok) {
+        return ApiResponder.error(ctx, pageParsed.message, 400)
+      }
+      const { limit, minId, maxId, direction } = pageParsed.value
       const atBlockHeight =
         (ctx.meta as any)?.$headers?.['at-block-height'] || (ctx.meta as any)?.$headers?.['At-Block-Height']
 
@@ -2231,6 +2239,7 @@ export default class ParticipantAPIService extends BullableService {
         return ApiResponder.error(ctx, `Participant with id=${id} not found`, 404)
       }
 
+      const fetchSize = minId !== undefined || maxId !== undefined ? Math.max(limit * 4, 256) : limit
       const activity = await buildActivityTimeline(
         {
           entityType: 'Participant',
@@ -2240,8 +2249,7 @@ export default class ParticipantAPIService extends BullableService {
           msgTypePrefixes: ['/verana.pp.v1'],
         },
         {
-          responseMaxSize,
-          transactionTimestampOlderThan,
+          responseMaxSize: fetchSize,
           atBlockHeight,
         }
       )
@@ -2249,7 +2257,7 @@ export default class ParticipantAPIService extends BullableService {
       const result = {
         entity_type: 'Participant',
         entity_id: String(id),
-        activity: activity || [],
+        activity: paginateActivityItems(Array.isArray(activity) ? activity : [], { minId, maxId, limit, direction }),
       }
 
       return ApiResponder.success(ctx, result, 200)
@@ -2401,33 +2409,22 @@ export default class ParticipantAPIService extends BullableService {
     rest: 'GET participant-session-history/:id',
     params: {
       id: { type: 'string', pattern: /^[0-9a-fA-F-]+$/ },
-      response_max_size: { type: 'number', optional: true, default: 64 },
-      transaction_timestamp_older_than: { type: 'string', optional: true },
+      min_id: { type: 'number', optional: true },
+      max_id: { type: 'number', optional: true },
+      limit: { type: 'number', optional: true },
+      sort: { type: 'string', optional: true, default: '-id' },
     },
   })
   async getParticipantSessionHistory(
-    ctx: Context<{ id: string; response_max_size?: number; transaction_timestamp_older_than?: string }>
+    ctx: Context<{ id: string; min_id?: number; max_id?: number; limit?: number; sort?: string }>
   ) {
     try {
-      const {
-        id,
-        response_max_size: responseMaxSize = 64,
-        transaction_timestamp_older_than: transactionTimestampOlderThan,
-      } = ctx.params
-
-      if (transactionTimestampOlderThan) {
-        if (!isValidISO8601UTC(transactionTimestampOlderThan)) {
-          return ApiResponder.error(
-            ctx,
-            "Invalid transaction_timestamp_older_than format. Must be ISO 8601 UTC format (e.g., '2026-01-18T10:00:00Z' or '2026-01-18T10:00:00.000Z')",
-            400
-          )
-        }
-        const timestampDate = new Date(transactionTimestampOlderThan)
-        if (Number.isNaN(timestampDate.getTime())) {
-          return ApiResponder.error(ctx, 'Invalid transaction_timestamp_older_than format', 400)
-        }
+      const { id } = ctx.params
+      const pageParsed = parseCorporationListPagination(ctx.params)
+      if (!pageParsed.ok) {
+        return ApiResponder.error(ctx, pageParsed.message, 400)
       }
+      const { limit, minId, maxId, direction } = pageParsed.value
 
       const atBlockHeight =
         (ctx.meta as any)?.$headers?.['at-block-height'] || (ctx.meta as any)?.$headers?.['At-Block-Height']
@@ -2440,6 +2437,7 @@ export default class ParticipantAPIService extends BullableService {
         return ApiResponder.error(ctx, `ParticipantSession ${id} not found`, 404)
       }
 
+      const fetchSize = minId !== undefined || maxId !== undefined ? Math.max(limit * 4, 256) : limit
       const activity = await buildActivityTimeline(
         {
           entityType: 'ParticipantSession',
@@ -2449,8 +2447,7 @@ export default class ParticipantAPIService extends BullableService {
           msgTypePrefixes: ['/verana.pp.v1'],
         },
         {
-          responseMaxSize,
-          transactionTimestampOlderThan,
+          responseMaxSize: fetchSize,
           atBlockHeight,
         }
       )
@@ -2458,7 +2455,7 @@ export default class ParticipantAPIService extends BullableService {
       const result = {
         entity_type: 'ParticipantSession',
         entity_id: id,
-        activity: activity || [],
+        activity: paginateActivityItems(Array.isArray(activity) ? activity : [], { minId, maxId, limit, direction }),
       }
 
       return ApiResponder.success(ctx, result, 200)

--- a/src/services/crawl-td/td_apis.service.ts
+++ b/src/services/crawl-td/td_apis.service.ts
@@ -5,11 +5,11 @@ import { MODULE_DISPLAY_NAMES, ModulesParamsNamesTypes, SERVICE } from '../../co
 import { validateRequiredAccountParam } from '../../common/utils/accountValidation'
 import { buildActivityTimeline } from '../../common/utils/activity_timeline_helper'
 import ApiResponder from '../../common/utils/apiResponse'
-import { isValidISO8601UTC } from '../../common/utils/date_utils'
 import knex from '../../common/utils/db_connection'
 import { getModuleParamsAction } from '../../common/utils/params_service'
 import { mapTrustDepositApiFields } from '../../common/vpr-v4-mapping'
 import TrustDeposit from '../../models/trust_deposit'
+import { paginateActivityItems, parseCorporationListPagination } from '../crawl-co/co_stats'
 
 @Service({
   name: SERVICE.V1.TrustDepositApiService.key,
@@ -109,12 +109,14 @@ export default class TrustDepositApiService extends BullableService {
     name: 'getTrustDepositHistory',
     params: {
       corporation: { type: 'string', min: 5 },
-      response_max_size: { type: 'number', optional: true, default: 64 },
-      transaction_timestamp_older_than: { type: 'string', optional: true },
+      min_id: { type: 'number', optional: true },
+      max_id: { type: 'number', optional: true },
+      limit: { type: 'number', optional: true },
+      sort: { type: 'string', optional: true, default: '-id' },
     },
   })
   public async getTrustDepositHistory(
-    ctx: Context<{ corporation: string; response_max_size?: number; transaction_timestamp_older_than?: string }>
+    ctx: Context<{ corporation: string; min_id?: number; max_id?: number; limit?: number; sort?: string }>
   ) {
     try {
       const accountValidation = validateRequiredAccountParam(ctx.params.corporation, 'corporation')
@@ -122,24 +124,11 @@ export default class TrustDepositApiService extends BullableService {
         return ApiResponder.error(ctx, accountValidation.error, 400)
       }
       const account = accountValidation.value
-      const {
-        response_max_size: responseMaxSize = 64,
-        transaction_timestamp_older_than: transactionTimestampOlderThan,
-      } = ctx.params
-
-      if (transactionTimestampOlderThan) {
-        if (!isValidISO8601UTC(transactionTimestampOlderThan)) {
-          return ApiResponder.error(
-            ctx,
-            "Invalid transaction_timestamp_older_than format. Must be ISO 8601 UTC format (e.g., '2026-01-18T10:00:00Z' or '2026-01-18T10:00:00.000Z')",
-            400
-          )
-        }
-        const timestampDate = new Date(transactionTimestampOlderThan)
-        if (Number.isNaN(timestampDate.getTime())) {
-          return ApiResponder.error(ctx, 'Invalid transaction_timestamp_older_than format', 400)
-        }
+      const pageParsed = parseCorporationListPagination(ctx.params)
+      if (!pageParsed.ok) {
+        return ApiResponder.error(ctx, pageParsed.message, 400)
       }
+      const { limit, minId, maxId, direction } = pageParsed.value
 
       const atBlockHeight =
         (ctx.meta as any)?.$headers?.['at-block-height'] || (ctx.meta as any)?.$headers?.['At-Block-Height']
@@ -163,6 +152,7 @@ export default class TrustDepositApiService extends BullableService {
         return ApiResponder.error(ctx, `No trust deposit found for corporation: ${account}`, 404)
       }
 
+      const fetchSize = minId !== undefined || maxId !== undefined ? Math.max(limit * 4, 256) : limit
       const activity = await buildActivityTimeline(
         {
           entityType: 'TrustDeposit',
@@ -172,8 +162,7 @@ export default class TrustDepositApiService extends BullableService {
           msgTypePrefixes: ['/verana.td.v1'],
         },
         {
-          responseMaxSize,
-          transactionTimestampOlderThan,
+          responseMaxSize: fetchSize,
           atBlockHeight,
         }
       )
@@ -181,7 +170,7 @@ export default class TrustDepositApiService extends BullableService {
       const result = {
         entity_type: 'TrustDeposit',
         entity_id: account,
-        activity: activity || [],
+        activity: paginateActivityItems(Array.isArray(activity) ? activity : [], { minId, maxId, limit, direction }),
       }
 
       return ApiResponder.success(ctx, result, 200)

--- a/src/services/crawl-td/td_apis.service.ts
+++ b/src/services/crawl-td/td_apis.service.ts
@@ -109,14 +109,14 @@ export default class TrustDepositApiService extends BullableService {
     name: 'getTrustDepositHistory',
     params: {
       corporation: { type: 'string', min: 5 },
-      min_id: { type: 'number', optional: true },
-      max_id: { type: 'number', optional: true },
+      min_id: { type: 'string', optional: true },
+      max_id: { type: 'string', optional: true },
       limit: { type: 'number', optional: true },
       sort: { type: 'string', optional: true, default: '-id' },
     },
   })
   public async getTrustDepositHistory(
-    ctx: Context<{ corporation: string; min_id?: number; max_id?: number; limit?: number; sort?: string }>
+    ctx: Context<{ corporation: string; min_id?: string; max_id?: string; limit?: number; sort?: string }>
   ) {
     try {
       const accountValidation = validateRequiredAccountParam(ctx.params.corporation, 'corporation')

--- a/src/services/crawl-xr/xr_apis.service.ts
+++ b/src/services/crawl-xr/xr_apis.service.ts
@@ -210,8 +210,8 @@ export default class ExchangeRateApiService extends BaseService {
       state: { type: 'boolean', optional: true, convert: true },
       expire: { type: 'string', optional: true },
       limit: { type: 'number', integer: true, optional: true, convert: true },
-      min_id: { type: 'number', integer: true, optional: true, convert: true },
-      max_id: { type: 'number', integer: true, optional: true, convert: true },
+      min_id: { type: 'string', optional: true, convert: true },
+      max_id: { type: 'string', optional: true, convert: true },
       sort: { type: 'string', optional: true },
     },
   })

--- a/test/integration/api-endpoints.spec.ts
+++ b/test/integration/api-endpoints.spec.ts
@@ -294,19 +294,19 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
 
   describe('API Response Timing Headers', () => {
     itIf('should include x-response-time-ms for participant list endpoint', async () => {
-      const response = await testEndpoint('GET', '/v4/participant/list', { response_max_size: 1 })
+      const response = await testEndpoint('GET', '/v4/participant/list', { limit: 1 })
       expect(response.status).not.toBeGreaterThanOrEqual(500)
       expectResponseTimeHeader(response)
     })
 
     itIf('should include x-response-time-ms for EC list endpoint', async () => {
-      const response = await testEndpoint('GET', '/v4/ecosystem/list', { response_max_size: 1 })
+      const response = await testEndpoint('GET', '/v4/ecosystem/list', { limit: 1 })
       expect(response.status).not.toBeGreaterThanOrEqual(500)
       expectResponseTimeHeader(response)
     })
 
     itIf('should include x-response-time-ms for CS list endpoint', async () => {
-      const response = await testEndpoint('GET', '/v4/credential-schema/list', { response_max_size: 1 })
+      const response = await testEndpoint('GET', '/v4/credential-schema/list', { limit: 1 })
       expect(response.status).not.toBeGreaterThanOrEqual(500)
       expectResponseTimeHeader(response)
     })
@@ -322,17 +322,17 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
   describe('Participant Role Attributes and Filters', () => {
     itIf('should accept participant-role min/max filters on participant/cs/ec list', async () => {
       const participant = await testEndpoint('GET', '/v4/participant/list', {
-        response_max_size: 1,
+        limit: 1,
         min_participants_ecosystem: 0,
         max_participants_ecosystem: 10,
       })
       const cs = await testEndpoint('GET', '/v4/credential-schema/list', {
-        response_max_size: 1,
+        limit: 1,
         min_participants_issuer: 0,
         max_participants_issuer: 10,
       })
       const ec = await testEndpoint('GET', '/v4/ecosystem/list', {
-        response_max_size: 1,
+        limit: 1,
         min_participants_verifier_grantor: 0,
         max_participants_verifier_grantor: 10,
       })
@@ -388,16 +388,16 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
-      itIf('should list trust registries - with response_max_size at minimum (1)', async () => {
+      itIf('should list trust registries - with limit at minimum (1)', async () => {
         const response = await testEndpoint('GET', '/v4/ecosystem/list', {
-          response_max_size: 1,
+          limit: 1,
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
-      itIf('should list trust registries - with response_max_size at maximum (1024)', async () => {
+      itIf('should list trust registries - with limit at maximum (1024)', async () => {
         const response = await testEndpoint('GET', '/v4/ecosystem/list', {
-          response_max_size: 1024,
+          limit: 1024,
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
@@ -511,7 +511,7 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
       itIf('should list trust registries - with ALL filters combined', async () => {
         const timestamps = getTimestamps()
         const response = await testEndpoint('GET', '/v4/ecosystem/list', {
-          response_max_size: 50,
+          limit: 50,
           controller: SAMPLE_ACCOUNT,
           modified_after: timestamps.from,
           only_active: true,
@@ -523,9 +523,9 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
-      itIf('should list trust registries - validation: response_max_size exceeds max', async () => {
+      itIf('should list trust registries - validation: limit exceeds max', async () => {
         const response = await testEndpoint('GET', '/v4/ecosystem/list', {
-          response_max_size: 2000,
+          limit: 2000,
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
@@ -544,26 +544,26 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
-      itIf('should get EC history - with response_max_size', async () => {
+      itIf('should get EC history - with limit', async () => {
         const response = await testEndpoint('GET', `/v4/ecosystem/history/${SAMPLE_TR_ID}`, {
-          response_max_size: 100,
+          limit: 100,
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
-      itIf('should get EC history - with transaction_timestamp_older_than', async () => {
-        const timestamps = getTimestamps()
+      itIf('should get EC history - with max_id cursor', async () => {
+        const _timestamps = getTimestamps()
         const response = await testEndpoint('GET', `/v4/ecosystem/history/${SAMPLE_TR_ID}`, {
-          transaction_timestamp_older_than: timestamps.lastWeek,
+          max_id: '1000000',
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
       itIf('should get EC history - with ALL parameters', async () => {
-        const timestamps = getTimestamps()
+        const _timestamps = getTimestamps()
         const response = await testEndpoint('GET', `/v4/ecosystem/history/${SAMPLE_TR_ID}`, {
-          response_max_size: 50,
-          transaction_timestamp_older_than: timestamps.lastWeek,
+          limit: 50,
+          max_id: '1000000',
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
@@ -603,9 +603,9 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
-      itIf('should list credential schemas - with response_max_size', async () => {
+      itIf('should list credential schemas - with limit', async () => {
         const response = await testEndpoint('GET', '/v4/credential-schema/list', {
-          response_max_size: 10,
+          limit: 10,
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
@@ -719,7 +719,7 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
       itIf('should list credential schemas - with ALL filters combined', async () => {
         const timestamps = getTimestamps()
         const response = await testEndpoint('GET', '/v4/credential-schema/list', {
-          response_max_size: 50,
+          limit: 50,
           ecosystem_id: SAMPLE_TR_ID,
           participant: SAMPLE_ACCOUNT,
           modified_after: timestamps.from,
@@ -747,26 +747,26 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
-      itIf('should get CS history - with response_max_size', async () => {
+      itIf('should get CS history - with limit', async () => {
         const response = await testEndpoint('GET', `/v4/credential-schema/history/${SAMPLE_ID}`, {
-          response_max_size: 100,
+          limit: 100,
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
-      itIf('should get CS history - with transaction_timestamp_older_than', async () => {
-        const timestamps = getTimestamps()
+      itIf('should get CS history - with max_id cursor', async () => {
+        const _timestamps = getTimestamps()
         const response = await testEndpoint('GET', `/v4/credential-schema/history/${SAMPLE_ID}`, {
-          transaction_timestamp_older_than: timestamps.lastWeek,
+          max_id: '1000000',
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
       itIf('should get CS history - with ALL parameters', async () => {
-        const timestamps = getTimestamps()
+        const _timestamps = getTimestamps()
         const response = await testEndpoint('GET', `/v4/credential-schema/history/${SAMPLE_ID}`, {
-          response_max_size: 50,
-          transaction_timestamp_older_than: timestamps.lastWeek,
+          limit: 50,
+          max_id: '1000000',
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
@@ -900,9 +900,9 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
-      itIf('should list participants - with response_max_size', async () => {
+      itIf('should list participants - with limit', async () => {
         const response = await testEndpoint('GET', '/v4/participant/list', {
-          response_max_size: 50,
+          limit: 50,
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
@@ -982,7 +982,7 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
           only_valid: true,
           modified_after: timestamps.from,
           op_state: 'VALIDATED',
-          response_max_size: 50,
+          limit: 50,
           when: timestamps.from,
           sort: 'modified',
           min_participants: 1,
@@ -1062,26 +1062,26 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
-      itIf('should get participant history - with response_max_size', async () => {
+      itIf('should get participant history - with limit', async () => {
         const response = await testEndpoint('GET', `/v4/participant/history/${SAMPLE_PARTICIPANT_ID}`, {
-          response_max_size: 100,
+          limit: 100,
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
-      itIf('should get participant history - with transaction_timestamp_older_than', async () => {
-        const timestamps = getTimestamps()
+      itIf('should get participant history - with max_id cursor', async () => {
+        const _timestamps = getTimestamps()
         const response = await testEndpoint('GET', `/v4/participant/history/${SAMPLE_PARTICIPANT_ID}`, {
-          transaction_timestamp_older_than: timestamps.lastWeek,
+          max_id: '1000000',
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
       itIf('should get participant history - with ALL parameters', async () => {
-        const timestamps = getTimestamps()
+        const _timestamps = getTimestamps()
         const response = await testEndpoint('GET', `/v4/participant/history/${SAMPLE_PARTICIPANT_ID}`, {
-          response_max_size: 50,
-          transaction_timestamp_older_than: timestamps.lastWeek,
+          limit: 50,
+          max_id: '1000000',
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
@@ -1103,37 +1103,37 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
-      itIf('should get participant session history - with response_max_size', async () => {
+      itIf('should get participant session history - with limit', async () => {
         const response = await testEndpoint(
           'GET',
           `/v4/participant/participant-session-history/${SAMPLE_PARTICIPANT_ID}`,
           {
-            response_max_size: 100,
+            limit: 100,
           }
         )
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
-      itIf('should get participant session history - with transaction_timestamp_older_than', async () => {
-        const timestamps = getTimestamps()
+      itIf('should get participant session history - with max_id cursor', async () => {
+        const _timestamps = getTimestamps()
         const response = await testEndpoint(
           'GET',
           `/v4/participant/participant-session-history/${SAMPLE_PARTICIPANT_ID}`,
           {
-            transaction_timestamp_older_than: timestamps.lastWeek,
+            max_id: '1000000',
           }
         )
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
       itIf('should get participant session history - with ALL parameters', async () => {
-        const timestamps = getTimestamps()
+        const _timestamps = getTimestamps()
         const response = await testEndpoint(
           'GET',
           `/v4/participant/participant-session-history/${SAMPLE_PARTICIPANT_ID}`,
           {
-            response_max_size: 50,
-            transaction_timestamp_older_than: timestamps.lastWeek,
+            limit: 50,
+            max_id: '1000000',
           }
         )
         expect(response.status).not.toBeGreaterThanOrEqual(500)
@@ -1200,26 +1200,26 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
-      itIf('should get TD history - with response_max_size', async () => {
+      itIf('should get TD history - with limit', async () => {
         const response = await testEndpoint('GET', `/v4/trust-deposit/history/${SAMPLE_ACCOUNT}`, {
-          response_max_size: 100,
+          limit: 100,
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
-      itIf('should get TD history - with transaction_timestamp_older_than', async () => {
-        const timestamps = getTimestamps()
+      itIf('should get TD history - with max_id cursor', async () => {
+        const _timestamps = getTimestamps()
         const response = await testEndpoint('GET', `/v4/trust-deposit/history/${SAMPLE_ACCOUNT}`, {
-          transaction_timestamp_older_than: timestamps.lastWeek,
+          max_id: '1000000',
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
       itIf('should get TD history - with ALL parameters', async () => {
-        const timestamps = getTimestamps()
+        const _timestamps = getTimestamps()
         const response = await testEndpoint('GET', `/v4/trust-deposit/history/${SAMPLE_ACCOUNT}`, {
-          response_max_size: 50,
-          transaction_timestamp_older_than: timestamps.lastWeek,
+          limit: 50,
+          max_id: '1000000',
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })

--- a/test/unit/services/crawl-co/co_stats_list.spec.ts
+++ b/test/unit/services/crawl-co/co_stats_list.spec.ts
@@ -32,6 +32,7 @@ import {
   countControlledEcosystemsBatch,
   emptyTrustDepositSnapshot,
   getCorporationTrustDepositBatch,
+  paginateActivityItems,
   parseCorporationListPagination,
   parseIdSortDirection,
 } from '../../../../src/services/crawl-co/co_stats'
@@ -198,6 +199,31 @@ describe('co_stats.parseIdSortDirection', () => {
     for (const s of ['modified', '-modified', 'weight', 'participants', 'created', 'id,modified']) {
       expect(parseIdSortDirection(s).ok).toBe(false)
     }
+  })
+})
+
+describe('co_stats.paginateActivityItems', () => {
+  const items = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }]
+
+  it('defaults to id descending and caps at limit', () => {
+    const res = paginateActivityItems(items, { limit: 3, direction: 'desc' })
+    expect(res.map((r) => r.id)).toEqual([5, 4, 3])
+  })
+
+  it('applies min_id inclusive and max_id exclusive', () => {
+    const res = paginateActivityItems(items, { minId: '2', maxId: '4', limit: 64, direction: 'asc' })
+    expect(res.map((r) => r.id)).toEqual([2, 3])
+  })
+
+  it('orders ascending when requested', () => {
+    const res = paginateActivityItems(items, { limit: 2, direction: 'asc' })
+    expect(res.map((r) => r.id)).toEqual([1, 2])
+  })
+
+  it('keeps uint64 ids beyond Number.MAX_SAFE_INTEGER exact', () => {
+    const big = [{ id: '9223372036854775806' }, { id: '9223372036854775807' }]
+    const res = paginateActivityItems(big, { minId: '9223372036854775807', limit: 64, direction: 'asc' })
+    expect(res.map((r) => r.id)).toEqual(['9223372036854775807'])
   })
 })
 

--- a/test/unit/services/crawl-ec/ec_database.spec.ts
+++ b/test/unit/services/crawl-ec/ec_database.spec.ts
@@ -140,10 +140,10 @@ describe('EcosystemDatabaseService', () => {
   })
 
   describe('listEcosystems', () => {
-    it('should return error for invalid response_max_size', async () => {
-      const ctx: any = { params: { response_max_size: 2000 } }
+    it('should return error for invalid limit', async () => {
+      const ctx: any = { params: { limit: 2000 } }
       await service.listEcosystems(ctx)
-      expect(ApiResponder.error).toHaveBeenCalledWith(ctx, 'response_max_size must be between 1 and 1024', 400)
+      expect(ApiResponder.error).toHaveBeenCalledWith(ctx, '"limit" must be an integer between 1 and 1024', 400)
     })
 
     it('should return filtered list with preferred language and active_gf_only', async () => {
@@ -208,7 +208,7 @@ describe('EcosystemDatabaseService', () => {
       })
 
       const ctx: any = {
-        params: { active_gf_only: 'true', preferred_language: 'fr', response_max_size: 2 },
+        params: { active_gf_only: 'true', preferred_language: 'fr', limit: 2 },
       }
       await service.listEcosystems(ctx)
 


### PR DESCRIPTION
Aligns the list and history methods with the v4 pagination spec: `limit` (1..1024, default 64), `min_id` (inclusive) and `max_id` (exclusive) as a half-open id-range cursor.

The Ecosystem and Participant list methods gain the id cursor and use `limit` for page size. The Ecosystem, Participant, Participant Session and Trust Deposit history methods are moved onto the same cursor — on the activity item id — replacing the previous size-and-timestamp parameters. Credential Schema list and history, which already used the id cursor, drop the leftover non-spec parameters. Corporation, Governance Framework and Exchange Rate methods were already aligned.

The OpenAPI document is updated to match. Adds unit tests for the cursor helper; verified end to end against a local indexer.

Closes #253
