### PR TITLE
fix: filter listParticipants by effective range for when

### DIFF
--- a/src/services/crawl-pp/pp_apis.service.ts
+++ b/src/services/crawl-pp/pp_apis.service.ts
@@ -313,7 +313,13 @@ export default class ParticipantAPIService extends BullableService {
     if (params.role) query.where(col('role'), params.role)
     if (params.op_state) query.where(col('op_state'), params.op_state)
     if (modifiedAfterIso) query.where(col('modified'), '>', modifiedAfterIso)
-    if (whenIso) query.where(col('modified'), '<=', whenIso)
+    if (whenIso) {
+      query.where((qb: any) => {
+        qb.where((q: any) => q.whereNull(col('effective_from')).orWhere(col('effective_from'), '<=', whenIso)).andWhere(
+          (q: any) => q.whereNull(col('effective_until')).orWhere(col('effective_until'), '>', whenIso)
+        )
+      })
+    }
 
     if (onlyValid) {
       query.where((qb: any) => {

--- a/test/unit/services/crawl-pp/pp_when_filter.spec.ts
+++ b/test/unit/services/crawl-pp/pp_when_filter.spec.ts
@@ -1,0 +1,25 @@
+import Knex from 'knex'
+
+import ParticipantAPIService from '../../../../src/services/crawl-pp/pp_apis.service'
+
+const knex = Knex({ client: 'pg' })
+
+const applyFilters = (whenIso: string) => {
+  const query = knex('participants')
+  const apply = (ParticipantAPIService.prototype as any).applyBaseListFiltersToQuery
+  apply.call({}, query, {}, undefined, undefined, whenIso, false, false, false, '2026-08-03T00:00:00.000Z')
+  return query.toSQL()
+}
+
+describe('listParticipants when filter', () => {
+  const WHEN = '2026-07-18T19:41:00.000Z'
+
+  it('filters on the effective range, not on modified', () => {
+    const { sql, bindings } = applyFilters(WHEN)
+
+    expect(sql).toContain('"effective_from" is null or "effective_from" <= ?')
+    expect(sql).toContain('"effective_until" is null or "effective_until" > ?')
+    expect(sql).not.toContain('"modified" <=')
+    expect(bindings).toEqual([WHEN, WHEN])
+  })
+})


### PR DESCRIPTION
Closes #381.

`when=` filtered on `modified` rather than the effective range, so it ignored both bounds. It now uses the same predicate as the `onlyValid` block just below, applied to `when` instead of now.

The `>` on the upper bound matches the EXPIRED rule in the participant state table, so `when=` and `participant_state` agree on the boundary.

Added an optional unit test (let me know if you want me to remove) on the generated query. Checked against devnet rows too: participant 9 is no longer returned a minute before it becomes effective, and participant 7 is no longer returned years after its range ended. 