### PR TITLE
fix: drop FeeGrant fields from OperatorAuthorization responses (IDX-DE-QRY-1/3)

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -8176,7 +8176,7 @@
       },
       "OperatorAuthorization": {
         "type": "object",
-        "description": "A corporation's authorization granted to a specific operator account for one or more module message types (IDX-DE-QRY-3).",
+        "description": "A corporation's authorization granted to a specific operator account for one or more module message types (IDX-DE-QRY-3). Fee-payment capability is not part of OperatorAuthorization; it lives on the separate FeeGrant entity, queried via List Fee Grants (IDX-DE-QRY-5).",
         "required": ["id", "corporation_id", "operator", "msg_types"],
         "properties": {
           "id": { "type": "integer", "format": "uint64" },
@@ -8185,8 +8185,6 @@
           "msg_types": { "type": "array", "items": { "type": "string" } },
           "spend_limit": { "type": "array", "items": { "$ref": "#/components/schemas/DenomAmount" } },
           "remaining_spend": { "type": "array", "items": { "$ref": "#/components/schemas/DenomAmount" }, "description": "Present when spend_limit is set." },
-          "fee_spend_limit": { "type": "array", "items": { "$ref": "#/components/schemas/DenomAmount" } },
-          "remaining_fee_spend": { "type": "array", "items": { "$ref": "#/components/schemas/DenomAmount" }, "description": "Present when fee_spend_limit is set." },
           "expiration": { "type": "string", "format": "date-time" },
           "period": { "type": "string", "description": "Reset period for spend_limit, as a duration (e.g. \"86400s\")." }
         }

--- a/src/services/crawl-de/de_apis.service.ts
+++ b/src/services/crawl-de/de_apis.service.ts
@@ -13,9 +13,9 @@ import VSOperatorAuthorization from '../../models/vs_operator_authorization'
 import VSOperatorAuthorizationHistory from '../../models/vs_operator_authorization_history'
 import { parseIdSortDirection } from '../crawl-co/co_stats'
 
+// Per IDX-DE-QRY-1/3 (spec #48) OperatorAuthorization carries no fee fields — fee-payment capability is a FeeGrant, served by listFeeGrants.
 function serializeOperatorAuthorizationRow(row: any) {
   const spendLimit = row.spend_limit ?? null
-  const feeSpendLimit = row.fee_spend_limit ?? null
 
   return {
     id: Number(row.operator_authorization_id ?? row.id),
@@ -23,7 +23,6 @@ function serializeOperatorAuthorizationRow(row: any) {
     operator: String(row.operator),
     msg_types: row.msg_types ?? [],
     ...(spendLimit ? { spend_limit: spendLimit, remaining_spend: row.remaining_spend ?? [] } : {}),
-    ...(feeSpendLimit ? { fee_spend_limit: feeSpendLimit, remaining_fee_spend: row.remaining_fee_spend ?? [] } : {}),
     ...(row.expiration ? { expiration: dateToIsoOrNull(row.expiration) } : {}),
     ...(row.period ? { period: String(row.period) } : {}),
   }

--- a/test/unit/services/crawl-de/de_apis.spec.ts
+++ b/test/unit/services/crawl-de/de_apis.spec.ts
@@ -1,0 +1,200 @@
+jest.mock('../../../../src/models/operator_authorization', () => ({
+  __esModule: true,
+  default: { query: jest.fn() },
+}))
+jest.mock('../../../../src/models/operator_authorization_history', () => ({
+  __esModule: true,
+  default: { query: jest.fn() },
+}))
+jest.mock('../../../../src/models/vs_operator_authorization', () => ({
+  __esModule: true,
+  default: { query: jest.fn() },
+}))
+jest.mock('../../../../src/models/vs_operator_authorization_history', () => ({
+  __esModule: true,
+  default: { query: jest.fn() },
+}))
+
+const mockKnexTable = jest.fn()
+const mockKnexFrom = jest.fn()
+jest.mock('../../../../src/common/utils/db_connection', () => ({
+  __esModule: true,
+  default: Object.assign((table: string) => mockKnexTable(table), { from: (sub: unknown) => mockKnexFrom(sub) }),
+}))
+
+jest.mock('../../../../src/common/utils/apiResponse', () => ({
+  __esModule: true,
+  default: {
+    success: jest.fn((_ctx: unknown, data: unknown) => data),
+    error: jest.fn((_ctx: unknown, message: string, code: number) => ({ error: message, code })),
+  },
+}))
+
+jest.mock('../../../../src/common/utils/block_time', () => ({
+  getBlockChainTimeAsOf: jest.fn(async () => new Date('2024-03-01T00:00:00.000Z')),
+}))
+
+import { ServiceBroker } from 'moleculer'
+import OperatorAuthorization from '../../../../src/models/operator_authorization'
+import OperatorAuthorizationHistory from '../../../../src/models/operator_authorization_history'
+import VSOperatorAuthorization from '../../../../src/models/vs_operator_authorization'
+import DelegationApiService from '../../../../src/services/crawl-de/de_apis.service'
+
+// A stored row still carrying the v3 fee columns — the serializer must not surface them (spec #48).
+function operatorAuthorizationRow(over: Record<string, unknown> = {}) {
+  return {
+    id: 7,
+    corporation_id: 3,
+    operator: 'verana1operator',
+    msg_types: ['/verana.ec.v1.MsgCreateEcosystem'],
+    spend_limit: [{ denom: 'uvna', amount: '1000' }],
+    remaining_spend: [{ denom: 'uvna', amount: '400' }],
+    fee_spend_limit: [{ denom: 'uvna', amount: '500' }],
+    remaining_fee_spend: [{ denom: 'uvna', amount: '250' }],
+    expiration: '2030-01-01T00:00:00.000Z',
+    period: '86400s',
+    revoked: false,
+    ...over,
+  }
+}
+
+function listQueryResolvesTo(rows: unknown[]) {
+  const qb: any = {}
+  qb.select = jest.fn(() => qb)
+  qb.where = jest.fn(() => qb)
+  qb.whereRaw = jest.fn(() => qb)
+  qb.orderBy = jest.fn(() => qb)
+  qb.distinctOn = jest.fn(() => qb)
+  qb.as = jest.fn(() => qb)
+  qb.limit = jest.fn(() => Promise.resolve(rows))
+  mockKnexTable.mockReturnValue(qb)
+  mockKnexFrom.mockReturnValue(qb)
+  return qb
+}
+
+function findByIdResolvesTo(model: { query: jest.Mock }, row: unknown) {
+  model.query.mockReturnValue({ findById: jest.fn(async () => row) })
+}
+
+function historyChainResolvesTo(row: unknown) {
+  const qb: any = {}
+  qb.where = jest.fn(() => qb)
+  qb.orderBy = jest.fn(() => qb)
+  qb.first = jest.fn(async () => row)
+  ;(OperatorAuthorizationHistory as unknown as { query: jest.Mock }).query.mockReturnValue(qb)
+  return qb
+}
+
+describe('DelegationApiService OperatorAuthorization responses (spec #48)', () => {
+  const broker = new ServiceBroker({ logger: false })
+  const service = new DelegationApiService(broker)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('listOperatorAuthorizations omits fee fields but keeps spend/expiration/period', async () => {
+    listQueryResolvesTo([operatorAuthorizationRow()])
+
+    const ctx: any = { params: {}, meta: {} }
+    const res: any = await service.listOperatorAuthorizations(ctx)
+
+    expect(res.authorizations).toHaveLength(1)
+    const entry = res.authorizations[0]
+    expect(entry).toEqual({
+      id: 7,
+      corporation_id: 3,
+      operator: 'verana1operator',
+      msg_types: ['/verana.ec.v1.MsgCreateEcosystem'],
+      spend_limit: [{ denom: 'uvna', amount: '1000' }],
+      remaining_spend: [{ denom: 'uvna', amount: '400' }],
+      expiration: '2030-01-01T00:00:00.000Z',
+      period: '86400s',
+    })
+    expect(entry).not.toHaveProperty('fee_spend_limit')
+    expect(entry).not.toHaveProperty('remaining_fee_spend')
+  })
+
+  it('getOperatorAuthorization omits fee fields on the latest-state path', async () => {
+    findByIdResolvesTo(OperatorAuthorization as unknown as { query: jest.Mock }, operatorAuthorizationRow())
+
+    const ctx: any = { params: { id: 7 }, meta: {} }
+    const res: any = await service.getOperatorAuthorization(ctx)
+
+    expect(res.authorization.id).toBe(7)
+    expect(res.authorization).not.toHaveProperty('fee_spend_limit')
+    expect(res.authorization).not.toHaveProperty('remaining_fee_spend')
+  })
+
+  it('getOperatorAuthorization omits fee fields on the At-Block-Height history path', async () => {
+    historyChainResolvesTo(operatorAuthorizationRow({ operator_authorization_id: 7, id: 99 }))
+
+    const ctx: any = { params: { id: 7 }, meta: { blockHeight: 50 } }
+    const res: any = await service.getOperatorAuthorization(ctx)
+
+    expect(res.authorization.id).toBe(7)
+    expect(res.authorization).not.toHaveProperty('fee_spend_limit')
+    expect(res.authorization).not.toHaveProperty('remaining_fee_spend')
+  })
+
+  it('listOperatorAuthorizations at-height serializes history rows — no fee fields, no raw columns', async () => {
+    listQueryResolvesTo([
+      operatorAuthorizationRow({ operator_authorization_id: 7, id: 99, height: 40, modified: '2024-02-01' }),
+    ])
+
+    const ctx: any = { params: {}, meta: { blockHeight: 50 } }
+    const res: any = await service.listOperatorAuthorizations(ctx)
+
+    expect(res.authorizations).toHaveLength(1)
+    expect(res.authorizations[0]).toEqual({
+      id: 7,
+      corporation_id: 3,
+      operator: 'verana1operator',
+      msg_types: ['/verana.ec.v1.MsgCreateEcosystem'],
+      spend_limit: [{ denom: 'uvna', amount: '1000' }],
+      remaining_spend: [{ denom: 'uvna', amount: '400' }],
+      expiration: '2030-01-01T00:00:00.000Z',
+      period: '86400s',
+    })
+  })
+
+  it('spend_limit stays optional: omitted entirely when the row has none', async () => {
+    listQueryResolvesTo([operatorAuthorizationRow({ spend_limit: null, remaining_spend: null })])
+
+    const ctx: any = { params: {}, meta: {} }
+    const res: any = await service.listOperatorAuthorizations(ctx)
+
+    expect(res.authorizations[0]).not.toHaveProperty('spend_limit')
+    expect(res.authorizations[0]).not.toHaveProperty('remaining_spend')
+  })
+
+  it('ParticipantAuthorizationRecord entries keep their fee fields (IDX-DE-QRY-4 untouched)', async () => {
+    findByIdResolvesTo(VSOperatorAuthorization as unknown as { query: jest.Mock }, {
+      id: 5,
+      corporation_id: 3,
+      vs_operator: 'verana1vsop',
+      revoked: false,
+      records: [
+        {
+          participant_id: 11,
+          msg_types: ['/verana.pp.v1.MsgRenewParticipant'],
+          spend_limit: [{ denom: 'uvna', amount: '100' }],
+          remaining_spend: [{ denom: 'uvna', amount: '90' }],
+          fee_spend_limit: [{ denom: 'uvna', amount: '50' }],
+          remaining_fee_spend: [{ denom: 'uvna', amount: '25' }],
+          with_feegrant: true,
+          expiration: '2030-01-01T00:00:00.000Z',
+          period: '86400s',
+        },
+      ],
+    })
+
+    const ctx: any = { params: { id: 5 }, meta: {} }
+    const res: any = await service.getVSOperatorAuthorization(ctx)
+
+    const record = res.authorization.records[0]
+    expect(record.fee_spend_limit).toEqual([{ denom: 'uvna', amount: '50' }])
+    expect(record.remaining_fee_spend).toEqual([{ denom: 'uvna', amount: '25' }])
+    expect(record.with_feegrant).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #394. Implements verana-spec#48 (merged).

Removes `fee_spend_limit` and `remaining_fee_spend` from OperatorAuthorization
responses in list and get operator authorizations, including the At-Block-Height
paths. Per the VPR data model, fee-payment capability is not part of
OperatorAuthorization; it lives on the separate FeeGrant entity, queried via
listFeeGrants (IDX-DE-QRY-5, PR #396).

- `ParticipantAuthorizationRecord` fields in vs-operator authorizations are
  untouched, as the spec keeps them
- openapi.json: fee fields removed from the OperatorAuthorization schema
- unit tests added for all four response paths