### PR TITLE
feat: policy_address filter on list corporations (IDX-CO-QRY-2)

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -424,6 +424,15 @@
             "description": "Filter by Corporation DID (exact match)"
           },
           {
+            "name": "policy_address",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Comma-separated policy_address accounts (min 1, max 64 entries). Returns only Corporations whose policy_address is in the list; an empty value or more than 64 entries is rejected with HTTP 400"
+          },
+          {
             "name": "modified_after",
             "in": "query",
             "required": false,

--- a/src/migrations/20260601000000_create_corporation_tables.ts
+++ b/src/migrations/20260601000000_create_corporation_tables.ts
@@ -4,7 +4,7 @@ export async function up(knex: Knex): Promise<void> {
   await knex.schema.createTable('corporation', (table) => {
     table.bigIncrements('id').primary()
     table.string('did').notNullable().unique()
-    table.text('policy_address').nullable()
+    table.text('policy_address').nullable().unique()
     table.string('corporation').nullable()
     table.string('creator').nullable()
     table.string('language', 8).nullable()

--- a/src/services/crawl-co/co_api.service.ts
+++ b/src/services/crawl-co/co_api.service.ts
@@ -29,6 +29,7 @@ import {
   getResolvedBlockHeight,
   parseCorporationListPagination,
   parseGfDataMode,
+  parsePolicyAddressFilter,
 } from './co_stats'
 
 // Stored event_type -> spec ActivityItem.msg. CGF events are stored under their spec names already.
@@ -189,6 +190,7 @@ export default class CorporationApiService extends BaseService {
       gf_data?: string
       preferred_language?: string
       did?: string
+      policy_address?: string
       modified_after?: string
       trust_data?: string
       limit?: string
@@ -218,6 +220,12 @@ export default class CorporationApiService extends BaseService {
       }
       const { limit, minId, maxId, direction } = pageParsed.value
 
+      const policyParsed = parsePolicyAddressFilter(ctx.params.policy_address)
+      if (!policyParsed.ok) {
+        return ApiResponder.error(ctx, policyParsed.message, 400)
+      }
+      const policyAddresses = policyParsed.addresses
+
       let modifiedAfterIso: string | undefined
       if (ctx.params.modified_after) {
         const ts = new Date(ctx.params.modified_after)
@@ -233,6 +241,14 @@ export default class CorporationApiService extends BaseService {
         gfData === 'none' ? 'governanceFrameworkVersions' : 'governanceFrameworkVersions.documents'
       )
       if (did) query = query.where('did', String(did))
+      // Matches the effective address (policy_address ?? corporation) — legacy rows store it only in `corporation`.
+      if (policyAddresses) {
+        query = query.where((qb) => {
+          qb.whereIn('policy_address', policyAddresses).orWhere((legacy) => {
+            legacy.whereNull('policy_address').whereIn('corporation', policyAddresses)
+          })
+        })
+      }
       if (modifiedAfterIso) query = query.where('modified', '>', modifiedAfterIso)
       if (minId !== undefined) query = query.where('id', '>=', minId)
       if (maxId !== undefined) query = query.where('id', '<', maxId)

--- a/src/services/crawl-co/co_stats.ts
+++ b/src/services/crawl-co/co_stats.ts
@@ -415,6 +415,24 @@ export function parseCorporationListPagination(params: {
   return { ok: true, value: { limit, minId: minId.value, maxId: maxId.value, direction: sortParsed.direction } }
 }
 
+// IDX-CO-QRY-2 `policy_address` filter: min 1, max 64 entries, over-limit and present-but-empty are HTTP 400 — a zero-membership x/group walk joins to '' and must not degrade into the full list.
+export function parsePolicyAddressFilter(
+  raw: unknown
+): { ok: true; addresses?: string[] } | { ok: false; message: string } {
+  if (raw === undefined || raw === null) return { ok: true }
+  const entries = String(raw)
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+  if (entries.length === 0) {
+    return { ok: false, message: '"policy_address" must contain between 1 and 64 comma-separated addresses' }
+  }
+  if (entries.length > 64) {
+    return { ok: false, message: '"policy_address" accepts at most 64 comma-separated addresses' }
+  }
+  return { ok: true, addresses: [...new Set(entries)] }
+}
+
 export function parseIdSortDirection(
   sort?: string | number
 ): { ok: true; direction: 'asc' | 'desc' } | { ok: false; message: string } {

--- a/test/unit/services/crawl-co/co_api_v4_list.spec.ts
+++ b/test/unit/services/crawl-co/co_api_v4_list.spec.ts
@@ -148,13 +148,14 @@ describe('CorporationApiService.listCorporationsV4', () => {
     expect(res.corporations[1]).toMatchObject({ id: 2, controlled_ecosystems: 0, deposit: 0 })
   })
 
-  it('applies did, modified_after and cursor filters plus sort/limit to the query', async () => {
+  it('applies did, policy_address, modified_after and cursor filters plus sort/limit to the query', async () => {
     const qb = queryResolvesTo([])
     ;(calculateCorporationParticipantStatsBatch as jest.Mock).mockResolvedValue(new Map())
 
     const ctx: any = {
       params: {
         did: 'did:example:co',
+        policy_address: 'verana1pol',
         modified_after: '2024-05-01T00:00:00Z',
         min_id: '5',
         max_id: '10',
@@ -169,8 +170,52 @@ describe('CorporationApiService.listCorporationsV4', () => {
     expect(qb.where).toHaveBeenCalledWith('modified', '>', '2024-05-01T00:00:00.000Z')
     expect(qb.where).toHaveBeenCalledWith('id', '>=', '5')
     expect(qb.where).toHaveBeenCalledWith('id', '<', '10')
+    // the grouped policy_address clause is ANDed onto the same chain as the other filters
+    expect((qb.where as jest.Mock).mock.calls.filter((call: unknown[]) => typeof call[0] === 'function')).toHaveLength(
+      1
+    )
     expect(qb.orderBy).toHaveBeenCalledWith('id', 'asc')
     expect(qb.limit).toHaveBeenCalledWith(25)
+  })
+
+  it('applies the policy_address filter over both policy_address and the legacy corporation column', async () => {
+    const qb = queryResolvesTo([])
+    const ctx: any = { params: { policy_address: 'verana1pol, verana1pol2,verana1pol' }, meta: {} }
+    await service.listCorporationsV4(ctx)
+
+    const groupedCall = (qb.where as jest.Mock).mock.calls.find((call: unknown[]) => typeof call[0] === 'function')
+    expect(groupedCall).toBeDefined()
+
+    const outer: any = { whereIn: jest.fn(() => outer), orWhere: jest.fn(() => outer) }
+    groupedCall![0](outer)
+    expect(outer.whereIn).toHaveBeenCalledWith('policy_address', ['verana1pol', 'verana1pol2'])
+
+    const legacyFn = (outer.orWhere as jest.Mock).mock.calls[0][0]
+    const legacy: any = { whereNull: jest.fn(() => legacy), whereIn: jest.fn(() => legacy) }
+    legacyFn(legacy)
+    expect(legacy.whereNull).toHaveBeenCalledWith('policy_address')
+    expect(legacy.whereIn).toHaveBeenCalledWith('corporation', ['verana1pol', 'verana1pol2'])
+  })
+
+  it('rejects a present-but-empty policy_address with 400', async () => {
+    queryResolvesTo([])
+    const ctx: any = { params: { policy_address: '' }, meta: {} }
+    const res: any = await service.listCorporationsV4(ctx)
+    expect(res).toMatchObject({ code: 400 })
+  })
+
+  it('accepts a full 64-entry policy_address list and forwards every address', async () => {
+    const qb = queryResolvesTo([])
+    const addresses = Array.from({ length: 64 }, (_, i) => `verana1addr${i}`)
+    const ctx: any = { params: { policy_address: addresses.join(',') }, meta: {} }
+    const res: any = await service.listCorporationsV4(ctx)
+    expect(res).toEqual({ corporations: [] })
+
+    const groupedCall = (qb.where as jest.Mock).mock.calls.find((call: unknown[]) => typeof call[0] === 'function')
+    expect(groupedCall).toBeDefined()
+    const outer: any = { whereIn: jest.fn(() => outer), orWhere: jest.fn(() => outer) }
+    groupedCall![0](outer)
+    expect(outer.whereIn).toHaveBeenCalledWith('policy_address', addresses)
   })
 
   it('defaults to newest-first (id desc) and limit 64', async () => {
@@ -230,6 +275,17 @@ describe('CorporationApiService.listCorporationsV4', () => {
     expect(qb.where).toHaveBeenCalledWith('created', '<=', '2024-03-01T00:00:00.000Z')
   })
 
+  it('composes the policy_address filter with the At-Block-Height created cutoff', async () => {
+    const qb = queryResolvesTo([])
+    const ctx: any = { params: { policy_address: 'verana1pol' }, meta: { blockHeight: 5 } }
+    await service.listCorporationsV4(ctx)
+
+    expect(qb.where).toHaveBeenCalledWith('created', '<=', '2024-03-01T00:00:00.000Z')
+    expect((qb.where as jest.Mock).mock.calls.filter((call: unknown[]) => typeof call[0] === 'function')).toHaveLength(
+      1
+    )
+  })
+
   it('does not apply the created filter when no At-Block-Height is set', async () => {
     const qb = queryResolvesTo([])
     const ctx: any = { params: {}, meta: {} }
@@ -271,6 +327,8 @@ describe('CorporationApiService.listCorporationsV4', () => {
       { min_id: 'abc' },
       { sort: 'weight' },
       { modified_after: 'not-a-date' },
+      { policy_address: ',,,' },
+      { policy_address: Array.from({ length: 65 }, (_, i) => `verana1addr${i}`).join(',') },
     ]) {
       jest.clearAllMocks()
       ;(parseTrustDataMode as jest.Mock).mockReturnValue({ ok: true, mode: 'none' })

--- a/test/unit/services/crawl-co/co_stats_list.spec.ts
+++ b/test/unit/services/crawl-co/co_stats_list.spec.ts
@@ -35,6 +35,7 @@ import {
   paginateActivityItems,
   parseCorporationListPagination,
   parseIdSortDirection,
+  parsePolicyAddressFilter,
 } from '../../../../src/services/crawl-co/co_stats'
 
 describe('co_stats.parseCorporationListPagination', () => {
@@ -180,6 +181,47 @@ describe('co_stats.countControlledEcosystemsBatch', () => {
 
     expect(map.get('1')).toBe(2)
     expect(map.get('2')).toBe(0)
+  })
+})
+
+describe('co_stats.parsePolicyAddressFilter', () => {
+  it('treats an absent value as no filter', () => {
+    expect(parsePolicyAddressFilter(undefined)).toEqual({ ok: true })
+    expect(parsePolicyAddressFilter(null)).toEqual({ ok: true })
+  })
+
+  it('rejects present-but-empty values (min 1 entry)', () => {
+    expect(parsePolicyAddressFilter('').ok).toBe(false)
+    expect(parsePolicyAddressFilter('   ').ok).toBe(false)
+  })
+
+  it('parses a single address and comma-separated lists, trimming whitespace', () => {
+    expect(parsePolicyAddressFilter('verana1abc')).toEqual({ ok: true, addresses: ['verana1abc'] })
+    expect(parsePolicyAddressFilter(' verana1abc , verana1def ')).toEqual({
+      ok: true,
+      addresses: ['verana1abc', 'verana1def'],
+    })
+  })
+
+  it('drops empty entries and deduplicates', () => {
+    expect(parsePolicyAddressFilter('verana1abc,,verana1abc,')).toEqual({ ok: true, addresses: ['verana1abc'] })
+  })
+
+  it('rejects values that contain no addresses at all', () => {
+    expect(parsePolicyAddressFilter(',,,').ok).toBe(false)
+  })
+
+  it('accepts exactly 64 entries and rejects 65', () => {
+    const list = (n: number) => Array.from({ length: n }, (_, i) => `verana1addr${i}`).join(',')
+    expect(parsePolicyAddressFilter(list(64))).toMatchObject({ ok: true })
+    const over = parsePolicyAddressFilter(list(65))
+    expect(over.ok).toBe(false)
+    if (!over.ok) expect(over.message).toContain('64')
+  })
+
+  it('applies the 64-entry cap before deduplication', () => {
+    const dupes = Array.from({ length: 65 }, () => 'verana1same').join(',')
+    expect(parsePolicyAddressFilter(dupes).ok).toBe(false)
   })
 })
 


### PR DESCRIPTION
Closes #388. Implements verana-spec#43 (merged).

Adds the `policy_address` query parameter to `GET /v4/corporation/list`:

- comma-separated, min 1 / max 64 entries; empty value or more than 64 → HTTP 400
- matches the effective address (`policy_address`, falling back to the legacy
  `corporation` column when null), same coalesce the responses use
- unmatched addresses are silently absent per spec
- composes with `did`, `modified_after`, pagination and `At-Block-Height`
- unique constraint on `corporation.policy_address` in the create migration,
  backing the spec's 1:1 invariant
- openapi.json updated