### PR TITLE
feat: standard list filters gaps with current v4 spec

### DIFF
--- a/src/common/utils/db_connection.ts
+++ b/src/common/utils/db_connection.ts
@@ -4,7 +4,6 @@ import { knexConfig } from '../../knexfile'
 import { Config } from '../index'
 
 pgTypes.setTypeParser(20, (val: string) => (val === null ? null : Number(val)))
-pgTypes.setTypeParser(1700, (val: string) => (val === null ? null : Number(val)))
 
 const environment = process.env.NODE_ENV || 'development'
 const cfg = knexConfig[environment]

--- a/src/common/utils/exact_numeric_range.ts
+++ b/src/common/utils/exact_numeric_range.ts
@@ -1,0 +1,57 @@
+const INTEGER_PATTERN = /^[+-]?\d+$/
+
+export const INTEGER_PARAM_PATTERN = /^\d+$/
+
+export function parseExactInteger(value: unknown): bigint | undefined {
+  if (value === undefined || value === null || value === '') return undefined
+  if (typeof value === 'bigint') return value
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? BigInt(Math.trunc(value)) : undefined
+  }
+  const raw = String(value).trim()
+  return INTEGER_PATTERN.test(raw) ? BigInt(raw) : undefined
+}
+
+export function isImpossibleExactRange(min: unknown, max: unknown): boolean {
+  const minValue = parseExactInteger(min)
+  const maxValue = parseExactInteger(max)
+  return minValue !== undefined && maxValue !== undefined && minValue >= maxValue
+}
+
+export function applyExactRangeToQuery(query: any, column: string, min?: string | number, max?: string | number): any {
+  const minValue = parseExactInteger(min)
+  const maxValue = parseExactInteger(max)
+
+  if (minValue !== undefined && maxValue !== undefined && minValue >= maxValue) {
+    return query.whereRaw('1 = 0')
+  }
+
+  let nextQuery = query
+  if (minValue !== undefined) {
+    nextQuery = nextQuery.whereRaw('?? >= ?::numeric', [column, minValue.toString()])
+  }
+  if (maxValue !== undefined) {
+    nextQuery = nextQuery.whereRaw('?? < ?::numeric', [column, maxValue.toString()])
+  }
+  return nextQuery
+}
+
+export function filterRowsByExactRange<T>(
+  rows: T[],
+  min: string | number | undefined,
+  max: string | number | undefined,
+  readValue: (row: T) => unknown
+): T[] {
+  const minValue = parseExactInteger(min)
+  const maxValue = parseExactInteger(max)
+
+  if (minValue === undefined && maxValue === undefined) return rows
+  if (minValue !== undefined && maxValue !== undefined && minValue >= maxValue) return []
+
+  return rows.filter((row) => {
+    const value = parseExactInteger(readValue(row)) ?? BigInt(0)
+    if (minValue !== undefined && value < minValue) return false
+    if (maxValue !== undefined && value >= maxValue) return false
+    return true
+  })
+}

--- a/src/services/crawl-cs/cs_database.service.ts
+++ b/src/services/crawl-cs/cs_database.service.ts
@@ -8,6 +8,11 @@ import ApiResponder from '../../common/utils/apiResponse'
 import { isValidISO8601UTC } from '../../common/utils/date_utils'
 import knex from '../../common/utils/db_connection'
 import {
+  applyExactRangeToQuery,
+  filterRowsByExactRange,
+  INTEGER_PARAM_PATTERN,
+} from '../../common/utils/exact_numeric_range'
+import {
   ensureDepositDefaultIfColumnExists,
   finalizeEcosystemHistoryInsert,
   resolveEcosystemHistoryParticipantColumn,
@@ -183,15 +188,15 @@ function addStatsToHistoryRow(historyRow: any, stats: any): void {
   target.participants_verifier_grantor = stats.participants_verifier_grantor
   target.participants_verifier = stats.participants_verifier
   target.participants_holder = stats.participants_holder
-  target.weight = Number(stats.weight ?? 0)
+  target.weight = String(stats.weight ?? '0')
   target.issued = Number(stats.issued ?? 0)
   target.verified = Number(stats.verified ?? 0)
   target.ecosystem_slash_events = stats.ecosystem_slash_events
-  target.ecosystem_slashed_amount = Number(stats.ecosystem_slashed_amount ?? 0)
-  target.ecosystem_slashed_amount_repaid = Number(stats.ecosystem_slashed_amount_repaid ?? 0)
+  target.ecosystem_slashed_amount = String(stats.ecosystem_slashed_amount ?? '0')
+  target.ecosystem_slashed_amount_repaid = String(stats.ecosystem_slashed_amount_repaid ?? '0')
   target.network_slash_events = stats.network_slash_events
-  target.network_slashed_amount = Number(stats.network_slashed_amount ?? 0)
-  target.network_slashed_amount_repaid = Number(stats.network_slashed_amount_repaid ?? 0)
+  target.network_slashed_amount = String(stats.network_slashed_amount ?? '0')
+  target.network_slashed_amount_repaid = String(stats.network_slashed_amount_repaid ?? '0')
 }
 
 function getCSStatsUpdateObject(stats: any): any {
@@ -203,15 +208,15 @@ function getCSStatsUpdateObject(stats: any): any {
     participants_verifier_grantor: stats.participants_verifier_grantor,
     participants_verifier: stats.participants_verifier,
     participants_holder: stats.participants_holder,
-    weight: Number(stats.weight ?? 0),
+    weight: String(stats.weight ?? '0'),
     issued: Number(stats.issued ?? 0),
     verified: Number(stats.verified ?? 0),
     ecosystem_slash_events: stats.ecosystem_slash_events,
-    ecosystem_slashed_amount: Number(stats.ecosystem_slashed_amount ?? 0),
-    ecosystem_slashed_amount_repaid: Number(stats.ecosystem_slashed_amount_repaid ?? 0),
+    ecosystem_slashed_amount: String(stats.ecosystem_slashed_amount ?? '0'),
+    ecosystem_slashed_amount_repaid: String(stats.ecosystem_slashed_amount_repaid ?? '0'),
     network_slash_events: stats.network_slash_events,
-    network_slashed_amount: Number(stats.network_slashed_amount ?? 0),
-    network_slashed_amount_repaid: Number(stats.network_slashed_amount_repaid ?? 0),
+    network_slashed_amount: String(stats.network_slashed_amount ?? '0'),
+    network_slashed_amount_repaid: String(stats.network_slashed_amount_repaid ?? '0'),
   }
 }
 
@@ -310,15 +315,15 @@ export async function syncEcosystemStatsAndHistoryFromSchemaChange(
     participants_holder: Number(trStats.participants_holder ?? 0),
     active_schemas: Number(trStats.active_schemas ?? 0),
     archived_schemas: Number(trStats.archived_schemas ?? 0),
-    weight: Number(trStats.weight ?? 0),
+    weight: String(trStats.weight ?? '0'),
     issued: Number(trStats.issued ?? 0),
     verified: Number(trStats.verified ?? 0),
     ecosystem_slash_events: Number(trStats.ecosystem_slash_events ?? 0),
-    ecosystem_slashed_amount: Number(trStats.ecosystem_slashed_amount ?? 0),
-    ecosystem_slashed_amount_repaid: Number(trStats.ecosystem_slashed_amount_repaid ?? 0),
+    ecosystem_slashed_amount: String(trStats.ecosystem_slashed_amount ?? '0'),
+    ecosystem_slashed_amount_repaid: String(trStats.ecosystem_slashed_amount_repaid ?? '0'),
     network_slash_events: Number(trStats.network_slash_events ?? 0),
-    network_slashed_amount: Number(trStats.network_slashed_amount ?? 0),
-    network_slashed_amount_repaid: Number(trStats.network_slashed_amount_repaid ?? 0),
+    network_slashed_amount: String(trStats.network_slashed_amount ?? '0'),
+    network_slashed_amount_repaid: String(trStats.network_slashed_amount_repaid ?? '0'),
   }
 
   await db('ecosystem').where('id', ecosystemId).update(trStatsUpdate)
@@ -1280,15 +1285,15 @@ export default class CredentialSchemaDatabaseService extends BullableService {
               participants_verifier_grantor: stats.participants_verifier_grantor,
               participants_verifier: stats.participants_verifier,
               participants_holder: stats.participants_holder,
-              weight: Number(stats.weight ?? 0),
+              weight: String(stats.weight ?? '0'),
               issued: Number(stats.issued ?? 0),
               verified: Number(stats.verified ?? 0),
               ecosystem_slash_events: stats.ecosystem_slash_events,
-              ecosystem_slashed_amount: Number(stats.ecosystem_slashed_amount ?? 0),
-              ecosystem_slashed_amount_repaid: Number(stats.ecosystem_slashed_amount_repaid ?? 0),
+              ecosystem_slashed_amount: String(stats.ecosystem_slashed_amount ?? '0'),
+              ecosystem_slashed_amount_repaid: String(stats.ecosystem_slashed_amount_repaid ?? '0'),
               network_slash_events: stats.network_slash_events,
-              network_slashed_amount: Number(stats.network_slashed_amount ?? 0),
-              network_slashed_amount_repaid: Number(stats.network_slashed_amount_repaid ?? 0),
+              network_slashed_amount: String(stats.network_slashed_amount ?? '0'),
+              network_slashed_amount_repaid: String(stats.network_slashed_amount_repaid ?? '0'),
             })
         } catch (statsUpdateError: any) {
           this.logger.warn(
@@ -1498,12 +1503,12 @@ export default class CredentialSchemaDatabaseService extends BullableService {
       max_participants_verifier: { type: 'number', optional: true },
       min_participants_holder: { type: 'number', optional: true },
       max_participants_holder: { type: 'number', optional: true },
-      min_weight: { type: 'number', optional: true },
-      max_weight: { type: 'number', optional: true },
-      min_issued: { type: 'number', optional: true },
-      max_issued: { type: 'number', optional: true },
-      min_verified: { type: 'number', optional: true },
-      max_verified: { type: 'number', optional: true },
+      min_weight: { type: 'string', pattern: INTEGER_PARAM_PATTERN, optional: true },
+      max_weight: { type: 'string', pattern: INTEGER_PARAM_PATTERN, optional: true },
+      min_issued: { type: 'string', pattern: INTEGER_PARAM_PATTERN, optional: true },
+      max_issued: { type: 'string', pattern: INTEGER_PARAM_PATTERN, optional: true },
+      min_verified: { type: 'string', pattern: INTEGER_PARAM_PATTERN, optional: true },
+      max_verified: { type: 'string', pattern: INTEGER_PARAM_PATTERN, optional: true },
       min_ecosystem_slash_events: { type: 'number', optional: true },
       max_ecosystem_slash_events: { type: 'number', optional: true },
       min_network_slash_events: { type: 'number', optional: true },
@@ -1539,12 +1544,12 @@ export default class CredentialSchemaDatabaseService extends BullableService {
       max_participants_verifier?: number
       min_participants_holder?: number
       max_participants_holder?: number
-      min_weight?: number
-      max_weight?: number
-      min_issued?: number
-      max_issued?: number
-      min_verified?: number
-      max_verified?: number
+      min_weight?: string
+      max_weight?: string
+      min_issued?: string
+      max_issued?: string
+      min_verified?: string
+      max_verified?: string
       min_ecosystem_slash_events?: number
       max_ecosystem_slash_events?: number
       min_network_slash_events?: number
@@ -1705,9 +1710,9 @@ export default class CredentialSchemaDatabaseService extends BullableService {
           )
           applyHalfOpenRangeToQuery(qb, 'participants_verifier', minParticipantsVerifier, maxParticipantsVerifier)
           applyHalfOpenRangeToQuery(qb, 'participants_holder', minParticipantsHolder, maxParticipantsHolder)
-          applyHalfOpenRangeToQuery(qb, 'weight', minWeight, maxWeight)
-          applyHalfOpenRangeToQuery(qb, 'issued', minIssued, maxIssued)
-          applyHalfOpenRangeToQuery(qb, 'verified', minVerified, maxVerified)
+          applyExactRangeToQuery(qb, 'weight', minWeight, maxWeight)
+          applyExactRangeToQuery(qb, 'issued', minIssued, maxIssued)
+          applyExactRangeToQuery(qb, 'verified', minVerified, maxVerified)
           applyHalfOpenRangeToQuery(qb, 'ecosystem_slash_events', minEcosystemSlashEvents, maxEcosystemSlashEvents)
           applyHalfOpenRangeToQuery(qb, 'network_slash_events', minNetworkSlashEvents, maxNetworkSlashEvents)
         }
@@ -1833,9 +1838,9 @@ export default class CredentialSchemaDatabaseService extends BullableService {
                 participants_verifier_grantor: Number(historyRecord.participants_verifier_grantor || 0),
                 participants_verifier: Number(historyRecord.participants_verifier || 0),
                 participants_holder: Number(historyRecord.participants_holder || 0),
-                weight: Number(historyRecord.weight || 0),
-                issued: Number(historyRecord.issued || 0),
-                verified: Number(historyRecord.verified || 0),
+                weight: String(historyRecord.weight ?? '0'),
+                issued: Number(historyRecord.issued ?? 0),
+                verified: Number(historyRecord.verified ?? 0),
                 ecosystem_slash_events: Number(historyRecord.ecosystem_slash_events || 0),
                 ecosystem_slashed_amount: Number(historyRecord.ecosystem_slashed_amount || 0),
                 ecosystem_slashed_amount_repaid: Number(historyRecord.ecosystem_slashed_amount_repaid || 0),
@@ -1917,15 +1922,15 @@ export default class CredentialSchemaDatabaseService extends BullableService {
                 participants_verifier_grantor: Number(stats.participants_verifier_grantor ?? 0),
                 participants_verifier: Number(stats.participants_verifier ?? 0),
                 participants_holder: Number(stats.participants_holder ?? 0),
-                weight: Number(stats.weight ?? 0),
+                weight: String(stats.weight ?? '0'),
                 issued: Number(stats.issued ?? 0),
                 verified: Number(stats.verified ?? 0),
                 ecosystem_slash_events: Number(stats.ecosystem_slash_events ?? 0),
-                ecosystem_slashed_amount: Number(stats.ecosystem_slashed_amount ?? 0),
-                ecosystem_slashed_amount_repaid: Number(stats.ecosystem_slashed_amount_repaid ?? 0),
+                ecosystem_slashed_amount: String(stats.ecosystem_slashed_amount ?? '0'),
+                ecosystem_slashed_amount_repaid: String(stats.ecosystem_slashed_amount_repaid ?? '0'),
                 network_slash_events: Number(stats.network_slash_events ?? 0),
-                network_slashed_amount: Number(stats.network_slashed_amount ?? 0),
-                network_slashed_amount_repaid: Number(stats.network_slashed_amount_repaid ?? 0),
+                network_slashed_amount: String(stats.network_slashed_amount ?? '0'),
+                network_slashed_amount_repaid: String(stats.network_slashed_amount_repaid ?? '0'),
               }
             })
           }
@@ -1991,9 +1996,9 @@ export default class CredentialSchemaDatabaseService extends BullableService {
               participants_verifier_grantor: num((stats as any).participants_verifier_grantor),
               participants_verifier: num((stats as any).participants_verifier),
               participants_holder: num((stats as any).participants_holder),
-              weight: num(stats.weight),
-              issued: num(stats.issued),
-              verified: num(stats.verified),
+              weight: String(stats.weight ?? '0'),
+              issued: Number(stats.issued ?? 0),
+              verified: Number(stats.verified ?? 0),
               ecosystem_slash_events: num(stats.ecosystem_slash_events),
               ecosystem_slashed_amount: num(stats.ecosystem_slashed_amount),
               ecosystem_slashed_amount_repaid: num(stats.ecosystem_slashed_amount_repaid),
@@ -2044,15 +2049,9 @@ export default class CredentialSchemaDatabaseService extends BullableService {
           maxParticipantsHolder,
           (s) => toFiniteNumber((s as any).participants_holder)
         )
-        filteredWithStats = applyHalfOpenRangeToRows(filteredWithStats, minWeight, maxWeight, (s) =>
-          toFiniteNumber(s.weight)
-        )
-        filteredWithStats = applyHalfOpenRangeToRows(filteredWithStats, minIssued, maxIssued, (s) =>
-          toFiniteNumber(s.issued)
-        )
-        filteredWithStats = applyHalfOpenRangeToRows(filteredWithStats, minVerified, maxVerified, (s) =>
-          toFiniteNumber(s.verified)
-        )
+        filteredWithStats = filterRowsByExactRange(filteredWithStats, minWeight, maxWeight, (s) => s.weight)
+        filteredWithStats = filterRowsByExactRange(filteredWithStats, minIssued, maxIssued, (s) => s.issued)
+        filteredWithStats = filterRowsByExactRange(filteredWithStats, minVerified, maxVerified, (s) => s.verified)
         filteredWithStats = applyHalfOpenRangeToRows(
           filteredWithStats,
           minEcosystemSlashEvents,
@@ -2074,7 +2073,7 @@ export default class CredentialSchemaDatabaseService extends BullableService {
           participants_verifier_grantor: number
           participants_verifier: number
           participants_holder: number
-          weight: number
+          weight: string
           issued: number
           verified: number
           ecosystem_slash_events: number
@@ -2127,9 +2126,9 @@ export default class CredentialSchemaDatabaseService extends BullableService {
       )
       applyHalfOpenRangeToQuery(query, 'participants_verifier', minParticipantsVerifier, maxParticipantsVerifier)
       applyHalfOpenRangeToQuery(query, 'participants_holder', minParticipantsHolder, maxParticipantsHolder)
-      applyHalfOpenRangeToQuery(query, 'weight', minWeight, maxWeight)
-      applyHalfOpenRangeToQuery(query, 'issued', minIssued, maxIssued)
-      applyHalfOpenRangeToQuery(query, 'verified', minVerified, maxVerified)
+      applyExactRangeToQuery(query, 'weight', minWeight, maxWeight)
+      applyExactRangeToQuery(query, 'issued', minIssued, maxIssued)
+      applyExactRangeToQuery(query, 'verified', minVerified, maxVerified)
       applyHalfOpenRangeToQuery(query, 'ecosystem_slash_events', minEcosystemSlashEvents, maxEcosystemSlashEvents)
       applyHalfOpenRangeToQuery(query, 'network_slash_events', minNetworkSlashEvents, maxNetworkSlashEvents)
 
@@ -2188,7 +2187,7 @@ export default class CredentialSchemaDatabaseService extends BullableService {
             typeof (item as any).participants_holder === 'number'
               ? (item as any).participants_holder
               : Number((item as any).participants_holder || 0),
-          weight: typeof item.weight === 'number' ? item.weight : Number(item.weight || 0),
+          weight: String(item.weight ?? '0'),
           issued: typeof item.issued === 'number' ? item.issued : Number(item.issued || 0),
           verified: typeof item.verified === 'number' ? item.verified : Number(item.verified || 0),
           ecosystem_slash_events:

--- a/src/services/crawl-cs/cs_stats.ts
+++ b/src/services/crawl-cs/cs_stats.ts
@@ -1,5 +1,6 @@
 import { getBlockChainTimeAsOf } from '../../common/utils/block_time'
 import knex from '../../common/utils/db_connection'
+import { parseExactInteger } from '../../common/utils/exact_numeric_range'
 import { calculateParticipantState } from '../crawl-pp/pp_state_utils'
 
 function participantFromTrRow(row: Record<string, unknown> | null | undefined): string | null {
@@ -99,15 +100,15 @@ export interface CredentialSchemaStats {
   participants_verifier_grantor: number
   participants_verifier: number
   participants_holder: number
-  weight: number
+  weight: bigint
   issued: number
   verified: number
   ecosystem_slash_events: number
-  ecosystem_slashed_amount: number
-  ecosystem_slashed_amount_repaid: number
+  ecosystem_slashed_amount: bigint
+  ecosystem_slashed_amount_repaid: bigint
   network_slash_events: number
-  network_slashed_amount: number
-  network_slashed_amount_repaid: number
+  network_slashed_amount: bigint
+  network_slashed_amount_repaid: bigint
 }
 
 export async function getSchemaController(schemaId: number, blockHeight?: number): Promise<string | null> {
@@ -200,27 +201,27 @@ export async function calculateSlashStatsForSchema(
   blockHeight?: number
 ): Promise<{
   ecosystem_slash_events: number
-  ecosystem_slashed_amount: number
-  ecosystem_slashed_amount_repaid: number
+  ecosystem_slashed_amount: bigint
+  ecosystem_slashed_amount_repaid: bigint
   network_slash_events: number
-  network_slashed_amount: number
-  network_slashed_amount_repaid: number
+  network_slashed_amount: bigint
+  network_slashed_amount_repaid: bigint
 }> {
   let ecosystemSlashEvents = 0
-  let ecosystemSlashedAmount = 0
-  let ecosystemSlashedAmountRepaid = 0
+  let ecosystemSlashedAmount = BigInt(0)
+  let ecosystemSlashedAmountRepaid = BigInt(0)
   let networkSlashEvents = 0
-  let networkSlashedAmount = 0
-  let networkSlashedAmountRepaid = 0
+  let networkSlashedAmount = BigInt(0)
+  let networkSlashedAmountRepaid = BigInt(0)
 
   if (participantIds.size === 0) {
     return {
       ecosystem_slash_events: 0,
-      ecosystem_slashed_amount: 0,
-      ecosystem_slashed_amount_repaid: 0,
+      ecosystem_slashed_amount: BigInt(0),
+      ecosystem_slashed_amount_repaid: BigInt(0),
       network_slash_events: 0,
-      network_slashed_amount: 0,
-      network_slashed_amount_repaid: 0,
+      network_slashed_amount: BigInt(0),
+      network_slashed_amount_repaid: BigInt(0),
     }
   }
 
@@ -248,21 +249,18 @@ export async function calculateSlashStatsForSchema(
       .orderBy('created_at', 'asc')
   }
 
-  const prevSlashedDeposits = new Map<string, number>()
-  const prevRepaidDeposits = new Map<string, number>()
+  const prevSlashedDeposits = new Map<string, bigint>()
+  const prevRepaidDeposits = new Map<string, bigint>()
 
   for (const event of slashEvents) {
     const participantIdStr = String(event.participant_id)
-    const prevSlashed = prevSlashedDeposits.get(participantIdStr) || 0
-    const currentSlashed =
-      typeof event.slashed_deposit === 'number' ? event.slashed_deposit : Number(event.slashed_deposit)
+    const prevSlashed = prevSlashedDeposits.get(participantIdStr) ?? BigInt(0)
+    const currentSlashed = parseExactInteger(event.slashed_deposit) ?? BigInt(0)
     const incrementalSlashed = currentSlashed - prevSlashed
 
-    if (incrementalSlashed <= 0) {
+    if (incrementalSlashed <= BigInt(0)) {
       prevSlashedDeposits.set(participantIdStr, currentSlashed)
-      const currentRepaid =
-        typeof event.repaid_deposit === 'number' ? event.repaid_deposit : Number(event.repaid_deposit)
-      prevRepaidDeposits.set(participantIdStr, currentRepaid)
+      prevRepaidDeposits.set(participantIdStr, parseExactInteger(event.repaid_deposit) ?? BigInt(0))
       continue
     }
 
@@ -270,19 +268,19 @@ export async function calculateSlashStatsForSchema(
 
     const isEcosystemSlash = event.role === 'ECOSYSTEM'
 
-    const repaid = typeof event.repaid_deposit === 'number' ? event.repaid_deposit : Number(event.repaid_deposit)
-    const prevRepaid = prevRepaidDeposits.get(participantIdStr) || 0
+    const repaid = parseExactInteger(event.repaid_deposit) ?? BigInt(0)
+    const prevRepaid = prevRepaidDeposits.get(participantIdStr) ?? BigInt(0)
     const incrementalRepaid = repaid - prevRepaid
     prevRepaidDeposits.set(participantIdStr, repaid)
 
     if (isEcosystemSlash) {
       ecosystemSlashEvents++
       ecosystemSlashedAmount += incrementalSlashed
-      if (incrementalRepaid > 0) ecosystemSlashedAmountRepaid += incrementalRepaid
+      if (incrementalRepaid > BigInt(0)) ecosystemSlashedAmountRepaid += incrementalRepaid
     } else {
       networkSlashEvents++
       networkSlashedAmount += incrementalSlashed
-      if (incrementalRepaid > 0) networkSlashedAmountRepaid += incrementalRepaid
+      if (incrementalRepaid > BigInt(0)) networkSlashedAmountRepaid += incrementalRepaid
     }
   }
 
@@ -310,15 +308,15 @@ export async function calculateCredentialSchemaStats(
       participants_verifier_grantor: 0,
       participants_verifier: 0,
       participants_holder: 0,
-      weight: 0,
+      weight: BigInt(0),
       issued: 0,
       verified: 0,
       ecosystem_slash_events: 0,
-      ecosystem_slashed_amount: 0,
-      ecosystem_slashed_amount_repaid: 0,
+      ecosystem_slashed_amount: BigInt(0),
+      ecosystem_slashed_amount_repaid: BigInt(0),
       network_slash_events: 0,
-      network_slashed_amount: 0,
-      network_slashed_amount_repaid: 0,
+      network_slashed_amount: BigInt(0),
+      network_slashed_amount_repaid: BigInt(0),
     }
   )
 }
@@ -387,15 +385,15 @@ export async function calculateCredentialSchemaStatsBatch(
       participants_verifier_grantor: 0,
       participants_verifier: 0,
       participants_holder: 0,
-      weight: 0,
+      weight: BigInt(0),
       issued: 0,
       verified: 0,
       ecosystem_slash_events: 0,
-      ecosystem_slashed_amount: 0,
-      ecosystem_slashed_amount_repaid: 0,
+      ecosystem_slashed_amount: BigInt(0),
+      ecosystem_slashed_amount_repaid: BigInt(0),
       network_slash_events: 0,
-      network_slashed_amount: 0,
-      network_slashed_amount_repaid: 0,
+      network_slashed_amount: BigInt(0),
+      network_slashed_amount_repaid: BigInt(0),
     })
     activeParticipantsBySchema.set(schemaId, new Set<string>())
     activeParticipantsEcosystemBySchema.set(schemaId, new Set<string>())
@@ -447,9 +445,9 @@ export async function calculateCredentialSchemaStatsBatch(
     const stats = result.get(schemaId)
     if (!stats) continue
     if (participant.weight != null) {
-      stats.weight += typeof participant.weight === 'number' ? participant.weight : Number(participant.weight || 0)
+      stats.weight += parseExactInteger(participant.weight) ?? BigInt(0)
     } else if (participant.deposit != null) {
-      stats.weight += typeof participant.deposit === 'number' ? participant.deposit : Number(participant.deposit || 0)
+      stats.weight += parseExactInteger(participant.deposit) ?? BigInt(0)
     }
 
     stats.issued += counters.issuer.get(participantId) || 0
@@ -457,11 +455,12 @@ export async function calculateCredentialSchemaStatsBatch(
 
     if (typeof blockHeight === 'undefined') {
       stats.ecosystem_slash_events += Number(participant.ecosystem_slash_events ?? 0)
-      stats.ecosystem_slashed_amount += Number(participant.ecosystem_slashed_amount ?? 0)
-      stats.ecosystem_slashed_amount_repaid += Number(participant.ecosystem_slashed_amount_repaid ?? 0)
+      stats.ecosystem_slashed_amount += parseExactInteger(participant.ecosystem_slashed_amount) ?? BigInt(0)
+      stats.ecosystem_slashed_amount_repaid +=
+        parseExactInteger(participant.ecosystem_slashed_amount_repaid) ?? BigInt(0)
       stats.network_slash_events += Number(participant.network_slash_events ?? 0)
-      stats.network_slashed_amount += Number(participant.network_slashed_amount ?? 0)
-      stats.network_slashed_amount_repaid += Number(participant.network_slashed_amount_repaid ?? 0)
+      stats.network_slashed_amount += parseExactInteger(participant.network_slashed_amount) ?? BigInt(0)
+      stats.network_slashed_amount_repaid += parseExactInteger(participant.network_slashed_amount_repaid) ?? BigInt(0)
     }
   }
 
@@ -487,8 +486,8 @@ export async function calculateCredentialSchemaStatsBatch(
           .orderBy('id', 'asc')
       : []
 
-  const prevSlashedDeposits = new Map<number, number>()
-  const prevRepaidDeposits = new Map<number, number>()
+  const prevSlashedDeposits = new Map<number, bigint>()
+  const prevRepaidDeposits = new Map<number, bigint>()
 
   for (const event of slashEvents) {
     const schemaId = Number(event.schema_id)
@@ -497,18 +496,17 @@ export async function calculateCredentialSchemaStatsBatch(
 
     if (!participantIdsBySchema.get(schemaId)?.has(participantId)) continue
 
-    const prevSlashed = prevSlashedDeposits.get(participantId) || 0
-    const currentSlashed =
-      typeof event.slashed_deposit === 'number' ? event.slashed_deposit : Number(event.slashed_deposit || 0)
+    const prevSlashed = prevSlashedDeposits.get(participantId) ?? BigInt(0)
+    const currentSlashed = parseExactInteger(event.slashed_deposit) ?? BigInt(0)
     const incrementalSlashed = currentSlashed - prevSlashed
     prevSlashedDeposits.set(participantId, currentSlashed)
 
-    const repaid = typeof event.repaid_deposit === 'number' ? event.repaid_deposit : Number(event.repaid_deposit || 0)
-    const prevRepaid = prevRepaidDeposits.get(participantId) || 0
+    const repaid = parseExactInteger(event.repaid_deposit) ?? BigInt(0)
+    const prevRepaid = prevRepaidDeposits.get(participantId) ?? BigInt(0)
     const incrementalRepaid = repaid - prevRepaid
     prevRepaidDeposits.set(participantId, repaid)
 
-    if (incrementalSlashed <= 0) continue
+    if (incrementalSlashed <= BigInt(0)) continue
 
     const stats = result.get(schemaId)
     if (!stats) continue
@@ -517,11 +515,11 @@ export async function calculateCredentialSchemaStatsBatch(
     if (isEcosystemSlash) {
       stats.ecosystem_slash_events += 1
       stats.ecosystem_slashed_amount += incrementalSlashed
-      if (incrementalRepaid > 0) stats.ecosystem_slashed_amount_repaid += incrementalRepaid
+      if (incrementalRepaid > BigInt(0)) stats.ecosystem_slashed_amount_repaid += incrementalRepaid
     } else {
       stats.network_slash_events += 1
       stats.network_slashed_amount += incrementalSlashed
-      if (incrementalRepaid > 0) stats.network_slashed_amount_repaid += incrementalRepaid
+      if (incrementalRepaid > BigInt(0)) stats.network_slashed_amount_repaid += incrementalRepaid
     }
   }
 

--- a/src/services/crawl-ec/ec_database.service.ts
+++ b/src/services/crawl-ec/ec_database.service.ts
@@ -8,6 +8,11 @@ import { validateParticipantParam } from '../../common/utils/accountValidation'
 import ApiResponder from '../../common/utils/apiResponse'
 import knex from '../../common/utils/db_connection'
 import {
+  applyExactRangeToQuery,
+  filterRowsByExactRange,
+  INTEGER_PARAM_PATTERN,
+} from '../../common/utils/exact_numeric_range'
+import {
   ensureDepositDefaultIfColumnExists,
   finalizeEcosystemHistoryInsert,
   prepareEcosystemSnapshotRowForInsert,
@@ -861,15 +866,9 @@ export default class EcosystemDatabaseService extends BaseService {
     filtered = this.applyRangeToRows(filtered, filters.minParticipantsHolder, filters.maxParticipantsHolder, (r) =>
       EcosystemDatabaseService.toFiniteNumber(r.participants_holder)
     )
-    filtered = this.applyRangeToRows(filtered, filters.minWeight, filters.maxWeight, (r) =>
-      EcosystemDatabaseService.toFiniteNumber(r.weight)
-    )
-    filtered = this.applyRangeToRows(filtered, filters.minIssued, filters.maxIssued, (r) =>
-      EcosystemDatabaseService.toFiniteNumber(r.issued)
-    )
-    filtered = this.applyRangeToRows(filtered, filters.minVerified, filters.maxVerified, (r) =>
-      EcosystemDatabaseService.toFiniteNumber(r.verified)
-    )
+    filtered = filterRowsByExactRange(filtered, filters.minWeight, filters.maxWeight, (r) => r.weight)
+    filtered = filterRowsByExactRange(filtered, filters.minIssued, filters.maxIssued, (r) => r.issued)
+    filtered = filterRowsByExactRange(filtered, filters.minVerified, filters.maxVerified, (r) => r.verified)
     filtered = this.applyRangeToRows(filtered, filters.minEcosystemSlashEvents, filters.maxEcosystemSlashEvents, (r) =>
       EcosystemDatabaseService.toFiniteNumber(r.ecosystem_slash_events)
     )
@@ -1501,12 +1500,12 @@ export default class EcosystemDatabaseService extends BaseService {
       max_participants_verifier: { type: 'number', optional: true },
       min_participants_holder: { type: 'number', optional: true },
       max_participants_holder: { type: 'number', optional: true },
-      min_weight: { type: 'string', optional: true },
-      max_weight: { type: 'string', optional: true },
-      min_issued: { type: 'string', optional: true },
-      max_issued: { type: 'string', optional: true },
-      min_verified: { type: 'string', optional: true },
-      max_verified: { type: 'string', optional: true },
+      min_weight: { type: 'string', pattern: INTEGER_PARAM_PATTERN, optional: true },
+      max_weight: { type: 'string', pattern: INTEGER_PARAM_PATTERN, optional: true },
+      min_issued: { type: 'string', pattern: INTEGER_PARAM_PATTERN, optional: true },
+      max_issued: { type: 'string', pattern: INTEGER_PARAM_PATTERN, optional: true },
+      min_verified: { type: 'string', pattern: INTEGER_PARAM_PATTERN, optional: true },
+      max_verified: { type: 'string', pattern: INTEGER_PARAM_PATTERN, optional: true },
       min_ecosystem_slash_events: { type: 'number', optional: true },
       max_ecosystem_slash_events: { type: 'number', optional: true },
       min_network_slash_events: { type: 'number', optional: true },
@@ -1760,7 +1759,7 @@ export default class EcosystemDatabaseService extends BaseService {
               participants_holder: Number(row.participants_holder ?? 0),
               active_schemas: Number(row.active_schemas ?? 0),
               archived_schemas: Number(row.archived_schemas ?? 0),
-              weight: Number(row.weight ?? 0),
+              weight: String(row.weight ?? '0'),
               issued: Number(row.issued ?? 0),
               verified: Number(row.verified ?? 0),
               ecosystem_slash_events: Number(row.ecosystem_slash_events ?? 0),
@@ -1863,7 +1862,7 @@ export default class EcosystemDatabaseService extends BaseService {
               participants_holder: Number((ecosystemHistory as any).participants_holder ?? 0),
               active_schemas: Number((ecosystemHistory as any).active_schemas ?? 0),
               archived_schemas: Number((ecosystemHistory as any).archived_schemas ?? 0),
-              weight: Number((ecosystemHistory as any).weight ?? 0),
+              weight: String((ecosystemHistory as any).weight ?? '0'),
               issued: Number((ecosystemHistory as any).issued ?? 0),
               verified: Number((ecosystemHistory as any).verified ?? 0),
               ecosystem_slash_events: Number((ecosystemHistory as any).ecosystem_slash_events ?? 0),
@@ -1948,24 +1947,9 @@ export default class EcosystemDatabaseService extends BaseService {
           maxParticipantsHolder
         )
         batchQuery = this.applyRangeToQuery(batchQuery, 'active_schemas', minActiveSchemas, maxActiveSchemas)
-        batchQuery = this.applyRangeToQuery(
-          batchQuery,
-          'weight',
-          minWeight !== undefined ? Number(minWeight) : undefined,
-          maxWeight !== undefined ? Number(maxWeight) : undefined
-        )
-        batchQuery = this.applyRangeToQuery(
-          batchQuery,
-          'issued',
-          minIssued !== undefined ? Number(minIssued) : undefined,
-          maxIssued !== undefined ? Number(maxIssued) : undefined
-        )
-        batchQuery = this.applyRangeToQuery(
-          batchQuery,
-          'verified',
-          minVerified !== undefined ? Number(minVerified) : undefined,
-          maxVerified !== undefined ? Number(maxVerified) : undefined
-        )
+        batchQuery = applyExactRangeToQuery(batchQuery, 'weight', minWeight, maxWeight)
+        batchQuery = applyExactRangeToQuery(batchQuery, 'issued', minIssued, maxIssued)
+        batchQuery = applyExactRangeToQuery(batchQuery, 'verified', minVerified, maxVerified)
         batchQuery = this.applyRangeToQuery(
           batchQuery,
           'ecosystem_slash_events',
@@ -2068,7 +2052,7 @@ export default class EcosystemDatabaseService extends BaseService {
             participants_holder: Number(ec.participants_holder ?? 0),
             active_schemas: Number(ec.active_schemas ?? 0),
             archived_schemas: Number(ec.archived_schemas ?? 0),
-            weight: Number(ec.weight ?? 0),
+            weight: String(ec.weight ?? '0'),
             issued: Number(ec.issued ?? 0),
             verified: Number(ec.verified ?? 0),
             ecosystem_slash_events: Number(ec.ecosystem_slash_events ?? 0),
@@ -2131,24 +2115,9 @@ export default class EcosystemDatabaseService extends BaseService {
       query = this.applyRangeToQuery(query, 'participants_verifier', minParticipantsVerifier, maxParticipantsVerifier)
       query = this.applyRangeToQuery(query, 'participants_holder', minParticipantsHolder, maxParticipantsHolder)
       query = this.applyRangeToQuery(query, 'active_schemas', minActiveSchemas, maxActiveSchemas)
-      query = this.applyRangeToQuery(
-        query,
-        'weight',
-        minWeight !== undefined ? Number(minWeight) : undefined,
-        maxWeight !== undefined ? Number(maxWeight) : undefined
-      )
-      query = this.applyRangeToQuery(
-        query,
-        'issued',
-        minIssued !== undefined ? Number(minIssued) : undefined,
-        maxIssued !== undefined ? Number(maxIssued) : undefined
-      )
-      query = this.applyRangeToQuery(
-        query,
-        'verified',
-        minVerified !== undefined ? Number(minVerified) : undefined,
-        maxVerified !== undefined ? Number(maxVerified) : undefined
-      )
+      query = applyExactRangeToQuery(query, 'weight', minWeight, maxWeight)
+      query = applyExactRangeToQuery(query, 'issued', minIssued, maxIssued)
+      query = applyExactRangeToQuery(query, 'verified', minVerified, maxVerified)
       query = this.applyRangeToQuery(query, 'ecosystem_slash_events', minEcosystemSlashEvents, maxEcosystemSlashEvents)
       query = this.applyRangeToQuery(query, 'network_slash_events', minNetworkSlashEvents, maxNetworkSlashEvents)
 
@@ -2203,9 +2172,9 @@ export default class EcosystemDatabaseService extends BaseService {
           participants_holder: Number((plain as any).participants_holder || 0),
           active_schemas: Number(plain.active_schemas || 0),
           archived_schemas: Number(plain.archived_schemas || 0),
-          weight: Number(plain.weight || 0),
-          issued: Number(plain.issued || 0),
-          verified: Number(plain.verified || 0),
+          weight: String(plain.weight ?? '0'),
+          issued: Number(plain.issued ?? 0),
+          verified: Number(plain.verified ?? 0),
           ecosystem_slash_events: Number(plain.ecosystem_slash_events || 0),
           ecosystem_slashed_amount: Number(plain.ecosystem_slashed_amount || 0),
           ecosystem_slashed_amount_repaid: Number(plain.ecosystem_slashed_amount_repaid || 0),

--- a/src/services/crawl-ec/ec_processor.service.ts
+++ b/src/services/crawl-ec/ec_processor.service.ts
@@ -26,15 +26,15 @@ function getDefaultTRStats(fallbackData?: any): any {
     participants_holder: Number(fallbackData?.participants_holder ?? 0) || 0,
     active_schemas: Number(fallbackData?.active_schemas ?? 0) || 0,
     archived_schemas: Number(fallbackData?.archived_schemas ?? 0) || 0,
-    weight: Number(fallbackData?.weight ?? 0) || 0,
+    weight: String(fallbackData?.weight ?? '0'),
     issued: Number(fallbackData?.issued ?? 0) || 0,
     verified: Number(fallbackData?.verified ?? 0) || 0,
     ecosystem_slash_events: Number(fallbackData?.ecosystem_slash_events ?? 0) || 0,
-    ecosystem_slashed_amount: Number(fallbackData?.ecosystem_slashed_amount ?? 0) || 0,
-    ecosystem_slashed_amount_repaid: Number(fallbackData?.ecosystem_slashed_amount_repaid ?? 0) || 0,
+    ecosystem_slashed_amount: String(fallbackData?.ecosystem_slashed_amount ?? '0'),
+    ecosystem_slashed_amount_repaid: String(fallbackData?.ecosystem_slashed_amount_repaid ?? '0'),
     network_slash_events: Number(fallbackData?.network_slash_events ?? 0) || 0,
-    network_slashed_amount: Number(fallbackData?.network_slashed_amount ?? 0) || 0,
-    network_slashed_amount_repaid: Number(fallbackData?.network_slashed_amount_repaid ?? 0) || 0,
+    network_slashed_amount: String(fallbackData?.network_slashed_amount ?? '0'),
+    network_slashed_amount_repaid: String(fallbackData?.network_slashed_amount_repaid ?? '0'),
   }
 }
 
@@ -253,15 +253,15 @@ export default class EcosystemMessageProcessorService extends BullableService {
         participants_holder: Number(stats.participants_holder ?? 0),
         active_schemas: Number(stats.active_schemas ?? 0),
         archived_schemas: Number(stats.archived_schemas ?? 0),
-        weight: Number(stats.weight ?? 0),
+        weight: String(stats.weight ?? BigInt(0)),
         issued: Number(stats.issued ?? 0),
         verified: Number(stats.verified ?? 0),
         ecosystem_slash_events: Number(stats.ecosystem_slash_events ?? 0),
-        ecosystem_slashed_amount: Number(stats.ecosystem_slashed_amount ?? 0),
-        ecosystem_slashed_amount_repaid: Number(stats.ecosystem_slashed_amount_repaid ?? 0),
+        ecosystem_slashed_amount: String(stats.ecosystem_slashed_amount ?? '0'),
+        ecosystem_slashed_amount_repaid: String(stats.ecosystem_slashed_amount_repaid ?? '0'),
         network_slash_events: Number(stats.network_slash_events ?? 0),
-        network_slashed_amount: Number(stats.network_slashed_amount ?? 0),
-        network_slashed_amount_repaid: Number(stats.network_slashed_amount_repaid ?? 0),
+        network_slashed_amount: String(stats.network_slashed_amount ?? '0'),
+        network_slashed_amount_repaid: String(stats.network_slashed_amount_repaid ?? '0'),
       }
 
       const statsChanged =
@@ -274,15 +274,15 @@ export default class EcosystemMessageProcessorService extends BullableService {
         Number(oldTr.participants_holder ?? 0) !== statsUpdate.participants_holder ||
         Number(oldTr.active_schemas ?? 0) !== statsUpdate.active_schemas ||
         Number(oldTr.archived_schemas ?? 0) !== statsUpdate.archived_schemas ||
-        Number(oldTr.weight ?? 0) !== statsUpdate.weight ||
+        String(oldTr.weight ?? '0') !== statsUpdate.weight ||
         Number(oldTr.issued ?? 0) !== statsUpdate.issued ||
         Number(oldTr.verified ?? 0) !== statsUpdate.verified ||
         Number(oldTr.ecosystem_slash_events ?? 0) !== statsUpdate.ecosystem_slash_events ||
-        Number(oldTr.ecosystem_slashed_amount ?? 0) !== statsUpdate.ecosystem_slashed_amount ||
-        Number(oldTr.ecosystem_slashed_amount_repaid ?? 0) !== statsUpdate.ecosystem_slashed_amount_repaid ||
+        String(oldTr.ecosystem_slashed_amount ?? '0') !== statsUpdate.ecosystem_slashed_amount ||
+        String(oldTr.ecosystem_slashed_amount_repaid ?? '0') !== statsUpdate.ecosystem_slashed_amount_repaid ||
         Number(oldTr.network_slash_events ?? 0) !== statsUpdate.network_slash_events ||
-        Number(oldTr.network_slashed_amount ?? 0) !== statsUpdate.network_slashed_amount ||
-        Number(oldTr.network_slashed_amount_repaid ?? 0) !== statsUpdate.network_slashed_amount_repaid
+        String(oldTr.network_slashed_amount ?? '0') !== statsUpdate.network_slashed_amount ||
+        String(oldTr.network_slashed_amount_repaid ?? '0') !== statsUpdate.network_slashed_amount_repaid
 
       if (statsChanged) {
         this.logger.info(`Stats changed for EC ${ecosystemId}, updating main table and recording StatsUpdate history`)
@@ -426,15 +426,15 @@ export default class EcosystemMessageProcessorService extends BullableService {
       participants_holder: Number(stats.participants_holder ?? 0),
       active_schemas: Number(stats.active_schemas ?? 0),
       archived_schemas: Number(stats.archived_schemas ?? 0),
-      weight: Number(stats.weight ?? 0),
+      weight: String(stats.weight ?? BigInt(0)),
       issued: Number(stats.issued ?? 0),
       verified: Number(stats.verified ?? 0),
       ecosystem_slash_events: Number(stats.ecosystem_slash_events ?? 0),
-      ecosystem_slashed_amount: Number(stats.ecosystem_slashed_amount ?? 0),
-      ecosystem_slashed_amount_repaid: Number(stats.ecosystem_slashed_amount_repaid ?? 0),
+      ecosystem_slashed_amount: String(stats.ecosystem_slashed_amount ?? '0'),
+      ecosystem_slashed_amount_repaid: String(stats.ecosystem_slashed_amount_repaid ?? '0'),
       network_slash_events: Number(stats.network_slash_events ?? 0),
-      network_slashed_amount: Number(stats.network_slashed_amount ?? 0),
-      network_slashed_amount_repaid: Number(stats.network_slashed_amount_repaid ?? 0),
+      network_slashed_amount: String(stats.network_slashed_amount ?? '0'),
+      network_slashed_amount_repaid: String(stats.network_slashed_amount_repaid ?? '0'),
       event_type: eventType,
       height: Number(height),
       changes: Object.keys(changes).length > 0 ? JSON.stringify(changes) : null,

--- a/src/services/crawl-ec/ec_stats.ts
+++ b/src/services/crawl-ec/ec_stats.ts
@@ -1,4 +1,5 @@
 import knex from '../../common/utils/db_connection'
+import { parseExactInteger } from '../../common/utils/exact_numeric_range'
 import { TR_STATS_FIELDS } from '../../common/utils/stats_fields'
 import { Ecosystem } from '../../models/ecosystem'
 import { resolveAddressByCorporationId } from '../crawl-co/corporation_resolve'
@@ -16,15 +17,15 @@ export interface EcosystemStats {
   participants_holder: number
   active_schemas: number
   archived_schemas: number
-  weight: number
+  weight: bigint
   issued: number
   verified: number
   ecosystem_slash_events: number
-  ecosystem_slashed_amount: number
-  ecosystem_slashed_amount_repaid: number
+  ecosystem_slashed_amount: bigint
+  ecosystem_slashed_amount_repaid: bigint
   network_slash_events: number
-  network_slashed_amount: number
-  network_slashed_amount_repaid: number
+  network_slashed_amount: bigint
+  network_slashed_amount_repaid: bigint
 }
 
 export { TR_STATS_FIELDS }
@@ -127,27 +128,27 @@ export async function calculateSlashStatsForSchema(
   blockHeight?: number
 ): Promise<{
   ecosystem_slash_events: number
-  ecosystem_slashed_amount: number
-  ecosystem_slashed_amount_repaid: number
+  ecosystem_slashed_amount: bigint
+  ecosystem_slashed_amount_repaid: bigint
   network_slash_events: number
-  network_slashed_amount: number
-  network_slashed_amount_repaid: number
+  network_slashed_amount: bigint
+  network_slashed_amount_repaid: bigint
 }> {
   let ecosystemSlashEvents = 0
-  let ecosystemSlashedAmount = 0
-  let ecosystemSlashedAmountRepaid = 0
+  let ecosystemSlashedAmount = BigInt(0)
+  let ecosystemSlashedAmountRepaid = BigInt(0)
   let networkSlashEvents = 0
-  let networkSlashedAmount = 0
-  let networkSlashedAmountRepaid = 0
+  let networkSlashedAmount = BigInt(0)
+  let networkSlashedAmountRepaid = BigInt(0)
 
   if (participantIds.size === 0) {
     return {
       ecosystem_slash_events: 0,
-      ecosystem_slashed_amount: 0,
-      ecosystem_slashed_amount_repaid: 0,
+      ecosystem_slashed_amount: BigInt(0),
+      ecosystem_slashed_amount_repaid: BigInt(0),
       network_slash_events: 0,
-      network_slashed_amount: 0,
-      network_slashed_amount_repaid: 0,
+      network_slashed_amount: BigInt(0),
+      network_slashed_amount_repaid: BigInt(0),
     }
   }
 
@@ -175,21 +176,18 @@ export async function calculateSlashStatsForSchema(
       .orderBy('created_at', 'asc')
   }
 
-  const prevSlashedDeposits = new Map<string, number>()
-  const prevRepaidDeposits = new Map<string, number>()
+  const prevSlashedDeposits = new Map<string, bigint>()
+  const prevRepaidDeposits = new Map<string, bigint>()
 
   for (const event of slashEvents) {
     const participantIdStr = String(event.participant_id)
-    const prevSlashed = prevSlashedDeposits.get(participantIdStr) || 0
-    const currentSlashed =
-      typeof event.slashed_deposit === 'number' ? event.slashed_deposit : Number(event.slashed_deposit)
+    const prevSlashed = prevSlashedDeposits.get(participantIdStr) ?? BigInt(0)
+    const currentSlashed = parseExactInteger(event.slashed_deposit) ?? BigInt(0)
     const incrementalSlashed = currentSlashed - prevSlashed
 
-    if (incrementalSlashed <= 0) {
+    if (incrementalSlashed <= BigInt(0)) {
       prevSlashedDeposits.set(participantIdStr, currentSlashed)
-      const currentRepaid =
-        typeof event.repaid_deposit === 'number' ? event.repaid_deposit : Number(event.repaid_deposit)
-      prevRepaidDeposits.set(participantIdStr, currentRepaid)
+      prevRepaidDeposits.set(participantIdStr, parseExactInteger(event.repaid_deposit) ?? BigInt(0))
       continue
     }
 
@@ -201,10 +199,10 @@ export async function calculateSlashStatsForSchema(
       networkSlashEvents++
       networkSlashedAmount += incrementalSlashed
 
-      const repaid = typeof event.repaid_deposit === 'number' ? event.repaid_deposit : Number(event.repaid_deposit)
-      const prevRepaid = prevRepaidDeposits.get(participantIdStr) || 0
+      const repaid = parseExactInteger(event.repaid_deposit) ?? BigInt(0)
+      const prevRepaid = prevRepaidDeposits.get(participantIdStr) ?? BigInt(0)
       const incrementalRepaid = repaid - prevRepaid
-      if (incrementalRepaid > 0) {
+      if (incrementalRepaid > BigInt(0)) {
         networkSlashedAmountRepaid += incrementalRepaid
       }
       prevRepaidDeposits.set(participantIdStr, repaid)
@@ -212,10 +210,10 @@ export async function calculateSlashStatsForSchema(
       ecosystemSlashEvents++
       ecosystemSlashedAmount += incrementalSlashed
 
-      const repaid = typeof event.repaid_deposit === 'number' ? event.repaid_deposit : Number(event.repaid_deposit)
-      const prevRepaid = prevRepaidDeposits.get(participantIdStr) || 0
+      const repaid = parseExactInteger(event.repaid_deposit) ?? BigInt(0)
+      const prevRepaid = prevRepaidDeposits.get(participantIdStr) ?? BigInt(0)
       const incrementalRepaid = repaid - prevRepaid
-      if (incrementalRepaid > 0) {
+      if (incrementalRepaid > BigInt(0)) {
         ecosystemSlashedAmountRepaid += incrementalRepaid
       }
       prevRepaidDeposits.set(participantIdStr, repaid)
@@ -245,15 +243,15 @@ export async function calculateEcosystemStats(ecosystemId: number, blockHeight?:
       participants_holder: 0,
       active_schemas: 0,
       archived_schemas: 0,
-      weight: 0,
+      weight: BigInt(0),
       issued: 0,
       verified: 0,
       ecosystem_slash_events: 0,
-      ecosystem_slashed_amount: 0,
-      ecosystem_slashed_amount_repaid: 0,
+      ecosystem_slashed_amount: BigInt(0),
+      ecosystem_slashed_amount_repaid: BigInt(0),
       network_slash_events: 0,
-      network_slashed_amount: 0,
-      network_slashed_amount_repaid: 0,
+      network_slashed_amount: BigInt(0),
+      network_slashed_amount_repaid: BigInt(0),
     }
   )
 }
@@ -312,15 +310,15 @@ export async function calculateEcosystemStatsBatch(
       participants_holder: 0,
       active_schemas: 0,
       archived_schemas: 0,
-      weight: 0,
+      weight: BigInt(0),
       issued: 0,
       verified: 0,
       ecosystem_slash_events: 0,
-      ecosystem_slashed_amount: 0,
-      ecosystem_slashed_amount_repaid: 0,
+      ecosystem_slashed_amount: BigInt(0),
+      ecosystem_slashed_amount_repaid: BigInt(0),
       network_slash_events: 0,
-      network_slashed_amount: 0,
-      network_slashed_amount_repaid: 0,
+      network_slashed_amount: BigInt(0),
+      network_slashed_amount_repaid: BigInt(0),
     })
   }
 
@@ -353,15 +351,15 @@ export async function calculateEcosystemStatsBatch(
     trStats.participants_verifier_grantor += Number(stats.participants_verifier_grantor || 0)
     trStats.participants_verifier += Number(stats.participants_verifier || 0)
     trStats.participants_holder += Number(stats.participants_holder || 0)
-    trStats.weight += Number(stats.weight || 0)
+    trStats.weight += stats.weight
     trStats.issued += Number(stats.issued || 0)
     trStats.verified += Number(stats.verified || 0)
     trStats.ecosystem_slash_events += Number(stats.ecosystem_slash_events || 0)
-    trStats.ecosystem_slashed_amount += Number(stats.ecosystem_slashed_amount || 0)
-    trStats.ecosystem_slashed_amount_repaid += Number(stats.ecosystem_slashed_amount_repaid || 0)
+    trStats.ecosystem_slashed_amount += stats.ecosystem_slashed_amount
+    trStats.ecosystem_slashed_amount_repaid += stats.ecosystem_slashed_amount_repaid
     trStats.network_slash_events += Number(stats.network_slash_events || 0)
-    trStats.network_slashed_amount += Number(stats.network_slashed_amount || 0)
-    trStats.network_slashed_amount_repaid += Number(stats.network_slashed_amount_repaid || 0)
+    trStats.network_slashed_amount += stats.network_slashed_amount
+    trStats.network_slashed_amount_repaid += stats.network_slashed_amount_repaid
   }
 
   return result

--- a/src/services/crawl-pp/pp_apis.service.ts
+++ b/src/services/crawl-pp/pp_apis.service.ts
@@ -8,6 +8,12 @@ import ApiResponder from '../../common/utils/apiResponse'
 import { getBlockHeight, hasBlockHeight } from '../../common/utils/blockHeight'
 import { isValidISO8601UTC } from '../../common/utils/date_utils'
 import knex from '../../common/utils/db_connection'
+import {
+  applyExactRangeToQuery,
+  filterRowsByExactRange,
+  INTEGER_PARAM_PATTERN,
+  isImpossibleExactRange,
+} from '../../common/utils/exact_numeric_range'
 import { getModuleParams, getModuleParamsAction } from '../../common/utils/params_service'
 import { mapParticipantType, normalizeParticipantEmptyStringsToNull } from '../../common/utils/utils'
 import { mapParticipantApiFields } from '../../common/vpr-v4-mapping'
@@ -381,9 +387,9 @@ export default class ParticipantAPIService extends BullableService {
         db: 'participants_holder',
         enabled: options.participantRoles,
       },
-      { min: 'min_weight', max: 'max_weight', db: 'weight', enabled: options.weight },
-      { min: 'min_issued', max: 'max_issued', db: 'issued', enabled: options.issued },
-      { min: 'min_verified', max: 'max_verified', db: 'verified', enabled: options.verified },
+      { min: 'min_weight', max: 'max_weight', db: 'weight', enabled: options.weight, exact: true },
+      { min: 'min_issued', max: 'max_issued', db: 'issued', enabled: options.issued, exact: true },
+      { min: 'min_verified', max: 'max_verified', db: 'verified', enabled: options.verified, exact: true },
       {
         min: 'min_ecosystem_slash_events',
         max: 'max_ecosystem_slash_events',
@@ -408,6 +414,16 @@ export default class ParticipantAPIService extends BullableService {
 
       if (!spec.enabled) {
         requiresPostFilter = true
+        continue
+      }
+
+      if (spec.exact) {
+        if (isImpossibleExactRange(minRaw, maxRaw)) {
+          query.whereRaw('1 = 0')
+          impossibleRange = true
+          continue
+        }
+        applyExactRangeToQuery(query, col(spec.db), minRaw, maxRaw)
         continue
       }
 
@@ -442,9 +458,9 @@ export default class ParticipantAPIService extends BullableService {
       },
       { min: 'min_participants_verifier', max: 'max_participants_verifier', field: 'participants_verifier' },
       { min: 'min_participants_holder', max: 'max_participants_holder', field: 'participants_holder' },
-      { min: 'min_weight', max: 'max_weight', field: 'weight' },
-      { min: 'min_issued', max: 'max_issued', field: 'issued' },
-      { min: 'min_verified', max: 'max_verified', field: 'verified' },
+      { min: 'min_weight', max: 'max_weight', field: 'weight', exact: true },
+      { min: 'min_issued', max: 'max_issued', field: 'issued', exact: true },
+      { min: 'min_verified', max: 'max_verified', field: 'verified', exact: true },
       { min: 'min_ecosystem_slash_events', max: 'max_ecosystem_slash_events', field: 'ecosystem_slash_events' },
       { min: 'min_network_slash_events', max: 'max_network_slash_events', field: 'network_slash_events' },
     ]
@@ -454,6 +470,12 @@ export default class ParticipantAPIService extends BullableService {
       const minRaw = params[spec.min]
       const maxRaw = params[spec.max]
       if (minRaw === undefined && maxRaw === undefined) continue
+
+      if (spec.exact) {
+        if (isImpossibleExactRange(minRaw, maxRaw)) return []
+        results = filterRowsByExactRange(results, minRaw, maxRaw, (participant) => participant?.[spec.field])
+        continue
+      }
 
       const minValue = minRaw !== undefined ? Number(minRaw) : undefined
       const maxValue = maxRaw !== undefined ? Number(maxRaw) : undefined
@@ -869,7 +891,7 @@ export default class ParticipantAPIService extends BullableService {
       op_current_fees: participant.op_current_fees != null ? Number(participant.op_current_fees) : 0,
       op_current_deposit: participant.op_current_deposit != null ? Number(participant.op_current_deposit) : 0,
       op_validator_deposit: participant.op_validator_deposit != null ? Number(participant.op_validator_deposit) : 0,
-      weight: participant.weight != null ? Number(participant.weight) : 0,
+      weight: participant.weight != null ? String(participant.weight) : '0',
       issued: participant.issued != null ? Number(participant.issued) : 0,
       verified: participant.verified != null ? Number(participant.verified) : 0,
       participants: participant.participants != null ? Number(participant.participants) : 0,
@@ -1225,7 +1247,7 @@ export default class ParticipantAPIService extends BullableService {
       now
     )
 
-    const weight = typeof participant.weight === 'number' ? participant.weight : Number(participant.weight || 0)
+    const weight = String(participant.weight ?? '0')
     const statistics = {
       issued: typeof participant.issued === 'number' ? participant.issued : Number(participant.issued || 0),
       verified: typeof participant.verified === 'number' ? participant.verified : Number(participant.verified || 0),
@@ -1378,12 +1400,12 @@ export default class ParticipantAPIService extends BullableService {
       max_participants_verifier: { type: 'number', integer: true, optional: true },
       min_participants_holder: { type: 'number', integer: true, optional: true },
       max_participants_holder: { type: 'number', integer: true, optional: true },
-      min_weight: { type: 'number', optional: true },
-      max_weight: { type: 'number', optional: true },
-      min_issued: { type: 'number', optional: true },
-      max_issued: { type: 'number', optional: true },
-      min_verified: { type: 'number', optional: true },
-      max_verified: { type: 'number', optional: true },
+      min_weight: { type: 'string', pattern: INTEGER_PARAM_PATTERN, optional: true },
+      max_weight: { type: 'string', pattern: INTEGER_PARAM_PATTERN, optional: true },
+      min_issued: { type: 'string', pattern: INTEGER_PARAM_PATTERN, optional: true },
+      max_issued: { type: 'string', pattern: INTEGER_PARAM_PATTERN, optional: true },
+      min_verified: { type: 'string', pattern: INTEGER_PARAM_PATTERN, optional: true },
+      max_verified: { type: 'string', pattern: INTEGER_PARAM_PATTERN, optional: true },
       min_ecosystem_slash_events: { type: 'number', integer: true, optional: true },
       max_ecosystem_slash_events: { type: 'number', integer: true, optional: true },
       min_network_slash_events: { type: 'number', integer: true, optional: true },

--- a/test/unit/common/exact_numeric_range.spec.ts
+++ b/test/unit/common/exact_numeric_range.spec.ts
@@ -1,0 +1,170 @@
+import { afterAll, beforeAll, describe, expect, test } from '@jest/globals'
+import knex from '../../../src/common/utils/db_connection'
+import {
+  applyExactRangeToQuery,
+  filterRowsByExactRange,
+  isImpossibleExactRange,
+  parseExactInteger,
+} from '../../../src/common/utils/exact_numeric_range'
+
+const ABOVE_2_53 = '250000000000000000123'
+const NEIGHBOUR_BELOW = '250000000000000000000'
+const BIGINT_BOUNDARY = '9007199254740993'
+
+describe('parseExactInteger', () => {
+  test('keeps precision far above Number.MAX_SAFE_INTEGER', () => {
+    expect(parseExactInteger(ABOVE_2_53)).toBe(BigInt(ABOVE_2_53))
+    expect(parseExactInteger(BIGINT_BOUNDARY)).toBe(BigInt(BIGINT_BOUNDARY))
+  })
+
+  test('distinguishes values that collapse onto each other as Number', () => {
+    expect(Number(ABOVE_2_53)).toBe(Number(NEIGHBOUR_BELOW))
+    expect(parseExactInteger(ABOVE_2_53)).not.toBe(parseExactInteger(NEIGHBOUR_BELOW))
+  })
+
+  test('returns undefined for absent or non-integer input', () => {
+    expect(parseExactInteger(undefined)).toBeUndefined()
+    expect(parseExactInteger('')).toBeUndefined()
+    expect(parseExactInteger('abc')).toBeUndefined()
+    expect(parseExactInteger('1.5')).toBeUndefined()
+    expect(parseExactInteger(Number.NaN)).toBeUndefined()
+  })
+})
+
+describe('isImpossibleExactRange', () => {
+  test('is true only when the half-open range cannot contain anything', () => {
+    expect(isImpossibleExactRange('10', '10')).toBe(true)
+    expect(isImpossibleExactRange('11', '10')).toBe(true)
+    expect(isImpossibleExactRange('10', '11')).toBe(false)
+    expect(isImpossibleExactRange('10', undefined)).toBe(false)
+  })
+})
+
+describe('applyExactRangeToQuery', () => {
+  const makeQuery = () => {
+    const calls: Array<{ sql: string; bindings: any[] }> = []
+    const query: any = {
+      calls,
+      whereRaw(sql: string, bindings: any[] = []) {
+        calls.push({ sql, bindings })
+        return query
+      },
+    }
+    return query
+  }
+
+  test('binds the bound as an exact numeric string, never a JS number', () => {
+    const query = makeQuery()
+    applyExactRangeToQuery(query, 'weight', ABOVE_2_53, undefined)
+
+    expect(query.calls).toHaveLength(1)
+    expect(query.calls[0].sql).toBe('?? >= ?::numeric')
+    expect(query.calls[0].bindings).toEqual(['weight', ABOVE_2_53])
+  })
+
+  test('emits a half-open range', () => {
+    const query = makeQuery()
+    applyExactRangeToQuery(query, 'weight', '10', '20')
+
+    expect(query.calls.map((c: any) => c.sql)).toEqual(['?? >= ?::numeric', '?? < ?::numeric'])
+    expect(query.calls[1].bindings).toEqual(['weight', '20'])
+  })
+
+  test('short-circuits an empty range', () => {
+    const query = makeQuery()
+    applyExactRangeToQuery(query, 'weight', '10', '10')
+
+    expect(query.calls).toEqual([{ sql: '1 = 0', bindings: [] }])
+  })
+})
+
+describe('filterRowsByExactRange', () => {
+  const rows = [{ weight: NEIGHBOUR_BELOW }, { weight: ABOVE_2_53 }]
+
+  test('excludes a row that Number-based comparison would wrongly include', () => {
+    const filtered = filterRowsByExactRange(rows, ABOVE_2_53, undefined, (r) => r.weight)
+    expect(filtered).toEqual([{ weight: ABOVE_2_53 }])
+  })
+
+  test('applies the max bound exclusively', () => {
+    const filtered = filterRowsByExactRange(rows, undefined, ABOVE_2_53, (r) => r.weight)
+    expect(filtered).toEqual([{ weight: NEIGHBOUR_BELOW }])
+  })
+
+  test('treats missing values as zero', () => {
+    const filtered = filterRowsByExactRange([{ weight: null }], '1', undefined, (r) => r.weight)
+    expect(filtered).toEqual([])
+  })
+
+  test('returns rows untouched when no bound is given', () => {
+    expect(filterRowsByExactRange(rows, undefined, undefined, (r) => r.weight)).toBe(rows)
+  })
+})
+
+describe('against postgres', () => {
+  const TABLE = 'exact_numeric_range_probe'
+
+  beforeAll(async () => {
+    await knex.schema.dropTableIfExists(TABLE)
+    await knex.schema.createTable(TABLE, (table) => {
+      table.bigInteger('id')
+      table.specificType('weight', 'NUMERIC(38,0)')
+      table.bigInteger('verified')
+    })
+    await knex(TABLE).insert([
+      { id: 1, weight: NEIGHBOUR_BELOW, verified: '9007199254740992' },
+      { id: 2, weight: ABOVE_2_53, verified: BIGINT_BOUNDARY },
+    ])
+  })
+
+  afterAll(async () => {
+    await knex.schema.dropTableIfExists(TABLE)
+    await knex.destroy()
+  })
+
+  test('a numeric column round-trips as an exact string', async () => {
+    const row = await knex(TABLE).where('id', 2).first()
+
+    expect(typeof row.weight).toBe('string')
+    expect(row.weight).toBe(ABOVE_2_53)
+  })
+
+  test('bigint columns stay numbers so ids and heights are unaffected', async () => {
+    const row = await knex(TABLE).where('id', 2).first()
+
+    expect(typeof row.id).toBe('number')
+  })
+
+  test('the value survives the subquery-plus-star shape the list endpoints use', async () => {
+    const ranked = knex(TABLE)
+      .select('*', knex.raw('ROW_NUMBER() OVER (PARTITION BY id ORDER BY id DESC) as rn'))
+      .as('ranked')
+    const row = await knex.from(ranked).where('rn', 1).andWhere('id', 2).first()
+
+    expect(row.weight).toBe(ABOVE_2_53)
+  })
+
+  test('min bound does not produce the false positive a JS number would', async () => {
+    const rows = await applyExactRangeToQuery(knex(TABLE), 'weight', ABOVE_2_53, undefined).orderBy('id')
+
+    expect(rows.map((r: any) => r.id)).toEqual([2])
+  })
+
+  test('filters a bigint column past 2^53 exactly', async () => {
+    const rows = await applyExactRangeToQuery(knex(TABLE), 'verified', BIGINT_BOUNDARY, undefined).orderBy('id')
+
+    expect(rows.map((r: any) => r.id)).toEqual([2])
+  })
+
+  test('max bound is exclusive and exact', async () => {
+    const rows = await applyExactRangeToQuery(knex(TABLE), 'weight', undefined, ABOVE_2_53).orderBy('id')
+
+    expect(rows.map((r: any) => r.id)).toEqual([1])
+  })
+
+  test('an empty half-open range returns nothing', async () => {
+    const rows = await applyExactRangeToQuery(knex(TABLE), 'weight', ABOVE_2_53, ABOVE_2_53)
+
+    expect(rows).toEqual([])
+  })
+})

--- a/test/unit/services/crawl-cs/cs_stats.spec.ts
+++ b/test/unit/services/crawl-cs/cs_stats.spec.ts
@@ -1,0 +1,48 @@
+import knex from '../../../../src/common/utils/db_connection'
+import { calculateCredentialSchemaStatsBatch } from '../../../../src/services/crawl-cs/cs_stats'
+
+const SCHEMA_ID = 909101
+
+const WEIGHT_A = '250000000000000000123'
+const WEIGHT_B = '250000000000000000456'
+const EXACT_TOTAL = '500000000000000000579'
+
+const baseParticipant = {
+  schema_id: SCHEMA_ID,
+  validation_fees: '0',
+  issuance_fees: '0',
+  verification_fees: '0',
+  deposit: '0',
+  slashed_deposit: '0',
+  repaid_deposit: '0',
+  op_current_fees: '0',
+  op_current_deposit: '0',
+  op_validator_deposit: '0',
+  issuance_fee_discount: '0',
+  verification_fee_discount: '0',
+  vs_operator_authz_enabled: false,
+  vs_operator_authz_with_feegrant: false,
+  participants: 0,
+  participants_ecosystem: 0,
+}
+
+describe('cs_stats weight aggregation', () => {
+  beforeAll(async () => {
+    await knex('participants').where('schema_id', SCHEMA_ID).del()
+    await knex('participants').insert([
+      { ...baseParticipant, id: 909101, role: 'ISSUER', weight: WEIGHT_A },
+      { ...baseParticipant, id: 909102, role: 'VERIFIER', weight: WEIGHT_B },
+    ])
+  })
+
+  afterAll(async () => {
+    await knex('participants').where('schema_id', SCHEMA_ID).del()
+    await knex.destroy()
+  })
+
+  it('sums participant weights far above 2^53 without losing a unit', async () => {
+    const stats = await calculateCredentialSchemaStatsBatch([SCHEMA_ID])
+
+    expect(stats.get(SCHEMA_ID)?.weight).toBe(BigInt(EXACT_TOTAL))
+  })
+})

--- a/test/unit/services/crawl-ec/ec_database.spec.ts
+++ b/test/unit/services/crawl-ec/ec_database.spec.ts
@@ -25,6 +25,7 @@ jest.mock('../../../../src/common/utils/db_connection', () => {
   mockQuery.orderBy = jest.fn(() => mockQuery)
   mockQuery.limit = jest.fn(() => mockQuery)
   mockQuery.first = jest.fn(() => mockQuery)
+  mockQuery.raw = jest.fn((sql: string) => sql)
   mockQuery.schema = { hasTable: jest.fn().mockResolvedValue(false) }
   return mockQuery
 })
@@ -163,6 +164,7 @@ describe('EcosystemDatabaseService', () => {
 
       // Complete mock for chained calls
       const mockQuery: any = {
+        select: jest.fn().mockReturnThis(),
         withGraphFetched: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),

--- a/test/unit/services/crawl-transaction/coin_transfer.spec.ts
+++ b/test/unit/services/crawl-transaction/coin_transfer.spec.ts
@@ -101,7 +101,7 @@ export default class CoinTransferSpec {
     for (let i = 0; i < coinTransfer.length; i += 1) {
       expect(coinTransfer[i].from).toEqual(sender)
       expect(coinTransfer[i].to).toEqual(receiver)
-      expect(coinTransfer[i].amount).toEqual(Number(amounts[i]))
+      expect(coinTransfer[i].amount).toEqual(String(amounts[i]))
     }
   }
 
@@ -167,7 +167,7 @@ export default class CoinTransferSpec {
     for (let i = 0; i < coinTransfers.length; i += 1) {
       expect(coinTransfers[i].from).toEqual(senders[i])
       expect(coinTransfers[i].to).toEqual(receivers[i])
-      expect(coinTransfers[i].amount).toEqual(Number(amounts[i]))
+      expect(coinTransfers[i].amount).toEqual(String(amounts[i]))
     }
   }
 
@@ -241,7 +241,7 @@ export default class CoinTransferSpec {
     for (let i = 0; i < coinTransfers.length; i += 1) {
       expect(coinTransfers[i].from).toEqual(senders[i])
       expect(coinTransfers[i].to).toEqual(receivers[i])
-      expect(coinTransfers[i].amount).toEqual(Number(amounts[i]))
+      expect(coinTransfers[i].amount).toEqual(String(amounts[i]))
     }
   }
 

--- a/test/unit/services/crawl-validator/crawl_delegators.spec.ts
+++ b/test/unit/services/crawl-validator/crawl_delegators.spec.ts
@@ -180,8 +180,8 @@ export default class CrawlDelegatorsTest {
       validator_id: validator?.id,
       delegator_address: 'delegator_addr_2',
     })
-    expect(d1?.amount).toBe(2000000)
-    expect(d2?.amount).toBe(2000000)
+    expect(d1?.amount).toBe('2000000')
+    expect(d2?.amount).toBe('2000000')
   }
 
   // ================================== EXISTING DB-DRIVEN TESTS ==================================
@@ -212,7 +212,7 @@ export default class CrawlDelegatorsTest {
       delegator_address: this.mockDelegatorAddress,
     })
 
-    expect(delegator?.amount).toBe(100000000)
+    expect(delegator?.amount).toBe('100000000')
     expect(validator?.delegators_count).toBe(1)
   }
 
@@ -250,7 +250,7 @@ export default class CrawlDelegatorsTest {
       delegator_address: this.mockDelegatorAddress,
     })
 
-    expect(delegator?.amount).toBe(200000000)
+    expect(delegator?.amount).toBe('200000000')
     expect(validator?.delegators_count).toBe(1)
   }
 
@@ -297,7 +297,7 @@ export default class CrawlDelegatorsTest {
       delegator_address: this.mockDelegatorAddress,
     })
 
-    expect(delegator?.amount).toBe(100000000)
+    expect(delegator?.amount).toBe('100000000')
     expect(validator?.delegators_count).toBe(1)
   }
 
@@ -382,7 +382,7 @@ export default class CrawlDelegatorsTest {
       delegator_address: this.mockDelegatorAddress,
     })
 
-    expect(delegator?.amount).toBe(100000000)
+    expect(delegator?.amount).toBe('100000000')
     expect(validator?.delegators_count).toBe(1)
   }
 
@@ -424,8 +424,8 @@ export default class CrawlDelegatorsTest {
       delegator_address: `${this.mockDelegatorAddress}_2`,
     })
 
-    expect(delegator1?.amount).toBe(100000000)
-    expect(delegator2?.amount).toBe(100000000)
+    expect(delegator1?.amount).toBe('100000000')
+    expect(delegator2?.amount).toBe('100000000')
     expect(validator?.delegators_count).toBe(2)
   }
 
@@ -486,7 +486,7 @@ export default class CrawlDelegatorsTest {
     })
 
     expect(delegatorSrc).toBeUndefined()
-    expect(delegatorDst?.amount).toBe(100000000)
+    expect(delegatorDst?.amount).toBe('100000000')
     expect(validatorSrc?.delegators_count).toBe(0)
     expect(validatorDst?.delegators_count).toBe(1)
   }

--- a/test/unit/services/crawl-validator/handle_stake_event.spec.ts
+++ b/test/unit/services/crawl-validator/handle_stake_event.spec.ts
@@ -262,9 +262,9 @@ export default class HandleStakeEventTest {
     const delegated = interesting.find((e) => e.type === PowerEvent.TYPES.DELEGATE)
     const redelegated = interesting.find((e) => e.type === PowerEvent.TYPES.REDELEGATE)
 
-    expect(delegated?.amount).toEqual(1000000)
+    expect(delegated?.amount).toEqual('1000000')
     expect(delegated?.height).toEqual(3967529)
-    expect(redelegated?.amount).toEqual(1000000)
+    expect(redelegated?.amount).toEqual('1000000')
     expect(redelegated?.height).toEqual(3967529)
 
     // Only compare validator ids if those columns exist in the table.

--- a/test/unit/services/ibc/crawl_ibc_ics20.spec.ts
+++ b/test/unit/services/ibc/crawl_ibc_ics20.spec.ts
@@ -95,7 +95,7 @@ export default class CrawlIbcIcs20Test {
       expect(result?.ibc_message_id).toEqual(message.id)
       expect(result?.sender).toEqual(ibcMessage.data.sender)
       expect(result?.receiver).toEqual(ibcMessage.data.receiver)
-      expect(result?.amount).toEqual(10000)
+      expect(result?.amount).toEqual('10000')
       expect(result?.denom).toEqual(ibcMessage.data.denom)
       expect(result?.status).toEqual(IbcIcs20.STATUS_TYPE.ONGOING)
       expect(result?.sequence_key).toEqual(ibcMessage.sequence_key)
@@ -205,7 +205,7 @@ export default class CrawlIbcIcs20Test {
       expect(result?.ibc_message_id).toEqual(ibcMsg.id)
       expect(result?.receiver).toEqual(getAttributeFrom(event1Attrs, EventAttribute.ATTRIBUTE_KEY.RECEIVER))
       expect(result?.sender).toEqual(getAttributeFrom(event1Attrs, EventAttribute.ATTRIBUTE_KEY.SENDER))
-      expect(result?.amount).toEqual(10000)
+      expect(result?.amount).toEqual('10000')
       expect(result?.denom).toEqual(
         `${ibcMessage.dst_port_id}/${
           ibcMessage.dst_channel_id
@@ -295,7 +295,7 @@ export default class CrawlIbcIcs20Test {
       expect(result?.ibc_message_id).toEqual(ibcMsg.id)
       expect(result?.receiver).toEqual(getAttributeFrom(event1Attrs, EventAttribute.ATTRIBUTE_KEY.RECEIVER))
       expect(result?.sender).toEqual(getAttributeFrom(event1Attrs, EventAttribute.ATTRIBUTE_KEY.SENDER))
-      expect(result?.amount).toEqual(10000)
+      expect(result?.amount).toEqual('10000')
       expect(result?.denom).toEqual('uatom')
       expect(result?.status).toEqual(IbcIcs20.STATUS_TYPE.ACK_SUCCESS)
       expect(result?.sequence_key).toEqual(ibcMessage.sequence_key)


### PR DESCRIPTION
### Changes

- Drop the global `numeric` type parser; `numeric` now round-trips as an
  exact string. `bigint` (ids, heights, cursors) is untouched.
- Add `exact_numeric_range`: BigInt parsing, `::numeric` SQL comparison and
  exact in-memory range filtering.
- Compare `min/max_weight|issued|verified` as numeric in SQL instead of JS
  number, in ec, cs and pp.
- Unify the three services' params to `string` with an integer pattern
  (were `number` in cs/pp, making >2^53 unrepresentable over HTTP).
- Sum and persist `weight` and the `*_slashed_amount` fields as `bigint` in
  `cs_stats` / `ec_stats`; the aggregates were computed in float and written
  corrupted.
- Serialize money as a string, counters as a number, matching the `vt`
  response schema and `metrics_api`.