### PR TITLE
fix: replace the trust evaluation ttl by expiresAtTime

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -8216,7 +8216,11 @@
           "trusted": { "type": "boolean" },
           "evaluatedAtTime": { "type": "string", "format": "date-time" },
           "evaluatedAtBlock": { "type": "integer", "minimum": 0 },
-          "expiresAtTime": { "type": "string", "format": "date-time" },
+          "expiresAtTime": {
+            "type": ["string", "null"],
+            "format": "date-time",
+            "description": "Earliest expiry boundary of the credentials the DID's trust state rests on: the soonest `validUntil` of its ECS service / service-provider credential and the soonest `effective_until` of the matching Participant entries. Null when none of them declares an expiry, and therefore when the DID has no stored evaluation at the requested block."
+          },
           "corporationId": { "type": "integer", "minimum": 0 },
           "corporation": { "$ref": "#/components/schemas/VtCorporation" },
           "participations": { "type": "array", "items": { "$ref": "#/components/schemas/VtParticipation" } },

--- a/src/config.json
+++ b/src/config.json
@@ -156,7 +156,6 @@
     "disableDigestSriVerification": false,
     "txPrefilterEnabled": true,
     "ecsEcosystems": [],
-    "trustEvaluationTtlSeconds": 3600,
     "pollObjectCachingRetryDays": 7
   },
   "crawlSigningInfo": {

--- a/src/services/api/vt_subscribe_protocol.ts
+++ b/src/services/api/vt_subscribe_protocol.ts
@@ -5,7 +5,7 @@ export type VtTrustCore = {
   trusted: boolean
   evaluatedAtTime: string
   evaluatedAtBlock: number
-  expiresAtTime: string
+  expiresAtTime: string | null
   corporationId: number | null
 }
 

--- a/src/services/resolver/resolver-poll.service.ts
+++ b/src/services/resolver/resolver-poll.service.ts
@@ -10,7 +10,6 @@ import {
   getDeclaredPollObjectCachingRetryDays,
   getResolverRuntimeConfig,
   getResolverTuning,
-  getTrustEvaluationTtlSeconds,
   listDueReattemptables,
   markReattemptableAttempt,
   resolveTrustForBlock,
@@ -33,43 +32,6 @@ const ResolverPollService = {
   },
 
   methods: {
-    async refreshExpiredTrustResults(this: any, landingHeight: number): Promise<boolean> {
-      const cfg = getResolverRuntimeConfig()
-      if (!cfg?.enabled) return false
-
-      const trustTtlSeconds = getTrustEvaluationTtlSeconds()
-      if (!Number.isFinite(trustTtlSeconds) || trustTtlSeconds <= 0) return false
-
-      const lastTrust = await this.getOrCreateResolverCheckpointHeight()
-      if (lastTrust <= 0) return false
-
-      // Refresh a small batch per poll cycle to avoid overwhelming the DB.
-      const now = new Date()
-      const rows = (await knex('trust_results')
-        .select('did', 'height', 'expires_at')
-        .whereNotNull('expires_at')
-        .andWhere('expires_at', '<=', now)
-        .andWhere('height', '<=', lastTrust)
-        .orderBy('expires_at', 'asc')
-        .limit(50)) as Array<{ did: string; height: number; expires_at: Date | string }>
-
-      if (rows.length === 0) return false
-
-      let forwarded = false
-      for (const r of rows) {
-        const did = String(r.did ?? '')
-        const height = Number(r.height ?? 0)
-        if (!did || !Number.isInteger(height) || height < 0) continue
-        try {
-          forwarded = (await resolveTrustForDidAtHeight(did, height, landingHeight)) || forwarded
-        } catch {
-          this.logger.warn(
-            `[RESOLVER] Failed to refresh trust for ${did}@${height}, will retry again later if still eligible.`
-          )
-        }
-      }
-      return forwarded
-    },
     async initialSyncIfNeeded(this: any): Promise<void> {
       const cfg = getResolverRuntimeConfig()
       if (!cfg?.enabled) return
@@ -195,7 +157,6 @@ const ResolverPollService = {
 
       let forwardedLate = false
       forwardedLate = (await this.retryDueFailures(targetEnd)) || forwardedLate
-      forwardedLate = (await this.refreshExpiredTrustResults(targetEnd)) || forwardedLate
 
       if (trustTxPrefilterEnabled()) {
         const activeHeights = await findHeightsWithTrustModuleMessages(currentHeight, targetEnd)

--- a/src/services/resolver/trust-api.service.ts
+++ b/src/services/resolver/trust-api.service.ts
@@ -6,11 +6,7 @@ import { ALL_PARTICIPANT_STATES, type ParticipantState } from '../../common/type
 import ApiResponder from '../../common/utils/apiResponse'
 import knex from '../../common/utils/db_connection'
 import { BlockCheckpoint } from '../../models'
-import {
-  getTrustEvaluationTtlSeconds,
-  getTrustResultLatestByDidAtOrBeforeHeight,
-  resolveTrustForDidAtHeight,
-} from './trust-resolve'
+import { getTrustResultLatestByDidAtOrBeforeHeight, resolveTrustForDidAtHeight } from './trust-resolve'
 import {
   buildCorporation,
   buildEcosystems,
@@ -66,16 +62,6 @@ export class TrustApiService extends BaseService {
     return ApiResponder.error(ctx, 'DID not found', 404)
   }
 
-  private isTrustRowExpired(row: { evaluated_at?: unknown; created_at?: unknown } | null | undefined): boolean {
-    if (!row) return true
-    const ttlSeconds = getTrustEvaluationTtlSeconds()
-    const evaluatedAtSource = row.evaluated_at ?? row.created_at
-    if (evaluatedAtSource == null) return true
-    const evaluatedMs = new Date(evaluatedAtSource as Date | string).getTime()
-    if (!Number.isFinite(evaluatedMs)) return true
-    return Date.now() >= evaluatedMs + ttlSeconds * 1000
-  }
-
   private isTrustRowTrusted(
     row:
       | { did?: string; resolve_result?: unknown; height?: number; evaluated_at?: unknown; created_at?: unknown }
@@ -92,7 +78,8 @@ export class TrustApiService extends BaseService {
       | null
       | undefined
   ): boolean {
-    return this.isTrustRowExpired(row) || !this.isTrustRowTrusted(row)
+    if (!row) return true
+    return !this.isTrustRowTrusted(row)
   }
 
   private async getLastProcessedTrustBlockHeight(): Promise<number> {
@@ -211,7 +198,6 @@ export class TrustApiService extends BaseService {
     }
 
     const resolveResult = row?.resolve_result ?? null
-    const ttlSeconds = getTrustEvaluationTtlSeconds()
     const blockTime = await this.blockTimeAtHeight(effectiveHeight)
 
     const core = await buildVtResponseCore({
@@ -220,7 +206,7 @@ export class TrustApiService extends BaseService {
       evaluatedAtBlock: row ? row.height : effectiveHeight,
       evaluatedAtSource: row ? (row.evaluated_at ?? row.created_at) : null,
       fallbackEvaluatedAtTime: (blockTime ?? new Date()).toISOString(),
-      ttlSeconds,
+      expiresAtSource: row ? (row.expires_at ?? null) : null,
       atHeight: requestedHeight,
     })
 

--- a/src/services/resolver/trust-resolve-v4.builders.ts
+++ b/src/services/resolver/trust-resolve-v4.builders.ts
@@ -749,3 +749,50 @@ export async function buildEcsCredentials(resolveResult: unknown): Promise<Array
   }
   return out
 }
+
+const TRUST_ANCHOR_CREDENTIAL_KEYS = ['service', 'serviceProvider'] as const
+
+async function anchoringParticipantEffectiveUntils(subjectDid: string, ecsSchemaTitle: string): Promise<Date[]> {
+  const participants = (await knex('participants')
+    .where({ did: subjectDid, role: 'HOLDER' })
+    .whereNull('revoked')
+    .select('schema_id', 'effective_until')) as Array<{ schema_id: number; effective_until: Date | string | null }>
+  if (participants.length === 0) return []
+
+  const schemaIds = [...new Set(participants.map((p) => Number(p.schema_id)).filter((n) => Number.isFinite(n)))]
+  if (schemaIds.length === 0) return []
+  const schemas = (await knex('credential_schemas').whereIn('id', schemaIds).select('id', 'json_schema')) as Array<{
+    id: number
+    json_schema: unknown
+  }>
+  const matchingSchemaIds = new Set(
+    schemas.filter((s) => parseSchemaJson(s.json_schema)?.title === ecsSchemaTitle).map((s) => Number(s.id))
+  )
+
+  return participants
+    .filter((p) => matchingSchemaIds.has(Number(p.schema_id)) && p.effective_until != null)
+    .map((p) => new Date(p.effective_until as Date | string))
+}
+
+export async function computeExpiresAtBoundary(resolveResult: unknown): Promise<Date | null> {
+  if (!resolveResult || typeof resolveResult !== 'object') return null
+  const r = resolveResult as Record<string, unknown>
+
+  const boundaries: Date[] = []
+  for (const key of TRUST_ANCHOR_CREDENTIAL_KEYS) {
+    const cred = r[key]
+    if (!cred || typeof cred !== 'object') continue
+    const c = cred as Record<string, unknown>
+    const ecsSchemaTitle = ECS_SCHEMA_TITLE_BY_TYPE[String(c.schemaType ?? '').toLowerCase()]
+    if (!ecsSchemaTitle) continue
+
+    if (typeof c.validUntil === 'string') boundaries.push(new Date(c.validUntil))
+
+    const subjectDid = typeof c.id === 'string' ? c.id : ''
+    if (subjectDid) boundaries.push(...(await anchoringParticipantEffectiveUntils(subjectDid, ecsSchemaTitle)))
+  }
+
+  const valid = boundaries.filter((d) => Number.isFinite(d.getTime()))
+  if (valid.length === 0) return null
+  return valid.reduce((min, d) => (d.getTime() < min.getTime() ? d : min))
+}

--- a/src/services/resolver/trust-resolve-v4.builders.ts
+++ b/src/services/resolver/trust-resolve-v4.builders.ts
@@ -761,13 +761,18 @@ async function anchoringParticipantEffectiveUntils(subjectDid: string, ecsSchema
 
   const schemaIds = [...new Set(participants.map((p) => Number(p.schema_id)).filter((n) => Number.isFinite(n)))]
   if (schemaIds.length === 0) return []
-  const schemas = (await knex('credential_schemas').whereIn('id', schemaIds).select('id', 'json_schema')) as Array<{
-    id: number
-    json_schema: unknown
-  }>
-  const matchingSchemaIds = new Set(
-    schemas.filter((s) => parseSchemaJson(s.json_schema)?.title === ecsSchemaTitle).map((s) => Number(s.id))
-  )
+  const schemas = (await knex('credential_schemas')
+    .whereIn('id', schemaIds)
+    .select('id', 'ecosystem_id', 'json_schema')) as Array<{ id: number; ecosystem_id: number; json_schema: unknown }>
+  const matchingSchemaIds = new Set<number>()
+  for (const s of schemas) {
+    if (
+      parseSchemaJson(s.json_schema)?.title === ecsSchemaTitle &&
+      (await isEcosystemEcsAllowlisted(Number(s.ecosystem_id) || 0))
+    ) {
+      matchingSchemaIds.add(Number(s.id))
+    }
+  }
 
   return participants
     .filter((p) => matchingSchemaIds.has(Number(p.schema_id)) && p.effective_until != null)

--- a/src/services/resolver/trust-resolve.ts
+++ b/src/services/resolver/trust-resolve.ts
@@ -32,7 +32,6 @@ export type ResolverRuntimeConfig = {
   blocksPerCall?: number
   useEmbeddedRegistryAdapter?: boolean
   disableDigestSriVerification?: boolean
-  trustEvaluationTtlSeconds?: number
   pollObjectCachingRetryDays?: number
 
   txPrefilterEnabled?: boolean
@@ -59,7 +58,6 @@ export function getResolverRuntimeConfig(): ResolverRuntimeConfig | null {
     blocksPerCall: next?.blocksPerCall ?? legacy?.blocksPerCall,
     useEmbeddedRegistryAdapter: next?.useEmbeddedRegistryAdapter ?? legacy?.useEmbeddedRegistryAdapter,
     disableDigestSriVerification: next?.disableDigestSriVerification,
-    trustEvaluationTtlSeconds: next?.trustEvaluationTtlSeconds ?? legacy?.trustEvaluationTtlSeconds,
     pollObjectCachingRetryDays: next?.pollObjectCachingRetryDays ?? legacy?.pollObjectCachingRetryDays,
     didResolveConcurrency: next?.didResolveConcurrency ?? legacy?.didResolveConcurrency,
     maxDidsPerTrustBlock: next?.maxDidsPerTrustBlock ?? legacy?.maxDidsPerTrustBlock,

--- a/src/services/resolver/trust-resolve.ts
+++ b/src/services/resolver/trust-resolve.ts
@@ -15,7 +15,7 @@ import { detectStartMode } from '../../common/utils/start_mode_detector'
 import config from '../../config.json' with { type: 'json' }
 import { isEcsAllowlistEnforced } from './ecs-allowlist'
 import { defaultVprRegistriesFromEnv, readBoolFromEnv } from './trust-resolve.helpers'
-import { hasAllowlistedEcsServiceCredential } from './trust-resolve-v4.builders'
+import { computeExpiresAtBoundary, hasAllowlistedEcsServiceCredential } from './trust-resolve-v4.builders'
 import { attachRegistryAdapters } from './verre-registry-adapter'
 
 export type ResolverTierConfig = {
@@ -66,12 +66,6 @@ export function getResolverRuntimeConfig(): ResolverRuntimeConfig | null {
     freshStart: next?.freshStart ?? legacy?.freshStart,
     reindexing: next?.reindexing ?? legacy?.reindexing,
   }
-}
-
-export function getTrustEvaluationTtlSeconds(): number {
-  const cfg = getResolverRuntimeConfig()
-  const s = Number(cfg?.trustEvaluationTtlSeconds ?? 3600)
-  return Number.isFinite(s) && s > 0 ? Math.floor(s) : 3600
 }
 
 export function getDeclaredPollObjectCachingRetryDays(): number | null {
@@ -326,11 +320,9 @@ export async function saveTrustResults(row: {
   verifier_auth: unknown
   ecosystem_participant: unknown
 }): Promise<void> {
-  const trustTtlSeconds = getTrustEvaluationTtlSeconds()
   const evaluatedAt = new Date()
   const { trustStatus, production } = deriveStoredTrustState(row.resolve_result)
-  const expiresAt =
-    trustTtlSeconds > 0 ? new Date(evaluatedAt.getTime() + trustTtlSeconds * 1000) : new Date(evaluatedAt.getTime())
+  const expiresAt = await computeExpiresAtBoundary(row.resolve_result)
 
   await knex('trust_results')
     .insert({

--- a/src/services/resolver/trust-vt-response.ts
+++ b/src/services/resolver/trust-vt-response.ts
@@ -1,4 +1,3 @@
-import { getTrustEvaluationTtlSeconds } from './trust-resolve'
 import { buildEcsCredentials, resolveCorporationId } from './trust-resolve-v4.builders'
 
 export type VtResponseCore = {
@@ -6,7 +5,7 @@ export type VtResponseCore = {
   trusted: boolean
   evaluatedAtTime: string
   evaluatedAtBlock: number
-  expiresAtTime: string
+  expiresAtTime: string | null
   corporationId: number
 }
 
@@ -27,17 +26,17 @@ export type VtResponseCoreArgs = {
   evaluatedAtBlock: number
   evaluatedAtSource?: Date | string | null
   fallbackEvaluatedAtTime?: string
-  ttlSeconds?: number
+  expiresAtSource?: Date | string | null
   atHeight?: number
 }
 
 export async function buildVtResponseCore(args: VtResponseCoreArgs): Promise<VtResponseCore> {
-  const ttlSeconds = args.ttlSeconds ?? getTrustEvaluationTtlSeconds()
   const evaluatedAtTime =
     args.evaluatedAtSource != null
       ? new Date(args.evaluatedAtSource as Date | string).toISOString()
       : (args.fallbackEvaluatedAtTime ?? new Date().toISOString())
-  const expiresAtTime = new Date(new Date(evaluatedAtTime).getTime() + Math.max(0, ttlSeconds) * 1000).toISOString()
+  const expiresAtTime =
+    args.expiresAtSource != null ? new Date(args.expiresAtSource as Date | string).toISOString() : null
 
   return {
     did: args.did,

--- a/src/services/resolver/vt_change_detection.ts
+++ b/src/services/resolver/vt_change_detection.ts
@@ -88,7 +88,7 @@ function trustCoreFromRow(row: TrustResultsRow, corporationId: number | null): V
     trusted: status === 'TRUSTED' || status === 'PARTIAL',
     evaluatedAtTime: toIsoSeconds(row.evaluated_at ?? row.created_at),
     evaluatedAtBlock: Number(row.height ?? 0),
-    expiresAtTime: toIsoSeconds(row.expires_at),
+    expiresAtTime: row.expires_at != null ? toIsoSeconds(row.expires_at) : null,
     corporationId,
   }
 }

--- a/test/unit/services/resolver/trust_resolve.api.spec.ts
+++ b/test/unit/services/resolver/trust_resolve.api.spec.ts
@@ -113,13 +113,26 @@ describe('TrustV1ApiService POST /v4/verifiable-trust/resolve (resolveV4)', () =
       corporationId: 0,
     })
     expect(typeof res.evaluatedAtTime).toBe('string')
-    expect(typeof res.expiresAtTime).toBe('string')
+    // IDX-VT-EVAL-2: no indexed boundary => null, never evaluatedAt + TTL
+    expect(res.expiresAtTime).toBeNull()
     // legacy fields must be gone
     expect(res.trust_status).toBeUndefined()
     expect(res.evaluated_at_block).toBeUndefined()
     // opt-in sections excluded by default
     expect(res.participations).toBeUndefined()
     expect(res.ecosystems).toBeUndefined()
+  })
+
+  it('serves the persisted expiresAtTime boundary verbatim (IDX-VT-EVAL-5)', async () => {
+    const TrustResolve = await import('../../../../src/services/resolver/trust-resolve')
+    jest
+      .spyOn(TrustResolve, 'getTrustResultLatestByDidAtOrBeforeHeight')
+      .mockResolvedValue(mockStoredRow({ expires_at: '2027-01-31T23:59:59.000Z' }))
+
+    const ctx: any = { params: { did: 'did:verana:test123' }, meta: {} }
+    const res = await service.resolveV4(ctx)
+
+    expect(res.expiresAtTime).toBe('2027-01-31T23:59:59.000Z')
   })
 
   it('trusted is true for PARTIAL (verified-test) outcomes', async () => {

--- a/test/unit/services/resolver/trust_resolve_late_attribution.spec.ts
+++ b/test/unit/services/resolver/trust_resolve_late_attribution.spec.ts
@@ -46,6 +46,7 @@ jest.mock('../../../../src/services/resolver/ecs-allowlist', () => ({
 jest.mock('../../../../src/services/resolver/trust-resolve-v4.builders', () => ({
   __esModule: true,
   hasAllowlistedEcsServiceCredential: async () => true,
+  computeExpiresAtBoundary: async () => null,
 }))
 
 jest.mock('../../../../src/services/resolver/verre-registry-adapter', () => ({

--- a/test/unit/services/resolver/trust_resolve_late_attribution.spec.ts
+++ b/test/unit/services/resolver/trust_resolve_late_attribution.spec.ts
@@ -26,7 +26,6 @@ jest.mock('../../../../src/config.json', () => {
       resolver: {
         ...actual.resolver,
         enabled: true,
-        trustEvaluationTtlSeconds: 3600,
         pollObjectCachingRetryDays: 7,
       },
     },


### PR DESCRIPTION
Use `expiresAtTime` as the source of truth for TTL evaluation instead of the legacy documentation.