### PR TITLE
feat(de): implement IDX-DE-QRY-5 list fee grants

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4901,6 +4901,139 @@
         }
       }
     },
+    "/v4/delegation/fee-grants": {
+      "get": {
+        "tags": ["Delegation"],
+        "summary": "List Fee Grants",
+        "description": "Retrieve a paginated, filtered list of FeeGrant entries: the grants through which a Corporation pays network transaction fees on behalf of a grantee. Aligned with the VPR FeeGrant entity (IDX-DE-QRY-5).",
+        "operationId": "listFeeGrants",
+        "parameters": [
+          {
+            "name": "grantor_corporation_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "uint64"
+            },
+            "description": "Filter by the granting Corporation id"
+          },
+          {
+            "name": "grantee",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by the grantee account"
+          },
+          {
+            "name": "msg_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter to grants whose msg_types[] includes this message type. Grants with an empty msg_types carry no message filter and match every type."
+          },
+          {
+            "name": "only_active",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "If true, only return non-expired grants (expiration > now or null). A periodic grant's auto-renewing cycle boundary never makes it inactive."
+          },
+          {
+            "name": "modified_after",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "description": "Only return grants modified strictly after this datetime. A grant is modified by its creation, update or revocation, and by any change to remaining_spend (fee draw or cycle reset)."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1024,
+              "default": 64
+            },
+            "description": "Caps the number of items returned"
+          },
+          {
+            "name": "min_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]+$"
+            },
+            "description": "Inclusive lower bound of the id range cursor"
+          },
+          {
+            "name": "max_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]+$"
+            },
+            "description": "Exclusive upper bound of the id range cursor"
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "id",
+                "+id",
+                "-id"
+              ],
+              "default": "-id"
+            },
+            "description": "Sort by id ascending (id/+id) or descending (-id, default)"
+          },
+          {
+            "$ref": "#/components/parameters/At-Block-Height"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of fee grants",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "fee_grants": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/FeeGrant"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerError"
+          }
+        }
+      }
+    },
     "/v4/trust-deposit/get/{corporation}": {
       "get": {
         "tags": [
@@ -8218,6 +8351,21 @@
           "records": { "type": "array", "items": { "$ref": "#/components/schemas/ParticipantAuthorizationRecord" } }
         }
       },
+      "FeeGrant": {
+        "type": "object",
+        "description": "A grant through which a Corporation pays network transaction fees on behalf of a grantee account (IDX-DE-QRY-5).",
+        "required": ["id", "grantor_corporation_id", "grantee", "msg_types"],
+        "properties": {
+          "id": { "type": "integer", "format": "uint64", "description": "Indexer-assigned per-row id, used as the pagination cursor. The VPR FeeGrant has no on-chain id." },
+          "grantor_corporation_id": { "type": "integer", "format": "uint64" },
+          "grantee": { "type": "string" },
+          "msg_types": { "type": "array", "items": { "type": "string" }, "description": "Message types the fee allowance applies to. Empty means the allowance carries no message filter and covers every type." },
+          "spend_limit": { "type": "array", "items": { "$ref": "#/components/schemas/DenomAmount" } },
+          "remaining_spend": { "type": "array", "items": { "$ref": "#/components/schemas/DenomAmount" }, "description": "Present when spend_limit is set. Sourced from the underlying x/feegrant allowance's running balance; zero once the allowance is exhausted." },
+          "expiration": { "type": "string", "format": "date-time", "description": "For periodic grants this is the allowance's current period_reset, the end of the current auto-renewing cycle." },
+          "period": { "type": "string", "description": "Reset period for spend_limit, as a duration (e.g. \"86400s\")." }
+        }
+      },
       "ResolutionResponse": {
         "type": "object",
         "required": ["did", "trusted", "evaluatedAtTime", "evaluatedAtBlock", "expiresAtTime", "corporationId"],
@@ -8584,7 +8732,7 @@
     },
     {
       "name": "Delegation",
-      "description": "Operator and VS-operator authorization queries"
+      "description": "Operator and VS-operator authorization queries, and corporation fee grants"
     },
     {
       "name": "Statistics",

--- a/src/migrations/20260710000000_create_delegation_tables.ts
+++ b/src/migrations/20260710000000_create_delegation_tables.ts
@@ -74,9 +74,51 @@ export async function up(knex: Knex): Promise<void> {
     table.index(['vs_operator_authorization_id', 'height'])
     table.index(['height'])
   })
+
+  await knex.schema.createTable('fee_grants', (table) => {
+    // FeeGrant has no on-chain id; this surrogate id is the spec's pagination cursor.
+    table.bigIncrements('id').primary()
+    table.bigInteger('grantor_corporation_id').notNullable()
+    table.string('grantee', 255).notNullable()
+    table.jsonb('msg_types').notNullable()
+    table.jsonb('spend_limit').nullable()
+    table.jsonb('remaining_spend').nullable()
+    table.timestamp('expiration').nullable()
+    table.text('period').nullable()
+    table.timestamp('modified').nullable()
+    table.integer('height').notNullable()
+    table.timestamp('created_at').defaultTo(knex.fn.now())
+
+    table.unique(['grantor_corporation_id', 'grantee'])
+    table.index(['grantor_corporation_id'])
+    table.index(['grantee'])
+    table.index(['modified'])
+    table.index(['height'])
+  })
+
+  await knex.schema.createTable('fee_grant_history', (table) => {
+    table.increments('id').primary()
+    table.bigInteger('fee_grant_id').notNullable()
+    table.bigInteger('grantor_corporation_id').notNullable()
+    table.string('grantee', 255).notNullable()
+    table.jsonb('msg_types').nullable()
+    table.jsonb('spend_limit').nullable()
+    table.jsonb('remaining_spend').nullable()
+    table.timestamp('expiration').nullable()
+    table.text('period').nullable()
+    table.timestamp('modified').nullable()
+    table.boolean('revoked').notNullable().defaultTo(false)
+    table.integer('height').notNullable()
+    table.timestamp('created_at').defaultTo(knex.fn.now())
+
+    table.index(['fee_grant_id', 'height'])
+    table.index(['height'])
+  })
 }
 
 export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('fee_grant_history')
+  await knex.schema.dropTableIfExists('fee_grants')
   await knex.schema.dropTableIfExists('vs_operator_authorization_history')
   await knex.schema.dropTableIfExists('vs_operator_authorizations')
   await knex.schema.dropTableIfExists('operator_authorization_history')

--- a/src/modules/de-height-sync/de_height_sync_helpers.ts
+++ b/src/modules/de-height-sync/de_height_sync_helpers.ts
@@ -1,6 +1,10 @@
 import type { Coin } from '@verana-labs/verana-types/codec/cosmos/base/v1beta1/coin'
 import type { Duration } from '@verana-labs/verana-types/codec/google/protobuf/duration'
 import {
+  QueryClientImpl as CoQueryClientImpl,
+  QueryGetCorporationRequest,
+} from '@verana-labs/verana-types/codec/verana/co/v1/query'
+import {
   QueryClientImpl as DeQueryClientImpl,
   QueryGetOperatorAuthorizationRequest,
   QueryGetVSOperatorAuthorizationRequest,
@@ -19,6 +23,8 @@ import {
   QueryClientImpl as FeegrantQueryClientImpl,
   QueryAllowanceRequest,
 } from 'cosmjs-types/cosmos/feegrant/v1beta1/query.js'
+import type { Timestamp } from 'cosmjs-types/google/protobuf/timestamp.js'
+import { fromTimestamp } from 'cosmjs-types/helpers.js'
 import { dateToIsoOrNull } from '../../common/utils/date_utils'
 import { withAbciQueryClient } from '../../common/utils/grpc_query'
 
@@ -180,4 +186,92 @@ export async function fetchFeeAllowance(
   const allowed = AllowedMsgAllowance.decode(allowance.value)
   if (!allowed.allowance) return undefined
   return unwrapFeeAllowance(allowed.allowance.typeUrl, allowed.allowance.value)
+}
+
+export interface FeeGrantAllowanceSnapshot {
+  msg_types: string[]
+  spend_limit: DenomAmount[] | null
+  remaining_spend: DenomAmount[] | null
+  expiration: string | null
+  period: string | null
+}
+
+function timestampToIso(ts: Timestamp | undefined): string | null {
+  if (!ts) return null
+  const date = fromTimestamp(ts)
+  return Number.isFinite(date.getTime()) ? date.toISOString() : null
+}
+
+function fetchAllowanceGrant(granter: string, grantee: string, blockHeight: number | undefined) {
+  return withAbciQueryClient(blockHeight, async (rpc) => {
+    const query = new FeegrantQueryClientImpl(rpc)
+    const res = await query.Allowance(QueryAllowanceRequest.fromPartial({ granter, grantee }))
+    return res?.allowance ?? undefined
+  })
+}
+
+export async function fetchCorporationPolicyAddress(
+  corporationId: number,
+  blockHeight: number | undefined
+): Promise<string | undefined> {
+  return withAbciQueryClient(blockHeight, async (rpc) => {
+    const query = new CoQueryClientImpl(rpc)
+    const res = await query.GetCorporation(QueryGetCorporationRequest.fromPartial({ corporationId }))
+    return res?.corporation?.policyAddress || undefined
+  })
+}
+
+function unwrapFeeGrantAllowance(
+  typeUrl: string,
+  value: Uint8Array
+): Omit<FeeGrantAllowanceSnapshot, 'msg_types'> | undefined {
+  if (typeUrl === PERIODIC_ALLOWANCE_TYPE_URL) {
+    const periodic = PeriodicAllowance.decode(value)
+    return {
+      spend_limit: serializeCoins(periodic.periodSpendLimit as Coin[]),
+      remaining_spend: serializeCoins(periodic.periodCanSpend as Coin[]),
+      // Spec: periodic expiration reflects the allowance's current period_reset.
+      expiration: timestampToIso(periodic.periodReset),
+      period: serializeDuration(periodic.period as Duration | undefined),
+    }
+  }
+  if (typeUrl === BASIC_ALLOWANCE_TYPE_URL) {
+    const basic = BasicAllowance.decode(value)
+    const limit = serializeCoins(basic.spendLimit as Coin[])
+    return {
+      spend_limit: limit,
+      remaining_spend: limit,
+      expiration: timestampToIso(basic.expiration),
+      period: null,
+    }
+  }
+  return undefined
+}
+
+export async function fetchFeeGrantAllowance(
+  granter: string,
+  grantee: string,
+  blockHeight: number | undefined
+): Promise<FeeGrantAllowanceSnapshot | undefined> {
+  let grant: Awaited<ReturnType<typeof fetchAllowanceGrant>>
+  try {
+    grant = await fetchAllowanceGrant(granter, grantee, blockHeight)
+  } catch (err: any) {
+    // A missing allowance surfaces as a thrown ABCI error, never an empty response.
+    if (/fee-grant not found/i.test(err?.message || String(err))) return undefined
+    throw err
+  }
+
+  const allowance = grant?.allowance
+  if (!allowance) return undefined
+
+  if (allowance.typeUrl !== ALLOWED_MSG_ALLOWANCE_TYPE_URL) {
+    const inner = unwrapFeeGrantAllowance(allowance.typeUrl, allowance.value)
+    return inner ? { msg_types: [], ...inner } : undefined
+  }
+
+  const allowed = AllowedMsgAllowance.decode(allowance.value)
+  if (!allowed.allowance) return undefined
+  const inner = unwrapFeeGrantAllowance(allowed.allowance.typeUrl, allowed.allowance.value)
+  return inner ? { msg_types: allowed.allowedMessages ?? [], ...inner } : undefined
 }

--- a/src/modules/de-height-sync/de_height_sync_helpers.ts
+++ b/src/modules/de-height-sync/de_height_sync_helpers.ts
@@ -266,6 +266,7 @@ export async function fetchFeeGrantAllowance(
   if (!allowance) return undefined
 
   if (allowance.typeUrl !== ALLOWED_MSG_ALLOWANCE_TYPE_URL) {
+    // No AllowedMsgAllowance wrapper means no message filter: empty msg_types reads as unrestricted.
     const inner = unwrapFeeGrantAllowance(allowance.typeUrl, allowance.value)
     return inner ? { msg_types: [], ...inner } : undefined
   }

--- a/src/modules/de-height-sync/de_height_sync_service.ts
+++ b/src/modules/de-height-sync/de_height_sync_service.ts
@@ -4,7 +4,9 @@ import { SERVICE } from '../../common'
 import { Corporation } from '../../models/corporation'
 import type { FeeAllowanceSnapshot } from './de_height_sync_helpers'
 import {
+  fetchCorporationPolicyAddress,
   fetchFeeAllowance,
+  fetchFeeGrantAllowance,
   fetchOperatorAuthorization,
   fetchVSOperatorAuthorization,
   serializeLedgerOperatorAuthorization,
@@ -17,6 +19,10 @@ export const DE_EVENT_TYPES = {
   GRANT_VS_OPERATOR_AUTHORIZATION: 'grant_vs_operator_authorization',
   REVOKE_VS_OPERATOR_AUTHORIZATION: 'revoke_vs_operator_authorization',
   UPDATE_VS_OPERATOR_AUTHORIZATION: 'update_vs_operator_authorization',
+  GRANT_FEE_ALLOWANCE: 'grant_fee_allowance',
+  REVOKE_FEE_ALLOWANCE: 'revoke_fee_allowance',
+  // SDK x/feegrant event: the only on-chain signal for fee draws (x/de emits none).
+  USE_FEEGRANT: 'use_feegrant',
 } as const
 
 const DE_EVENT_TYPE_SET = new Set<string>(Object.values(DE_EVENT_TYPES))
@@ -31,6 +37,8 @@ const VS_OPERATOR_AUTHORIZATION_EVENTS = new Set<string>([
   DE_EVENT_TYPES.REVOKE_VS_OPERATOR_AUTHORIZATION,
   DE_EVENT_TYPES.UPDATE_VS_OPERATOR_AUTHORIZATION,
 ])
+
+const FEE_GRANT_EVENTS = new Set<string>([DE_EVENT_TYPES.GRANT_FEE_ALLOWANCE, DE_EVENT_TYPES.REVOKE_FEE_ALLOWANCE])
 
 interface BlockEventAttribute {
   key?: string
@@ -100,6 +108,45 @@ export function extractVSOperatorAuthorizationIds(events: BlockEvent[]): number[
   return [...ids]
 }
 
+interface FeeGrantTouch {
+  grantorCorporationId: number
+  grantee: string
+  revoked: boolean
+}
+
+export function extractFeeGrantTouches(events: BlockEvent[]): FeeGrantTouch[] {
+  const touches = new Map<string, FeeGrantTouch>()
+  for (const event of events) {
+    if (!event.type || !FEE_GRANT_EVENTS.has(event.type)) continue
+    const grantorCorporationId = parseId(getAttr(event, 'corporation_id'))
+    const grantee = getAttr(event, 'grantee')
+    if (grantorCorporationId === undefined || !grantee) continue
+    touches.set(`${grantorCorporationId}:${grantee}`, {
+      grantorCorporationId,
+      grantee,
+      revoked: event.type === DE_EVENT_TYPES.REVOKE_FEE_ALLOWANCE,
+    })
+  }
+  return [...touches.values()]
+}
+
+interface FeeGrantUse {
+  granter: string
+  grantee: string
+}
+
+export function extractFeeGrantUses(events: BlockEvent[]): FeeGrantUse[] {
+  const uses = new Map<string, FeeGrantUse>()
+  for (const event of events) {
+    if (event.type !== DE_EVENT_TYPES.USE_FEEGRANT) continue
+    const granter = getAttr(event, 'granter')
+    const grantee = getAttr(event, 'grantee')
+    if (!granter || !grantee) continue
+    uses.set(`${granter}:${grantee}`, { granter, grantee })
+  }
+  return [...uses.values()]
+}
+
 async function resolveCorporationPolicyAddress(corporationId: number): Promise<string | undefined> {
   const corporation = await Corporation.query().findById(corporationId)
   return corporation?.policy_address ?? undefined
@@ -140,6 +187,72 @@ async function syncOperatorAuthorization(
   await broker.call(`${SERVICE.V1.DelegationDatabaseService.path}.syncOperatorAuthorization`, {
     authorization,
     feeAllowance: feeAllowance ?? null,
+    blockHeight,
+  })
+}
+
+async function syncFeeGrant(broker: ServiceBroker, touch: FeeGrantTouch, blockHeight: number): Promise<void> {
+  if (touch.revoked) {
+    await broker.call(`${SERVICE.V1.DelegationDatabaseService.path}.revokeFeeGrant`, {
+      grantorCorporationId: touch.grantorCorporationId,
+      grantee: touch.grantee,
+      blockHeight,
+    })
+    return
+  }
+
+  // Chain fallback covers reindex ordering, where the corporation pipeline may lag this one.
+  const policyAddress =
+    (await resolveCorporationPolicyAddress(touch.grantorCorporationId)) ??
+    (await fetchCorporationPolicyAddress(touch.grantorCorporationId, blockHeight))
+  if (!policyAddress) {
+    broker.logger.warn(
+      `[DE Height Sync] No policy address for corporation=${touch.grantorCorporationId}; skipping fee grant sync at block=${blockHeight}`
+    )
+    return
+  }
+
+  const snapshot = await fetchFeeGrantAllowance(policyAddress, touch.grantee, blockHeight)
+  if (!snapshot) {
+    // Allowance already pruned at end of block (re-grant fully drawn): zero an existing row.
+    broker.logger.warn(
+      `[DE Height Sync] No fee allowance found granter=${policyAddress} grantee=${touch.grantee} at block=${blockHeight}`
+    )
+    await broker.call(`${SERVICE.V1.DelegationDatabaseService.path}.refreshFeeGrantSpend`, {
+      grantorCorporationId: touch.grantorCorporationId,
+      grantee: touch.grantee,
+      snapshot: null,
+      blockHeight,
+    })
+    return
+  }
+
+  await broker.call(`${SERVICE.V1.DelegationDatabaseService.path}.syncFeeGrant`, {
+    grantorCorporationId: touch.grantorCorporationId,
+    grantee: touch.grantee,
+    snapshot,
+    blockHeight,
+  })
+}
+
+async function refreshFeeGrantUse(
+  broker: ServiceBroker,
+  use: FeeGrantUse,
+  blockHeight: number,
+  touchedPairs: Set<string>
+): Promise<void> {
+  const corporation = await Corporation.query().where('policy_address', use.granter).first()
+  if (!corporation?.id) return
+  // A grant/revoke in this block already synced the pair's end-of-block state.
+  if (touchedPairs.has(`${Number(corporation.id)}:${use.grantee}`)) return
+
+  // Transport errors propagate to the caller's catch, so a failed fetch writes nothing.
+  const snapshot = (await fetchFeeGrantAllowance(use.granter, use.grantee, blockHeight)) ?? null
+
+  await broker.call(`${SERVICE.V1.DelegationDatabaseService.path}.refreshFeeGrantSpend`, {
+    grantorCorporationId: Number(corporation.id),
+    grantee: use.grantee,
+    snapshot,
     blockHeight,
   })
 }
@@ -187,6 +300,28 @@ export async function runHeightSyncDE(
     } catch (err: any) {
       broker.logger.warn(
         `[DE Height Sync] Sync failed vs_operator_authorization=${vsoaId} at block=${blockHeight}: ${err?.message || String(err)}`
+      )
+    }
+  }
+
+  const feeGrantTouches = extractFeeGrantTouches(events)
+  const touchedPairs = new Set(feeGrantTouches.map((touch) => `${touch.grantorCorporationId}:${touch.grantee}`))
+  for (const touch of feeGrantTouches) {
+    try {
+      await syncFeeGrant(broker, touch, blockHeight)
+    } catch (err: any) {
+      broker.logger.warn(
+        `[DE Height Sync] Sync failed fee_grant corporation=${touch.grantorCorporationId} grantee=${touch.grantee} at block=${blockHeight}: ${err?.message || String(err)}`
+      )
+    }
+  }
+
+  for (const use of extractFeeGrantUses(events)) {
+    try {
+      await refreshFeeGrantUse(broker, use, blockHeight, touchedPairs)
+    } catch (err: any) {
+      broker.logger.warn(
+        `[DE Height Sync] Refresh failed fee_grant granter=${use.granter} grantee=${use.grantee} at block=${blockHeight}: ${err?.message || String(err)}`
       )
     }
   }

--- a/src/services/api/api.service.ts
+++ b/src/services/api/api.service.ts
@@ -370,6 +370,7 @@ function createRoute(path: string, aliases: Record<string, string>, requireBlock
         'GET operator-authorization/:id': `${SERVICE.V1.DelegationApiService.path}.getOperatorAuthorization`,
         'GET vs-operator-authorizations': `${SERVICE.V1.DelegationApiService.path}.listVSOperatorAuthorizations`,
         'GET vs-operator-authorization/:id': `${SERVICE.V1.DelegationApiService.path}.getVSOperatorAuthorization`,
+        'GET fee-grants': `${SERVICE.V1.DelegationApiService.path}.listFeeGrants`,
       }),
       createRoute('/v4/trust-deposit', {
         'GET get/:corporation_id': `${SERVICE.V1.TrustDepositApiService.path}.getTrustDeposit`,

--- a/src/services/crawl-de/de_apis.service.ts
+++ b/src/services/crawl-de/de_apis.service.ts
@@ -53,6 +53,32 @@ function serializeVSOperatorAuthorizationRow(row: any) {
   }
 }
 
+function serializeFeeGrantRow(row: any) {
+  const spendLimit = row.spend_limit ?? null
+
+  return {
+    id: Number(row.fee_grant_id ?? row.id),
+    grantor_corporation_id: Number(row.grantor_corporation_id),
+    grantee: String(row.grantee),
+    msg_types: row.msg_types ?? [],
+    ...(spendLimit ? { spend_limit: spendLimit, remaining_spend: row.remaining_spend ?? [] } : {}),
+    ...(row.expiration ? { expiration: dateToIsoOrNull(row.expiration) } : {}),
+    ...(row.period ? { period: String(row.period) } : {}),
+  }
+}
+
+interface ListFeeGrantsParams {
+  grantor_corporation_id?: number
+  grantee?: string
+  msg_type?: string
+  only_active?: boolean
+  modified_after?: string
+  limit?: number
+  min_id?: number
+  max_id?: number
+  sort?: string
+}
+
 interface ListOperatorAuthorizationsParams {
   corporation_id?: number
   operator?: string
@@ -290,6 +316,93 @@ export default class DelegationApiService extends BaseService {
       query.whereRaw(
         "EXISTS (SELECT 1 FROM jsonb_array_elements(records) rec WHERE rec->>'expiration' IS NULL OR (rec->>'expiration')::timestamptz > ?)",
         [ctx.now]
+      )
+    }
+    if (ctx.modifiedAfter) query.where('modified', '>', ctx.modifiedAfter)
+    if (p.min_id !== undefined) query.where(ctx.idColumn, '>=', p.min_id)
+    if (p.max_id !== undefined) query.where(ctx.idColumn, '<', p.max_id)
+  }
+
+  @Action({
+    rest: 'GET fee-grants',
+    params: {
+      grantor_corporation_id: { type: 'number', integer: true, positive: true, optional: true, convert: true },
+      grantee: { type: 'string', optional: true },
+      msg_type: { type: 'string', optional: true },
+      only_active: { type: 'boolean', optional: true, convert: true },
+      modified_after: { type: 'string', optional: true },
+      limit: { type: 'number', integer: true, optional: true, convert: true },
+      min_id: { type: 'string', optional: true, convert: true },
+      max_id: { type: 'string', optional: true, convert: true },
+      sort: { type: 'string', optional: true },
+    },
+  })
+  async listFeeGrants(ctx: Context<ListFeeGrantsParams>) {
+    try {
+      const p = ctx.params
+
+      const sortParsed = parseIdSortDirection(p.sort)
+      if (!sortParsed.ok) {
+        return ApiResponder.error(ctx, sortParsed.message, 400)
+      }
+      const sortDir = sortParsed.direction
+
+      let modifiedAfter: Date | undefined
+      if (p.modified_after) {
+        modifiedAfter = new Date(p.modified_after)
+        if (Number.isNaN(modifiedAfter.getTime())) {
+          return ApiResponder.error(ctx, 'Invalid modified_after datetime format', 400)
+        }
+      }
+
+      const limit = Math.min(Math.max(Number(p.limit) || 64, 1), 1024)
+      const blockHeight = getBlockHeight(ctx)
+
+      const query =
+        blockHeight !== undefined
+          ? this.buildAtHeightFeeGrantListQuery(blockHeight)
+          : knex<any>('fee_grants').select('*')
+      const idColumn = blockHeight !== undefined ? 'fee_grant_id' : 'id'
+
+      let now: Date | undefined
+      if (p.only_active) {
+        now = blockHeight !== undefined ? await getBlockChainTimeAsOf(blockHeight, { logger: this.logger }) : new Date()
+      }
+
+      this.applyFeeGrantListFilters(query, p, { modifiedAfter, now, idColumn })
+      const rows = await query.orderBy(idColumn, sortDir).limit(limit)
+
+      return ApiResponder.success(ctx, {
+        fee_grants: rows.map(serializeFeeGrantRow),
+      })
+    } catch (err: any) {
+      this.logger.error('Error in Delegation.listFeeGrants:', err)
+      return ApiResponder.error(ctx, `Failed to list fee grants: ${err?.message || String(err)}`, 500)
+    }
+  }
+
+  private buildAtHeightFeeGrantListQuery(blockHeight: number) {
+    const latestPerId = knex('fee_grant_history')
+      .distinctOn('fee_grant_id')
+      .select('*')
+      .where('height', '<=', blockHeight)
+      .orderBy('fee_grant_id', 'asc')
+      .orderBy('height', 'desc')
+    return knex.from(latestPerId.as('fg')).select('*').where('revoked', false)
+  }
+
+  private applyFeeGrantListFilters(
+    query: any,
+    p: ListFeeGrantsParams,
+    ctx: { modifiedAfter?: Date; now?: Date; idColumn: string }
+  ) {
+    if (p.grantor_corporation_id !== undefined) query.where('grantor_corporation_id', p.grantor_corporation_id)
+    if (p.grantee) query.where('grantee', p.grantee)
+    if (p.msg_type) query.whereRaw('msg_types @> ?::jsonb', [JSON.stringify([p.msg_type])])
+    if (ctx.now) {
+      // Periodic grants auto-renew: a past cycle boundary never makes them inactive.
+      query.where((builder: any) =>
+        builder.whereNull('expiration').orWhere('expiration', '>', ctx.now).orWhereNotNull('period')
       )
     }
     if (ctx.modifiedAfter) query.where('modified', '>', ctx.modifiedAfter)

--- a/src/services/crawl-de/de_apis.service.ts
+++ b/src/services/crawl-de/de_apis.service.ts
@@ -398,7 +398,10 @@ export default class DelegationApiService extends BaseService {
   ) {
     if (p.grantor_corporation_id !== undefined) query.where('grantor_corporation_id', p.grantor_corporation_id)
     if (p.grantee) query.where('grantee', p.grantee)
-    if (p.msg_type) query.whereRaw('msg_types @> ?::jsonb', [JSON.stringify([p.msg_type])])
+    // Empty msg_types means the allowance carries no message filter, so it covers every type.
+    if (p.msg_type) {
+      query.whereRaw("(msg_types @> ?::jsonb OR msg_types = '[]'::jsonb)", [JSON.stringify([p.msg_type])])
+    }
     if (ctx.now) {
       // Periodic grants auto-renew: a past cycle boundary never makes them inactive.
       query.where((builder: any) =>

--- a/src/services/crawl-de/de_database.service.ts
+++ b/src/services/crawl-de/de_database.service.ts
@@ -6,10 +6,18 @@ import { getBlockChainTimeAsOf } from '../../common/utils/block_time'
 import knex from '../../common/utils/db_connection'
 import { toJsonbColumn } from '../../common/utils/helper'
 import type {
+  DenomAmount,
   FeeAllowanceSnapshot,
+  FeeGrantAllowanceSnapshot,
   OperatorAuthorizationRow,
   VSOperatorAuthorizationRow,
 } from '../../modules/de-height-sync/de_height_sync_helpers'
+
+function parseJsonb<T>(value: unknown): T | null {
+  if (value == null) return null
+  if (typeof value === 'string') return JSON.parse(value)
+  return value as T
+}
 
 @Service({
   name: SERVICE.V1.DelegationDatabaseService.key,
@@ -100,6 +108,132 @@ export default class DelegationDatabaseService extends BaseService {
         operator_authorization_id: id,
         corporation_id: corporationId,
         operator,
+        modified,
+        revoked: true,
+        height: blockHeight,
+      })
+    })
+
+    return { success: true }
+  }
+
+  @Action({ name: 'syncFeeGrant' })
+  async syncFeeGrant(ctx: {
+    params: {
+      grantorCorporationId: number
+      grantee: string
+      snapshot: FeeGrantAllowanceSnapshot
+      blockHeight: number
+    }
+  }): Promise<{ success: boolean }> {
+    const { grantorCorporationId, grantee, snapshot, blockHeight } = ctx.params
+
+    const modified = await getBlockChainTimeAsOf(blockHeight, { logger: this.logger })
+
+    const row = {
+      grantor_corporation_id: grantorCorporationId,
+      grantee,
+      msg_types: toJsonbColumn(snapshot.msg_types),
+      spend_limit: toJsonbColumn(snapshot.spend_limit),
+      remaining_spend: toJsonbColumn(snapshot.remaining_spend),
+      expiration: snapshot.expiration,
+      period: snapshot.period,
+      modified,
+      height: blockHeight,
+    }
+
+    await knex.transaction(async (trx) => {
+      const [upserted] = await trx('fee_grants')
+        .insert(row)
+        .onConflict(['grantor_corporation_id', 'grantee'])
+        .merge(['msg_types', 'spend_limit', 'remaining_spend', 'expiration', 'period', 'modified', 'height'])
+        .returning('id')
+
+      await trx('fee_grant_history').insert({
+        fee_grant_id: upserted.id,
+        ...row,
+        revoked: false,
+      })
+    })
+
+    return { success: true }
+  }
+
+  @Action({ name: 'refreshFeeGrantSpend' })
+  async refreshFeeGrantSpend(ctx: {
+    params: {
+      grantorCorporationId: number
+      grantee: string
+      snapshot: FeeGrantAllowanceSnapshot | null
+      blockHeight: number
+    }
+  }): Promise<{ success: boolean }> {
+    const { grantorCorporationId, grantee, snapshot, blockHeight } = ctx.params
+
+    const existing = await knex('fee_grants')
+      .where('grantor_corporation_id', grantorCorporationId)
+      .where('grantee', grantee)
+      .first()
+    if (!existing) return { success: true }
+
+    const modified = await getBlockChainTimeAsOf(blockHeight, { logger: this.logger })
+
+    const spendLimit = parseJsonb<DenomAmount[]>(existing.spend_limit)
+    // Allowance gone while the grant row persists means fully exhausted: report zero.
+    const remainingSpend = snapshot
+      ? snapshot.remaining_spend
+      : (spendLimit?.map((coin) => ({ denom: coin.denom, amount: '0' })) ?? null)
+    const expiration = snapshot ? snapshot.expiration : existing.expiration
+
+    await knex.transaction(async (trx) => {
+      await trx('fee_grants')
+        .where('id', existing.id)
+        .update({
+          remaining_spend: toJsonbColumn(remainingSpend),
+          expiration,
+          modified,
+          height: blockHeight,
+        })
+
+      await trx('fee_grant_history').insert({
+        fee_grant_id: existing.id,
+        grantor_corporation_id: grantorCorporationId,
+        grantee,
+        msg_types: toJsonbColumn(parseJsonb<string[]>(existing.msg_types)),
+        spend_limit: toJsonbColumn(spendLimit),
+        remaining_spend: toJsonbColumn(remainingSpend),
+        expiration,
+        period: existing.period,
+        modified,
+        revoked: false,
+        height: blockHeight,
+      })
+    })
+
+    return { success: true }
+  }
+
+  @Action({ name: 'revokeFeeGrant' })
+  async revokeFeeGrant(ctx: {
+    params: { grantorCorporationId: number; grantee: string; blockHeight: number }
+  }): Promise<{ success: boolean }> {
+    const { grantorCorporationId, grantee, blockHeight } = ctx.params
+
+    const existing = await knex('fee_grants')
+      .where('grantor_corporation_id', grantorCorporationId)
+      .where('grantee', grantee)
+      .first()
+    if (!existing) return { success: true }
+
+    const modified = await getBlockChainTimeAsOf(blockHeight, { logger: this.logger })
+
+    await knex.transaction(async (trx) => {
+      await trx('fee_grants').where('id', existing.id).delete()
+
+      await trx('fee_grant_history').insert({
+        fee_grant_id: existing.id,
+        grantor_corporation_id: grantorCorporationId,
+        grantee,
         modified,
         revoked: true,
         height: blockHeight,

--- a/test/unit/modules/de-height-sync/de_fee_grant_allowance.spec.ts
+++ b/test/unit/modules/de-height-sync/de_fee_grant_allowance.spec.ts
@@ -1,0 +1,89 @@
+import {
+  AllowedMsgAllowance,
+  BasicAllowance,
+  PeriodicAllowance,
+} from 'cosmjs-types/cosmos/feegrant/v1beta1/feegrant.js'
+import { toTimestamp } from 'cosmjs-types/helpers.js'
+import Long from 'long'
+import { withAbciQueryClient } from '../../../../src/common/utils/grpc_query'
+import { fetchFeeGrantAllowance } from '../../../../src/modules/de-height-sync/de_height_sync_helpers'
+
+jest.mock('../../../../src/common/utils/grpc_query', () => ({
+  withAbciQueryClient: jest.fn(),
+}))
+
+const mockAbci = withAbciQueryClient as jest.MockedFunction<typeof withAbciQueryClient>
+
+const EC_CREATE = '/verana.ec.v1.MsgCreateEcosystem'
+const RESET = new Date('2026-08-01T00:00:00.000Z')
+const EXPIRY = new Date('2026-09-01T00:00:00.000Z')
+
+function allowedMsgGrant(inner: { typeUrl: string; value: Uint8Array }) {
+  return {
+    allowance: {
+      typeUrl: '/cosmos.feegrant.v1beta1.AllowedMsgAllowance',
+      value: AllowedMsgAllowance.encode(
+        AllowedMsgAllowance.fromPartial({ allowedMessages: [EC_CREATE], allowance: inner })
+      ).finish(),
+    },
+  }
+}
+
+describe('fetchFeeGrantAllowance', () => {
+  beforeEach(() => mockAbci.mockReset())
+
+  it('decodes a periodic allowance: period_reset becomes expiration, period_can_spend the remaining', async () => {
+    const periodic = PeriodicAllowance.encode(
+      PeriodicAllowance.fromPartial({
+        basic: BasicAllowance.fromPartial({}),
+        period: { seconds: Long.fromNumber(604800), nanos: 0 },
+        periodSpendLimit: [{ denom: 'uvna', amount: '1000' }],
+        periodCanSpend: [{ denom: 'uvna', amount: '400' }],
+        periodReset: toTimestamp(RESET),
+      })
+    ).finish()
+    mockAbci.mockResolvedValue(
+      allowedMsgGrant({ typeUrl: '/cosmos.feegrant.v1beta1.PeriodicAllowance', value: periodic })
+    )
+
+    expect(await fetchFeeGrantAllowance('verana1policy', 'verana1op', 100)).toEqual({
+      msg_types: [EC_CREATE],
+      spend_limit: [{ denom: 'uvna', amount: '1000' }],
+      remaining_spend: [{ denom: 'uvna', amount: '400' }],
+      expiration: RESET.toISOString(),
+      period: '604800s',
+    })
+  })
+
+  it('decodes a basic allowance: spend_limit doubles as remaining, absolute expiration, no period', async () => {
+    const basic = BasicAllowance.encode(
+      BasicAllowance.fromPartial({
+        spendLimit: [{ denom: 'uvna', amount: '600' }],
+        expiration: toTimestamp(EXPIRY),
+      })
+    ).finish()
+    mockAbci.mockResolvedValue(allowedMsgGrant({ typeUrl: '/cosmos.feegrant.v1beta1.BasicAllowance', value: basic }))
+
+    expect(await fetchFeeGrantAllowance('verana1policy', 'verana1op', 100)).toEqual({
+      msg_types: [EC_CREATE],
+      spend_limit: [{ denom: 'uvna', amount: '600' }],
+      remaining_spend: [{ denom: 'uvna', amount: '600' }],
+      expiration: EXPIRY.toISOString(),
+      period: null,
+    })
+  })
+
+  it('returns undefined when the chain reports the allowance absent', async () => {
+    mockAbci.mockRejectedValue(
+      new Error('Query failed with (38): rpc error: code = Internal desc = fee-grant not found: not found')
+    )
+
+    expect(await fetchFeeGrantAllowance('verana1policy', 'verana1op', 100)).toBeUndefined()
+  })
+
+  it('rethrows transport errors instead of treating them as an absent allowance', async () => {
+    mockAbci.mockRejectedValue(new Error('connection refused'))
+
+    await expect(fetchFeeGrantAllowance('verana1policy', 'verana1op', 100)).rejects.toThrow('connection refused')
+  })
+})

--- a/test/unit/modules/de-height-sync/de_fee_grant_allowance.spec.ts
+++ b/test/unit/modules/de-height-sync/de_fee_grant_allowance.spec.ts
@@ -73,6 +73,19 @@ describe('fetchFeeGrantAllowance', () => {
     })
   })
 
+  it('reports an unwrapped allowance as unrestricted (empty msg_types)', async () => {
+    const basic = BasicAllowance.encode(
+      BasicAllowance.fromPartial({ spendLimit: [{ denom: 'uvna', amount: '600' }] })
+    ).finish()
+    mockAbci.mockResolvedValue({
+      allowance: { typeUrl: '/cosmos.feegrant.v1beta1.BasicAllowance', value: basic },
+    })
+
+    const snapshot = await fetchFeeGrantAllowance('verana1policy', 'verana1op', 100)
+    expect(snapshot?.msg_types).toEqual([])
+    expect(snapshot?.spend_limit).toEqual([{ denom: 'uvna', amount: '600' }])
+  })
+
   it('returns undefined when the chain reports the allowance absent', async () => {
     mockAbci.mockRejectedValue(
       new Error('Query failed with (38): rpc error: code = Internal desc = fee-grant not found: not found')

--- a/test/unit/services/crawl-de/de_fee_grants.spec.ts
+++ b/test/unit/services/crawl-de/de_fee_grants.spec.ts
@@ -1,0 +1,412 @@
+import { Buffer } from 'node:buffer'
+import { ServiceBroker } from 'moleculer'
+import { SERVICE } from '../../../../src/common'
+import knex from '../../../../src/common/utils/db_connection'
+import {
+  extractFeeGrantTouches,
+  extractFeeGrantUses,
+  hasDelegationEvents,
+} from '../../../../src/modules/de-height-sync/de_height_sync_service'
+import DelegationApiService from '../../../../src/services/crawl-de/de_apis.service'
+import DelegationDatabaseService from '../../../../src/services/crawl-de/de_database.service'
+
+const b64 = (value: string) => Buffer.from(value, 'utf8').toString('base64')
+
+function event(type: string, attributes: Record<string, string>, encoded = false) {
+  return {
+    type,
+    attributes: Object.entries(attributes).map(([key, value]) =>
+      encoded ? { key: b64(key), value: b64(value) } : { key, value }
+    ),
+  }
+}
+
+const EC_CREATE = '/verana.ec.v1.MsgCreateEcosystem'
+const CS_CREATE = '/verana.cs.v1.MsgCreateCredentialSchema'
+
+const T1 = '2026-07-01T00:00:00.000Z'
+const T2 = '2026-07-05T00:00:00.000Z'
+const T3 = '2026-07-09T00:00:00.000Z'
+const PAST = '2020-01-01T00:00:00.000Z'
+const FUTURE = '2999-01-01T00:00:00.000Z'
+
+describe('de height-sync fee grant event extraction', () => {
+  it('detects fee grant and use_feegrant events among unrelated ones', () => {
+    expect(hasDelegationEvents([event('coin_spent', { amount: '1uvna' })])).toBe(false)
+    expect(hasDelegationEvents([event('grant_fee_allowance', { corporation_id: '1' })])).toBe(true)
+    expect(hasDelegationEvents([event('revoke_fee_allowance', { corporation_id: '1' })])).toBe(true)
+    expect(hasDelegationEvents([event('use_feegrant', { granter: 'verana1policy' })])).toBe(true)
+  })
+
+  it('extracts a fee grant touch from a plain event', () => {
+    const events = [event('grant_fee_allowance', { corporation_id: '7', grantee: 'verana1operator' })]
+
+    expect(extractFeeGrantTouches(events)).toEqual([
+      { grantorCorporationId: 7, grantee: 'verana1operator', revoked: false },
+    ])
+  })
+
+  it('decodes base64-encoded fee grant attributes', () => {
+    const events = [event('grant_fee_allowance', { corporation_id: '3', grantee: 'verana1abc' }, true)]
+
+    expect(extractFeeGrantTouches(events)).toEqual([{ grantorCorporationId: 3, grantee: 'verana1abc', revoked: false }])
+  })
+
+  it('last touch per (corporation, grantee) pair wins', () => {
+    const events = [
+      event('grant_fee_allowance', { corporation_id: '3', grantee: 'verana1abc' }),
+      event('revoke_fee_allowance', { corporation_id: '3', grantee: 'verana1abc' }),
+      event('grant_fee_allowance', { corporation_id: '3', grantee: 'verana1other' }),
+    ]
+
+    expect(extractFeeGrantTouches(events)).toEqual([
+      { grantorCorporationId: 3, grantee: 'verana1abc', revoked: true },
+      { grantorCorporationId: 3, grantee: 'verana1other', revoked: false },
+    ])
+  })
+
+  it('ignores fee grant touches with missing attributes', () => {
+    const events = [
+      event('grant_fee_allowance', { grantee: 'verana1abc' }),
+      event('grant_fee_allowance', { corporation_id: '0', grantee: 'verana1abc' }),
+      event('revoke_fee_allowance', { corporation_id: '3' }),
+    ]
+
+    expect(extractFeeGrantTouches(events)).toEqual([])
+  })
+
+  it('dedupes use_feegrant events per (granter, grantee) pair', () => {
+    const events = [
+      event('use_feegrant', { granter: 'verana1policy', grantee: 'verana1op' }),
+      event('use_feegrant', { granter: 'verana1policy', grantee: 'verana1op' }, true),
+      event('use_feegrant', { granter: 'verana1policy', grantee: 'verana1other' }),
+      event('use_feegrant', { granter: 'verana1policy' }),
+    ]
+
+    expect(extractFeeGrantUses(events)).toEqual([
+      { granter: 'verana1policy', grantee: 'verana1op' },
+      { granter: 'verana1policy', grantee: 'verana1other' },
+    ])
+  })
+})
+
+function seedFeeGrantRow(row: Record<string, unknown>) {
+  return {
+    spend_limit: null,
+    remaining_spend: null,
+    expiration: null,
+    period: null,
+    ...row,
+    msg_types: JSON.stringify(row.msg_types),
+  }
+}
+
+function listedIds(res: any): number[] {
+  return (res.fee_grants as any[]).map((g) => g.id)
+}
+
+describe('DelegationApiService.listFeeGrants', () => {
+  const broker = new ServiceBroker({ logger: false })
+  const serviceKey = SERVICE.V1.DelegationApiService.path
+
+  beforeAll(async () => {
+    broker.createService(DelegationApiService)
+    await broker.start()
+
+    await knex('fee_grant_history').del()
+    await knex('fee_grants').del()
+
+    await knex('fee_grants').insert([
+      seedFeeGrantRow({
+        id: 1,
+        grantor_corporation_id: 1,
+        grantee: 'verana1opA',
+        msg_types: [EC_CREATE],
+        spend_limit: JSON.stringify([{ denom: 'uvna', amount: '1000' }]),
+        remaining_spend: JSON.stringify([{ denom: 'uvna', amount: '600' }]),
+        expiration: null,
+        modified: T1,
+        height: 100,
+      }),
+      seedFeeGrantRow({
+        id: 2,
+        grantor_corporation_id: 1,
+        grantee: 'verana1opB',
+        msg_types: [CS_CREATE],
+        expiration: FUTURE,
+        modified: T2,
+        height: 110,
+      }),
+      seedFeeGrantRow({
+        id: 3,
+        grantor_corporation_id: 2,
+        grantee: 'verana1opA',
+        msg_types: [EC_CREATE],
+        expiration: PAST,
+        modified: T3,
+        height: 120,
+      }),
+      seedFeeGrantRow({
+        id: 4,
+        grantor_corporation_id: 2,
+        grantee: 'verana1opC',
+        msg_types: [EC_CREATE],
+        spend_limit: JSON.stringify([{ denom: 'uvna', amount: '500' }]),
+        remaining_spend: JSON.stringify([{ denom: 'uvna', amount: '500' }]),
+        expiration: PAST,
+        period: '604800s',
+        modified: T3,
+        height: 130,
+      }),
+    ])
+  })
+
+  afterAll(async () => {
+    await broker.stop()
+  })
+
+  const list = (params: Record<string, unknown> = {}) =>
+    broker.call(`${serviceKey}.listFeeGrants`, params) as Promise<any>
+
+  it('returns all rows newest-first by default (-id)', async () => {
+    expect(listedIds(await list())).toEqual([4, 3, 2, 1])
+  })
+
+  it('sorts ascending with sort=+id', async () => {
+    expect(listedIds(await list({ sort: '+id' }))).toEqual([1, 2, 3, 4])
+  })
+
+  it('rejects an unsupported sort column', async () => {
+    expect((await list({ sort: 'grantee' })).code).toBe(400)
+  })
+
+  it('filters by grantor_corporation_id', async () => {
+    expect(listedIds(await list({ grantor_corporation_id: 1 }))).toEqual([2, 1])
+  })
+
+  it('filters by grantee', async () => {
+    expect(listedIds(await list({ grantee: 'verana1opA' }))).toEqual([3, 1])
+  })
+
+  it('filters by msg_type membership in msg_types[]', async () => {
+    expect(listedIds(await list({ msg_type: CS_CREATE }))).toEqual([2])
+  })
+
+  it('only_active excludes expired grants but keeps periodic ones past their cycle boundary', async () => {
+    expect(listedIds(await list({ only_active: true }))).toEqual([4, 2, 1])
+  })
+
+  it('modified_after filters strictly after the given datetime', async () => {
+    expect(listedIds(await list({ modified_after: T2 }))).toEqual([4, 3])
+  })
+
+  it('rejects an invalid modified_after datetime', async () => {
+    expect((await list({ modified_after: 'not-a-date' })).code).toBe(400)
+  })
+
+  it('paginates with the half-open id cursor and limit', async () => {
+    expect(listedIds(await list({ max_id: 3 }))).toEqual([2, 1])
+    expect(listedIds(await list({ min_id: 3 }))).toEqual([4, 3])
+    expect(listedIds(await list({ limit: 1 }))).toEqual([4])
+  })
+
+  it('serializes spend_limit/remaining_spend only when set', async () => {
+    const res = await list({ grantor_corporation_id: 1, sort: '+id' })
+    const [first, second] = res.fee_grants
+    expect(first.id).toBe(1)
+    expect(first.spend_limit).toEqual([{ denom: 'uvna', amount: '1000' }])
+    expect(first.remaining_spend).toEqual([{ denom: 'uvna', amount: '600' }])
+    expect(second.id).toBe(2)
+    expect(second).not.toHaveProperty('spend_limit')
+  })
+
+  it('serializes period and expiration only when set', async () => {
+    const res = await list({ sort: '+id' })
+    const rows = res.fee_grants
+    expect(rows[0]).not.toHaveProperty('expiration')
+    expect(rows[0]).not.toHaveProperty('period')
+    expect(rows[3].period).toBe('604800s')
+    expect(rows[3].expiration).toBe(PAST)
+  })
+
+  it('does not expose the internal modified field in the response', async () => {
+    const [row] = (await list({ limit: 1 })).fee_grants
+    expect(row).not.toHaveProperty('modified')
+  })
+
+  it('resolves the list as of a requested block height from history', async () => {
+    await knex('fee_grant_history').insert([
+      seedFeeGrantRow({
+        fee_grant_id: 1,
+        grantor_corporation_id: 1,
+        grantee: 'verana1opA',
+        msg_types: [EC_CREATE],
+        spend_limit: JSON.stringify([{ denom: 'uvna', amount: '1000' }]),
+        remaining_spend: JSON.stringify([{ denom: 'uvna', amount: '1000' }]),
+        modified: T1,
+        revoked: false,
+        height: 100,
+      }),
+      seedFeeGrantRow({
+        fee_grant_id: 1,
+        grantor_corporation_id: 1,
+        grantee: 'verana1opA',
+        msg_types: [EC_CREATE],
+        spend_limit: JSON.stringify([{ denom: 'uvna', amount: '1000' }]),
+        remaining_spend: JSON.stringify([{ denom: 'uvna', amount: '600' }]),
+        modified: T2,
+        revoked: false,
+        height: 110,
+      }),
+      seedFeeGrantRow({
+        fee_grant_id: 2,
+        grantor_corporation_id: 1,
+        grantee: 'verana1opB',
+        msg_types: [CS_CREATE],
+        modified: T3,
+        revoked: true,
+        height: 105,
+      }),
+    ])
+
+    const atHeight = (blockHeight: number) =>
+      broker.call(`${serviceKey}.listFeeGrants`, {}, { meta: { blockHeight } }) as Promise<any>
+
+    const res100 = await atHeight(100)
+    expect(listedIds(res100)).toEqual([1])
+    expect(res100.fee_grants[0].remaining_spend).toEqual([{ denom: 'uvna', amount: '1000' }])
+
+    const res110 = await atHeight(110)
+    expect(listedIds(res110)).toEqual([1])
+    expect(res110.fee_grants[0].remaining_spend).toEqual([{ denom: 'uvna', amount: '600' }])
+  })
+})
+
+describe('DelegationDatabaseService fee grant actions', () => {
+  const broker = new ServiceBroker({ logger: false })
+  const serviceKey = SERVICE.V1.DelegationDatabaseService.path
+
+  const snapshot = (overrides: Record<string, unknown> = {}) => ({
+    msg_types: [EC_CREATE],
+    spend_limit: [{ denom: 'uvna', amount: '1000' }],
+    remaining_spend: [{ denom: 'uvna', amount: '1000' }],
+    expiration: FUTURE,
+    period: null,
+    ...overrides,
+  })
+
+  const blockTime = (height: number) => new Date(Date.UTC(2026, 6, height)).toISOString()
+  const seededHeights = [10, 11, 12, 13, 14, 15, 16, 17]
+
+  beforeAll(async () => {
+    broker.createService(DelegationDatabaseService)
+    await broker.start()
+
+    await knex('fee_grant_history').del()
+    await knex('fee_grants').del()
+
+    await knex('block').whereIn('height', seededHeights).del()
+    await knex('block').insert(
+      seededHeights.map((height) => ({
+        height,
+        hash: `feegrant-test-${height}`,
+        time: blockTime(height),
+        proposer_address: 'test',
+        data: '{}',
+        tx_count: 0,
+      }))
+    )
+  })
+
+  afterAll(async () => {
+    await knex('block').whereIn('height', seededHeights).del()
+    await broker.stop()
+  })
+
+  const call = (action: string, params: Record<string, unknown>) =>
+    broker.call(`${serviceKey}.${action}`, params) as Promise<any>
+
+  it('syncFeeGrant inserts a row and re-sync keeps the surrogate id', async () => {
+    await call('syncFeeGrant', { grantorCorporationId: 1, grantee: 'verana1op', snapshot: snapshot(), blockHeight: 10 })
+
+    const inserted = await knex('fee_grants').where({ grantor_corporation_id: 1, grantee: 'verana1op' }).first()
+    expect(inserted).toBeTruthy()
+    expect(inserted.msg_types).toEqual([EC_CREATE])
+
+    await call('syncFeeGrant', {
+      grantorCorporationId: 1,
+      grantee: 'verana1op',
+      snapshot: snapshot({ msg_types: [EC_CREATE, CS_CREATE] }),
+      blockHeight: 11,
+    })
+
+    const updated = await knex('fee_grants').where({ grantor_corporation_id: 1, grantee: 'verana1op' }).first()
+    expect(Number(updated.id)).toBe(Number(inserted.id))
+    expect(updated.msg_types).toEqual([EC_CREATE, CS_CREATE])
+
+    const history = await knex('fee_grant_history').where('fee_grant_id', inserted.id)
+    expect(history).toHaveLength(2)
+  })
+
+  it('refreshFeeGrantSpend updates remaining_spend, expiration, and modified from the snapshot', async () => {
+    await call('refreshFeeGrantSpend', {
+      grantorCorporationId: 1,
+      grantee: 'verana1op',
+      snapshot: snapshot({ remaining_spend: [{ denom: 'uvna', amount: '400' }], expiration: T3 }),
+      blockHeight: 12,
+    })
+
+    const row = await knex('fee_grants').where({ grantor_corporation_id: 1, grantee: 'verana1op' }).first()
+    expect(row.remaining_spend).toEqual([{ denom: 'uvna', amount: '400' }])
+    expect(new Date(row.expiration).toISOString()).toBe(T3)
+    expect(Number(row.height)).toBe(12)
+    expect(new Date(row.modified).toISOString()).toBe(blockTime(12))
+  })
+
+  it('refreshFeeGrantSpend zeroes remaining_spend when the allowance is gone', async () => {
+    await call('refreshFeeGrantSpend', {
+      grantorCorporationId: 1,
+      grantee: 'verana1op',
+      snapshot: null,
+      blockHeight: 13,
+    })
+
+    const row = await knex('fee_grants').where({ grantor_corporation_id: 1, grantee: 'verana1op' }).first()
+    expect(row.remaining_spend).toEqual([{ denom: 'uvna', amount: '0' }])
+  })
+
+  it('refreshFeeGrantSpend is a no-op for an untracked pair', async () => {
+    const res = await call('refreshFeeGrantSpend', {
+      grantorCorporationId: 99,
+      grantee: 'verana1nobody',
+      snapshot: null,
+      blockHeight: 14,
+    })
+    expect(res.success).toBe(true)
+    expect(await knex('fee_grants').where('grantor_corporation_id', 99).first()).toBeUndefined()
+  })
+
+  it('revokeFeeGrant deletes the row and a later re-grant mints a fresh id', async () => {
+    const before = await knex('fee_grants').where({ grantor_corporation_id: 1, grantee: 'verana1op' }).first()
+
+    await call('revokeFeeGrant', { grantorCorporationId: 1, grantee: 'verana1op', blockHeight: 15 })
+
+    expect(await knex('fee_grants').where({ grantor_corporation_id: 1, grantee: 'verana1op' }).first()).toBeUndefined()
+    const revokedHistory = await knex('fee_grant_history').where('fee_grant_id', before.id).where('revoked', true)
+    expect(revokedHistory).toHaveLength(1)
+
+    await call('syncFeeGrant', { grantorCorporationId: 1, grantee: 'verana1op', snapshot: snapshot(), blockHeight: 16 })
+
+    const regranted = await knex('fee_grants').where({ grantor_corporation_id: 1, grantee: 'verana1op' }).first()
+    expect(Number(regranted.id)).toBeGreaterThan(Number(before.id))
+  })
+
+  it('revokeFeeGrant is a no-op when no grant exists', async () => {
+    const res = await call('revokeFeeGrant', { grantorCorporationId: 42, grantee: 'verana1ghost', blockHeight: 17 })
+    expect(res.success).toBe(true)
+  })
+})
+
+afterAll(async () => {
+  await knex.destroy()
+})

--- a/test/unit/services/crawl-de/de_fee_grants.spec.ts
+++ b/test/unit/services/crawl-de/de_fee_grants.spec.ts
@@ -282,6 +282,62 @@ describe('DelegationApiService.listFeeGrants', () => {
   })
 })
 
+describe('DelegationApiService.listFeeGrants msg_type filter', () => {
+  const broker = new ServiceBroker({ logger: false })
+  const serviceKey = SERVICE.V1.DelegationApiService.path
+
+  beforeAll(async () => {
+    broker.createService(DelegationApiService)
+    await broker.start()
+
+    await knex('fee_grant_history').del()
+    await knex('fee_grants').del()
+
+    await knex('fee_grants').insert([
+      seedFeeGrantRow({
+        id: 10,
+        grantor_corporation_id: 1,
+        grantee: 'verana1restricted',
+        msg_types: [EC_CREATE],
+        modified: T1,
+        height: 100,
+      }),
+      seedFeeGrantRow({
+        id: 11,
+        grantor_corporation_id: 1,
+        grantee: 'verana1unrestricted',
+        msg_types: [],
+        modified: T1,
+        height: 100,
+      }),
+    ])
+  })
+
+  afterAll(async () => {
+    await broker.stop()
+  })
+
+  const list = (params: Record<string, unknown> = {}) =>
+    broker.call(`${serviceKey}.listFeeGrants`, params) as Promise<any>
+
+  it('returns both restricted and unrestricted grants when unfiltered', async () => {
+    expect(listedIds(await list({ sort: '+id' }))).toEqual([10, 11])
+  })
+
+  it('matches a grant whose msg_types includes the type, plus unrestricted grants', async () => {
+    expect(listedIds(await list({ msg_type: EC_CREATE, sort: '+id' }))).toEqual([10, 11])
+  })
+
+  it('keeps unrestricted grants for a type no restricted grant covers', async () => {
+    expect(listedIds(await list({ msg_type: CS_CREATE }))).toEqual([11])
+  })
+
+  it('serializes an unrestricted grant with an empty msg_types array', async () => {
+    const [row] = (await list({ msg_type: CS_CREATE })).fee_grants
+    expect(row.msg_types).toEqual([])
+  })
+})
+
 describe('DelegationDatabaseService fee grant actions', () => {
   const broker = new ServiceBroker({ logger: false })
   const serviceKey = SERVICE.V1.DelegationDatabaseService.path


### PR DESCRIPTION
Closes #389

Implements GET /v4/delegation/fee-grants per verana-spec PR #47.

- fee_grants and fee_grant_history tables, surrogate id as pagination cursor, unique on (grantor_corporation_id, grantee)
- DE height-sync handles grant_fee_allowance, revoke_fee_allowance and use_feegrant; state read via ABCI at height
- remaining_spend refreshed on fee draws and bumps modified; periodic expiration sourced from the allowance period_reset
- allowance-not-found is distinguished from transport errors, so only genuine absence zeroes remaining_spend
- corporation policy address falls back to a chain query when the local row is not yet indexed
- supports all spec filters, id keyset pagination and At-Block-Height
