### PR TITLE
feat: scope pending flat by corporation_id (IDX-PP-QRY-5)

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3339,17 +3339,18 @@
           "Participant"
         ],
         "summary": "Get pending tasks",
-        "description": "Return pending tasks for a given account grouped by Ecosystem and Credential Schema. Supports At-Block-Height header for historical state.",
+        "description": "Return the open task list for a given Corporation — every Participant whose validator Participant entry is owned by that Corporation and whose state requires the validator's action — grouped by Ecosystem and Credential Schema. Supports At-Block-Height header for historical state.",
         "operationId": "pendingFlat",
         "parameters": [
           {
-            "name": "account",
+            "name": "corporation_id",
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "minimum": 1
             },
-            "description": "Account address"
+            "description": "Id of the Corporation whose pending tasks are returned (the Corporation owning the validator Participant entries). Which of its operators may execute a pending action is resolved separately against the Corporation's authorization grants"
           },
           {
             "name": "limit",
@@ -6922,7 +6923,7 @@
             "items": {
               "$ref": "#/components/schemas/Participant"
             },
-            "description": "Participant entries pending action from the validator account"
+            "description": "Participant entries pending action from the validator Corporation"
           }
         }
       },

--- a/src/services/crawl-pp/pp_apis.service.ts
+++ b/src/services/crawl-pp/pp_apis.service.ts
@@ -2,7 +2,7 @@ import { Action, Service } from '@ourparentcenter/moleculer-decorators-extended'
 import { Context, ServiceBroker } from 'moleculer'
 import BullableService from '../../base/bullable.service'
 import { MODULE_DISPLAY_NAMES, ModulesParamsNamesTypes, SERVICE } from '../../common'
-import { validateParticipantParam, validateRequiredAccountParam } from '../../common/utils/accountValidation'
+import { validateParticipantParam } from '../../common/utils/accountValidation'
 import { buildActivityTimeline } from '../../common/utils/activity_timeline_helper'
 import ApiResponder from '../../common/utils/apiResponse'
 import { getBlockHeight, hasBlockHeight } from '../../common/utils/blockHeight'
@@ -2484,14 +2484,14 @@ export default class ParticipantAPIService extends BullableService {
   @Action({
     rest: 'GET pending/flat',
     params: {
-      account: { type: 'string' },
+      corporation_id: { type: 'number', integer: true, positive: true },
       limit: { type: 'number', optional: true, default: 64 },
       trust_data: { type: 'string', optional: true },
     },
   })
   async pendingFlat(
     ctx: Context<{
-      account: string
+      corporation_id: number
       limit?: number
       trust_data?: string
     }>
@@ -2503,16 +2503,9 @@ export default class ParticipantAPIService extends BullableService {
         return ApiResponder.error(ctx, trustDataModeParsed.message, 400)
       }
       const trustDataMode = trustDataModeParsed.mode
-      const accountRaw = typeof p.account === 'string' && p.account.trim() !== '' ? p.account : undefined
-      const accountValidation = validateRequiredAccountParam(accountRaw, 'account')
-      if (!accountValidation.valid) {
-        return ApiResponder.error(ctx, accountValidation.error, 400)
-      }
-      const account = accountValidation.value
-      // VPR v4: validator ownership is corporation-based; resolve the account once.
-      const accountCorpId = await resolveCorporationIdByAddress(account)
-      if (accountCorpId === null) {
-        return ApiResponder.success(ctx, { ecosystems: [] }, 200)
+      const corporationId = Number(p.corporation_id)
+      if (!Number.isInteger(corporationId) || corporationId <= 0) {
+        return ApiResponder.error(ctx, '"corporation_id" must be a positive integer', 400)
       }
 
       const limit = Math.min(Math.max(p.limit || 64, 1), 1024)
@@ -2525,7 +2518,7 @@ export default class ParticipantAPIService extends BullableService {
 
       const validatorParentTypeList = [...PENDING_FLAT_VALIDATOR_PARENT_TYPES]
 
-      /** At-height: latest row per participant where account holds a grantor/validator parent role. */
+      /** At-height: latest row per participant where the Corporation holds a grantor/validator parent role. */
       let parentIdsAtHeightSubquery: ReturnType<typeof knex> | null = null
       if (useHistory) {
         const rankedParentAtHeight = knex('participant_history')
@@ -2536,7 +2529,7 @@ export default class ParticipantAPIService extends BullableService {
             )
           )
           .whereRaw('height <= ?', [Number(blockHeight)])
-          .andWhere('corporation_id', accountCorpId)
+          .andWhere('corporation_id', corporationId)
           .whereIn('role', validatorParentTypeList)
           .as('ranked_parent')
 
@@ -2550,7 +2543,7 @@ export default class ParticipantAPIService extends BullableService {
 
       const validatorParentIdsSubquery = knex('participants')
         .select('id')
-        .where('corporation_id', accountCorpId)
+        .where('corporation_id', corporationId)
         .whereIn('role', validatorParentTypeList)
 
       if (!useHistory) {
@@ -2609,7 +2602,7 @@ export default class ParticipantAPIService extends BullableService {
           )
           .whereRaw('height <= ?', [Number(blockHeight)])
           .where((qb) => {
-            qb.where('corporation_id', accountCorpId)
+            qb.where('corporation_id', corporationId)
             if (parentIdsAtHeightSubquery) {
               qb.orWhereIn('validator_participant_id', parentIdsAtHeightSubquery.clone())
             }
@@ -2679,7 +2672,7 @@ export default class ParticipantAPIService extends BullableService {
         const rows = await knex('participants')
           .select(baseColumns)
           .where((qb) => {
-            qb.where('corporation_id', accountCorpId)
+            qb.where('corporation_id', corporationId)
             qb.orWhereIn('validator_participant_id', validatorParentIdsSubquery.clone())
           })
           .limit(fetchLimit)
@@ -2700,7 +2693,7 @@ export default class ParticipantAPIService extends BullableService {
         50
       )
       const filtered = enriched.filter((participant: any) => {
-        if (Number(participant.corporation_id ?? 0) === accountCorpId) {
+        if (Number(participant.corporation_id ?? 0) === corporationId) {
           if (pendingFlatMatchesOpPendingWithEligibleParticipantState(participant)) return true
           if (participant.participant_state === 'SLASHED') return true
           if (participant.participant_state === 'ACTIVE' && participant.expire_soon === true) return true

--- a/test/integration/api-endpoints.spec.ts
+++ b/test/integration/api-endpoints.spec.ts
@@ -1000,16 +1000,16 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
-      itIf('should get pending flat - with account (required)', async () => {
+      itIf('should get pending flat - with corporation_id (required)', async () => {
         const response = await testEndpoint('GET', '/v4/participant/pending/flat', {
-          account: SAMPLE_ACCOUNT,
+          corporation_id: SAMPLE_ID,
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
       itIf('should get pending flat - with limit', async () => {
         const response = await testEndpoint('GET', '/v4/participant/pending/flat', {
-          account: SAMPLE_ACCOUNT,
+          corporation_id: SAMPLE_ID,
           limit: 100,
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
@@ -1017,7 +1017,7 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
 
       itIf('should get pending flat - with sort parameter', async () => {
         const response = await testEndpoint('GET', '/v4/participant/pending/flat', {
-          account: SAMPLE_ACCOUNT,
+          corporation_id: SAMPLE_ID,
           sort: 'modified',
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
@@ -1025,7 +1025,7 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
 
       itIf('should get pending flat - with participant-role sort parameter', async () => {
         const response = await testEndpoint('GET', '/v4/participant/pending/flat', {
-          account: SAMPLE_ACCOUNT,
+          corporation_id: SAMPLE_ID,
           sort: '-participants_ecosystem',
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)

--- a/test/unit/services/crawl-pp/pending_flat.spec.ts
+++ b/test/unit/services/crawl-pp/pending_flat.spec.ts
@@ -66,8 +66,16 @@ describe('Pending Flat API', () => {
   it('returns empty when no participants found', async () => {
     ;(knex as any).mockImplementation(() => createKnexChain())
 
-    const ctx: any = { params: { account: 'acc1', limit: 10 }, meta: {} }
+    const ctx: any = { params: { corporation_id: 1, limit: 10 }, meta: {} }
     const res = await service.pendingFlat(ctx)
     expect(res).toEqual({ ecosystems: [] })
+  })
+
+  it('rejects a non-positive corporation_id with 400', async () => {
+    ;(knex as any).mockImplementation(() => createKnexChain())
+
+    const ctx: any = { params: { corporation_id: 0 }, meta: {} }
+    const res: any = await service.pendingFlat(ctx)
+    expect(res).toMatchObject({ code: 400 })
   })
 })


### PR DESCRIPTION
Replaces the account-typed `account` parameter of IDX-PP-QRY-5 Pending Flat with a required `corporation_id`, and rewords the method around validator-Corporation ownership.