### PR TITLE
fix: parse colon-form vpr schema refs in the registry adapter

### DIFF
--- a/src/services/resolver/verre-registry-adapter.ts
+++ b/src/services/resolver/verre-registry-adapter.ts
@@ -21,9 +21,11 @@ function positiveInt(value: unknown): number | null {
   return n
 }
 
-function schemaIdFromUrl(url: string): number | null {
+export function schemaIdFromUrl(url: string): number | null {
   const direct = positiveInt(url)
   if (direct) return direct
+  const colonForm = /(?:^|[:/])cs(?:[:/]v\d+[:/]js)?[:/](\d+)$/.exec(url)
+  if (colonForm) return positiveInt(colonForm[1])
   try {
     const segments = new URL(url).pathname.split('/').filter(Boolean)
     return positiveInt(segments.at(-1))

--- a/test/unit/services/resolver/verre_registry_adapter.spec.ts
+++ b/test/unit/services/resolver/verre_registry_adapter.spec.ts
@@ -1,0 +1,22 @@
+import { schemaIdFromUrl } from '../../../../src/services/resolver/verre-registry-adapter'
+
+describe('schemaIdFromUrl', () => {
+  it.each([
+    ['vpr:verana:vna-testnet-1:cs:2', 2],
+    ['verana:cs:1', 1],
+    ['vpr:verana:vna-testnet-1/cs/v1/js/137', 137],
+    ['https://reg.example/cs/v1/js/9', 9],
+    ['42', 42],
+  ])('parses %s -> %s', (input, expected) => {
+    expect(schemaIdFromUrl(input)).toBe(expected)
+  })
+
+  it.each([
+    ['https://agent.example/vt/cs/v1/js/ecs-service'],
+    ['vpr:verana:vna-testnet-1:cs:'],
+    ['not-a-ref'],
+    [''],
+  ])('returns null for %s', (input) => {
+    expect(schemaIdFromUrl(input)).toBeNull()
+  })
+})


### PR DESCRIPTION
The registry adapter parses a schema ref to its numeric id to look up the on-chain schema. It only handled the path form (`.../cs/v1/js/137`) and bare numbers, so the canonical colon form `vpr:verana:<chain>:cs:<id>` fell through to `null`. That made the ISSUER permission check fail, and any credential whose JsonSchemaCredential dereferences to a colon-form ref stayed unresolvable.

Adds colon-form parsing (`verana:cs:1`, `vpr:verana:vna-testnet-1:cs:2`) alongside the existing forms, with a unit test covering both the parsed and the null cases. If you want me to remove the unit test please let me know.