### PR TITLE
fix: change history written at block

### DIFF
--- a/src/services/resolver/resolver-poll.service.ts
+++ b/src/services/resolver/resolver-poll.service.ts
@@ -33,15 +33,15 @@ const ResolverPollService = {
   },
 
   methods: {
-    async refreshExpiredTrustResults(this: any): Promise<void> {
+    async refreshExpiredTrustResults(this: any, landingHeight: number): Promise<boolean> {
       const cfg = getResolverRuntimeConfig()
-      if (!cfg?.enabled) return
+      if (!cfg?.enabled) return false
 
       const trustTtlSeconds = getTrustEvaluationTtlSeconds()
-      if (!Number.isFinite(trustTtlSeconds) || trustTtlSeconds <= 0) return
+      if (!Number.isFinite(trustTtlSeconds) || trustTtlSeconds <= 0) return false
 
       const lastTrust = await this.getOrCreateResolverCheckpointHeight()
-      if (lastTrust <= 0) return
+      if (lastTrust <= 0) return false
 
       // Refresh a small batch per poll cycle to avoid overwhelming the DB.
       const now = new Date()
@@ -53,20 +53,22 @@ const ResolverPollService = {
         .orderBy('expires_at', 'asc')
         .limit(50)) as Array<{ did: string; height: number; expires_at: Date | string }>
 
-      if (rows.length === 0) return
+      if (rows.length === 0) return false
 
+      let forwarded = false
       for (const r of rows) {
         const did = String(r.did ?? '')
         const height = Number(r.height ?? 0)
         if (!did || !Number.isInteger(height) || height < 0) continue
         try {
-          await resolveTrustForDidAtHeight(did, height)
+          forwarded = (await resolveTrustForDidAtHeight(did, height, landingHeight)) || forwarded
         } catch {
           this.logger.warn(
             `[RESOLVER] Failed to refresh trust for ${did}@${height}, will retry again later if still eligible.`
           )
         }
       }
+      return forwarded
     },
     async initialSyncIfNeeded(this: any): Promise<void> {
       const cfg = getResolverRuntimeConfig()
@@ -81,13 +83,14 @@ const ResolverPollService = {
       await this.processBlock(indexedHeight)
       await this.advanceResolverCheckpoint(indexedHeight)
     },
-    async retryDueFailures(this: any): Promise<void> {
+    async retryDueFailures(this: any, landingHeight: number): Promise<boolean> {
       const retryDays = getDeclaredPollObjectCachingRetryDays() ?? 0
-      if (retryDays <= 0) return
+      if (retryDays <= 0) return false
 
       const due = await listDueReattemptables(200)
-      if (due.length === 0) return
+      if (due.length === 0) return false
 
+      let forwarded = false
       for (const item of due) {
         const rid = String(item.resource_id ?? '')
         if (!rid) continue
@@ -100,11 +103,12 @@ const ResolverPollService = {
         const height = Number(m[2])
         if (!Number.isInteger(height) || height < 0) continue
         try {
-          await resolveTrustForDidAtHeight(did, height)
+          forwarded = (await resolveTrustForDidAtHeight(did, height, landingHeight)) || forwarded
         } catch {
           console.error(`[RESOLVER] Reattempt for ${rid} failed, will retry again later if still eligible.`)
         }
       }
+      return forwarded
     },
     async getIndexedHeight(this: any): Promise<number> {
       const checkpoint = await knex('block_checkpoint').where('job_name', BULL_JOB_NAME.HANDLE_TRANSACTION).first()
@@ -182,10 +186,6 @@ const ResolverPollService = {
 
       await this.initialSyncIfNeeded()
 
-      await this.retryDueFailures()
-
-      await this.refreshExpiredTrustResults()
-
       const currentHeight = await this.getOrCreateResolverCheckpointHeight()
       const indexedHeight = await this.getIndexedHeight()
       if (indexedHeight <= currentHeight) return
@@ -193,9 +193,14 @@ const ResolverPollService = {
       const tuning = await getResolverTuning(this.logger)
       const targetEnd = Math.min(indexedHeight, currentHeight + tuning.blocksPerCall)
 
+      let forwardedLate = false
+      forwardedLate = (await this.retryDueFailures(targetEnd)) || forwardedLate
+      forwardedLate = (await this.refreshExpiredTrustResults(targetEnd)) || forwardedLate
+
       if (trustTxPrefilterEnabled()) {
         const activeHeights = await findHeightsWithTrustModuleMessages(currentHeight, targetEnd)
         const activeSet = new Set<number>(activeHeights.map((h) => Number(h)))
+        if (forwardedLate) activeSet.add(targetEnd)
         try {
           for (let height = currentHeight + 1; height <= targetEnd; height++) {
             if (activeSet.has(height)) {

--- a/src/services/resolver/trust-resolve.ts
+++ b/src/services/resolver/trust-resolve.ts
@@ -399,11 +399,33 @@ async function getImpactedDids(blockHeight: number, limit: number): Promise<stri
   return out
 }
 
-export async function resolveTrustForDidAtHeight(did: string, blockHeight: number): Promise<void> {
+function isResolveError(resolveResult: unknown): boolean {
+  return Boolean(resolveResult && typeof resolveResult === 'object' && (resolveResult as { error?: unknown }).error)
+}
+
+function trustResultMeaningfullyChanged(nextResolve: unknown, prevRow: TrustResultsRow | null): boolean {
+  const next = deriveStoredTrustState(nextResolve)
+  const prevStatus = prevRow ? String(prevRow.trust_status ?? 'UNTRUSTED').toUpperCase() : 'UNTRUSTED'
+  const prevProduction = prevRow ? Boolean(prevRow.production) : false
+  if (next.trustStatus !== prevStatus) return true
+  if (next.production !== prevProduction) return true
+  const prevError = prevRow ? isResolveError(prevRow.resolve_result) : true
+  return isResolveError(nextResolve) !== prevError
+}
+
+export async function resolveTrustForDidAtHeight(
+  did: string,
+  blockHeight: number,
+  landingHeight?: number
+): Promise<boolean> {
   const { verifiablePublicRegistries, skipDigestSRICheck } = getVerreTrustEvaluationCallOptions()
   const cfg = getResolverRuntimeConfig()
   const retryDays = Number(cfg?.pollObjectCachingRetryDays ?? 0) || 0
   const resourceId = `${did}@${blockHeight}`
+
+  let resolveResult: unknown
+  let snap: TrustRoleSnapshot
+  let failureMessage: string | null = null
 
   try {
     const result = (await resolveDID(did, {
@@ -417,57 +439,67 @@ export async function resolveTrustForDidAtHeight(did: string, blockHeight: numbe
       result.outcome = TrustResolutionOutcome.NOT_TRUSTED
     }
 
-    const snap = snapshotFromResolution(result)
-    await saveTrustResults({
-      did,
-      height: blockHeight,
-      resolve_result: result,
-      issuer_auth: snap,
-      verifier_auth: snap,
-      ecosystem_participant: snap,
-    })
-
-    await clearReattemptable(resourceId)
+    resolveResult = result
+    snap = snapshotFromResolution(result)
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err)
-    const snap = snapshotFromError(message)
+    failureMessage = message
     const lower = message.toLowerCase()
     const errorCode =
       lower.includes('not found') || lower.includes('not_found') || lower.includes('404')
         ? 'not_found'
         : 'resolution_failed'
 
-    await saveTrustResults({
-      did,
-      height: blockHeight,
-      resolve_result: {
-        error: true,
-        message,
-        dereferenceErrors: [],
-        credentials: [],
-        failedCredentials: [
-          {
-            id: did,
-            error: `DID resolution failed for ${did}`,
-            format: 'N/A',
-            errorCode,
-            message,
-          },
-        ],
-      },
-      issuer_auth: snap,
-      verifier_auth: snap,
-      ecosystem_participant: snap,
-    })
+    resolveResult = {
+      error: true,
+      message,
+      dereferenceErrors: [],
+      credentials: [],
+      failedCredentials: [
+        {
+          id: did,
+          error: `DID resolution failed for ${did}`,
+          format: 'N/A',
+          errorCode,
+          message,
+        },
+      ],
+    }
+    snap = snapshotFromError(message)
+  }
 
+  let saveHeight = blockHeight
+  let forwarded = false
+  if (typeof landingHeight === 'number' && Number.isInteger(landingHeight) && landingHeight !== blockHeight) {
+    const prevRow = await getTrustResultLatestByDidAtOrBeforeHeight(did, blockHeight)
+    if (trustResultMeaningfullyChanged(resolveResult, prevRow)) {
+      saveHeight = landingHeight
+      forwarded = true
+    }
+  }
+
+  await saveTrustResults({
+    did,
+    height: saveHeight,
+    resolve_result: resolveResult,
+    issuer_auth: snap,
+    verifier_auth: snap,
+    ecosystem_participant: snap,
+  })
+
+  if (failureMessage !== null) {
     await markReattemptableFailure({
       resourceId,
       resourceType: 'did-evaluation',
       errorType: 'resolveDID',
-      lastError: message,
+      lastError: failureMessage,
       retryDays,
     })
+  } else {
+    await clearReattemptable(resourceId)
   }
+
+  return forwarded
 }
 
 export async function resolveTrustForBlock(blockHeight: number): Promise<void> {
@@ -476,7 +508,9 @@ export async function resolveTrustForBlock(blockHeight: number): Promise<void> {
   const tuning = await getResolverTuning()
   const impactedDids = await getImpactedDids(blockHeight, tuning.maxDidsPerBlock)
 
-  await runPool(impactedDids, tuning.didConcurrency, async (did) => resolveTrustForDidAtHeight(did, blockHeight))
+  await runPool(impactedDids, tuning.didConcurrency, async (did) => {
+    await resolveTrustForDidAtHeight(did, blockHeight)
+  })
 }
 
 function mapOutcomeToTrustStatus(verified: boolean, outcome: unknown): string {

--- a/test/unit/services/resolver/trust_resolve_late_attribution.spec.ts
+++ b/test/unit/services/resolver/trust_resolve_late_attribution.spec.ts
@@ -1,0 +1,207 @@
+const TrustResolutionOutcome = {
+  VERIFIED: 'verified',
+  VERIFIED_TEST: 'verified-test',
+  NOT_TRUSTED: 'not-trusted',
+  INVALID: 'invalid',
+} as const
+
+const resolveDIDMock = jest.fn()
+
+jest.mock(
+  '@verana-labs/verre',
+  () => ({
+    __esModule: true,
+    resolveDID: (...args: unknown[]) => resolveDIDMock(...args),
+    TrustResolutionOutcome,
+  }),
+  { virtual: true }
+)
+
+jest.mock('../../../../src/config.json', () => {
+  const actual = jest.requireActual('../../../../src/config.json')
+  return {
+    __esModule: true,
+    default: {
+      ...actual,
+      resolver: {
+        ...actual.resolver,
+        enabled: true,
+        trustEvaluationTtlSeconds: 3600,
+        pollObjectCachingRetryDays: 7,
+      },
+    },
+  }
+})
+
+jest.mock('../../../../src/common/utils/start_mode_detector', () => ({
+  __esModule: true,
+  detectStartMode: async () => ({ isFreshStart: false }),
+}))
+
+jest.mock('../../../../src/services/resolver/ecs-allowlist', () => ({
+  __esModule: true,
+  isEcsAllowlistEnforced: () => false,
+}))
+
+jest.mock('../../../../src/services/resolver/trust-resolve-v4.builders', () => ({
+  __esModule: true,
+  hasAllowlistedEcsServiceCredential: async () => true,
+}))
+
+jest.mock('../../../../src/services/resolver/verre-registry-adapter', () => ({
+  __esModule: true,
+  attachRegistryAdapters: (registries: unknown) => registries,
+}))
+
+type Row = Record<string, any>
+const store: Record<string, Row[]> = { trust_results: [], trust_reattemptable: [] }
+
+jest.mock('../../../../src/common/utils/db_connection', () => {
+  type Cond = { key: string; op: string; value: any }
+
+  const makeChain = (table: string) => {
+    const conds: Cond[] = []
+    let order: { key: string; dir: string } | null = null
+
+    const matching = () => {
+      let rows = store[table].filter((row) =>
+        conds.every((c) => {
+          if (c.op === '=') return row[c.key] === c.value
+          if (c.op === '<=') return Number(row[c.key]) <= Number(c.value)
+          return true
+        })
+      )
+      if (order) {
+        const { key, dir } = order
+        rows = [...rows].sort((a, b) =>
+          dir === 'desc' ? Number(b[key]) - Number(a[key]) : Number(a[key]) - Number(b[key])
+        )
+      }
+      return rows
+    }
+
+    const chain: any = {}
+    chain.select = () => chain
+    chain.whereNotNull = () => chain
+    chain.limit = () => chain
+    chain.orderBy = (key: string, dir = 'asc') => {
+      order = { key, dir }
+      return chain
+    }
+    chain.where = (a: any, b?: any, c?: any) => {
+      if (a && typeof a === 'object') {
+        for (const [key, value] of Object.entries(a)) conds.push({ key, op: '=', value })
+      } else if (c === undefined) {
+        conds.push({ key: a, op: '=', value: b })
+      } else {
+        conds.push({ key: a, op: b, value: c })
+      }
+      return chain
+    }
+    chain.first = async () => matching()[0]
+    chain.delete = async () => {
+      const doomed = new Set(matching())
+      store[table] = store[table].filter((row) => !doomed.has(row))
+      return doomed.size
+    }
+    chain.insert = (row: Row) => {
+      const inserted = { ...row }
+      return {
+        onConflict: (keys: string | string[]) => {
+          const keyList = Array.isArray(keys) ? keys : [keys]
+          return {
+            merge: async (patch: Row) => {
+              const existing = store[table].find((r) => keyList.every((k) => r[k] === inserted[k]))
+              if (existing) Object.assign(existing, patch)
+              else store[table].push(inserted)
+            },
+            ignore: async () => {
+              const existing = store[table].find((r) => keyList.every((k) => r[k] === inserted[k]))
+              if (!existing) store[table].push(inserted)
+            },
+          }
+        },
+      }
+    }
+    return chain
+  }
+
+  const knexMock: any = jest.fn((table: string) => makeChain(table))
+  knexMock.raw = jest.fn(async () => ({ rows: [] }))
+  return { __esModule: true, default: knexMock }
+})
+
+const DID = 'did:webvh:QmScid:issuer.example.org'
+const ANNOUNCE_BLOCK = 100
+const CURRENT_HEAD = 5000
+
+const successResolution = {
+  verified: true,
+  outcome: TrustResolutionOutcome.VERIFIED,
+  didDocument: {
+    id: DID,
+    service: [
+      { type: 'LinkedVerifiablePresentation', serviceEndpoint: 'https://issuer.example.org/vp.json' },
+      { type: 'did-communication', serviceEndpoint: 'wss://issuer.example.org' },
+    ],
+  },
+}
+
+const rowsAt = (height: number) => store.trust_results.filter((r) => r.did === DID && r.height === height)
+
+describe('resolveTrustForDidAtHeight — late-arriving DID document attribution', () => {
+  beforeEach(() => {
+    store.trust_results = []
+    store.trust_reattemptable = []
+    resolveDIDMock.mockReset()
+  })
+
+  it('attributes a late successful retry to the landing block, not the block that announced the DID', async () => {
+    const { resolveTrustForDidAtHeight } = await import('../../../../src/services/resolver/trust-resolve')
+
+    resolveDIDMock.mockRejectedValueOnce(new Error('DID document not found'))
+    const initial = await resolveTrustForDidAtHeight(DID, ANNOUNCE_BLOCK)
+
+    expect(initial).toBe(false)
+    expect(rowsAt(ANNOUNCE_BLOCK)[0].resolve_result.error).toBe(true)
+
+    resolveDIDMock.mockResolvedValueOnce(successResolution)
+    const forwarded = await resolveTrustForDidAtHeight(DID, ANNOUNCE_BLOCK, CURRENT_HEAD)
+
+    expect(forwarded).toBe(true)
+
+    const landed = rowsAt(CURRENT_HEAD)
+    expect(landed).toHaveLength(1)
+    expect(landed[0].resolve_result.didDocument.service).toHaveLength(2)
+    expect(landed[0].trust_status).toBe('TRUSTED')
+
+    // The announcing block keeps the failure it actually had at that point in time.
+    expect(rowsAt(ANNOUNCE_BLOCK)).toHaveLength(1)
+    expect(rowsAt(ANNOUNCE_BLOCK)[0].resolve_result.error).toBe(true)
+  })
+
+  it('leaves an unchanged repeated failure on the original block so no spurious change is broadcast', async () => {
+    const { resolveTrustForDidAtHeight } = await import('../../../../src/services/resolver/trust-resolve')
+
+    resolveDIDMock.mockRejectedValueOnce(new Error('DID document not found'))
+    await resolveTrustForDidAtHeight(DID, ANNOUNCE_BLOCK)
+
+    resolveDIDMock.mockRejectedValueOnce(new Error('DID document not found'))
+    const forwarded = await resolveTrustForDidAtHeight(DID, ANNOUNCE_BLOCK, CURRENT_HEAD)
+
+    expect(forwarded).toBe(false)
+    expect(rowsAt(CURRENT_HEAD)).toHaveLength(0)
+    expect(rowsAt(ANNOUNCE_BLOCK)).toHaveLength(1)
+  })
+
+  it('keeps the in-block resolution on its own block when no landing block is given', async () => {
+    const { resolveTrustForDidAtHeight } = await import('../../../../src/services/resolver/trust-resolve')
+
+    resolveDIDMock.mockResolvedValueOnce(successResolution)
+    const forwarded = await resolveTrustForDidAtHeight(DID, ANNOUNCE_BLOCK)
+
+    expect(forwarded).toBe(false)
+    expect(rowsAt(ANNOUNCE_BLOCK)).toHaveLength(1)
+    expect(rowsAt(ANNOUNCE_BLOCK)[0].trust_status).toBe('TRUSTED')
+  })
+})


### PR DESCRIPTION
**Changes**
When a DID is resolved for the first time, it may take some time for the corresponding document to become available. The block height stored in the database represents the block where the DID resolution process started, not the block where the document was successfully validated.
To address this, a new validation has been added to the resolution flow. Once the document is successfully resolved, the resolved block is reported so the WebSocket can notify clients with the correct block information.