### PR TITLE
feat: corporation-typed participant filter on ecosystem and schema lists

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1396,13 +1396,14 @@
             "description": "Maximum number of active schemas (exclusive)."
           },
           {
-            "name": "participant",
+            "name": "participant_corporation_id",
             "in": "query",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "minimum": 1
             },
-            "description": "Participant account. TRs where this account is EC corporation or holds an active participant on a schema in the EC."
+            "description": "Id of a Corporation. Returns Ecosystems where this Corporation is the controlling Corporation (Ecosystem.corporation_id) or owns an active Participant entry on any Credential Schema of the Ecosystem."
           },
           {
             "name": "min_participants",
@@ -2242,13 +2243,14 @@
             "description": "Sort by id ascending or descending"
           },
           {
-            "name": "participant",
+            "name": "participant_corporation_id",
             "in": "query",
             "required": false,
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "minimum": 1
             },
-            "description": "Participant account. Schemas whose EC corporation matches or where the account holds an active participant."
+            "description": "Id of a Corporation. Returns schemas where this Corporation controls the owning Ecosystem (Ecosystem.corporation_id) or owns an active Participant entry on the schema."
           },
           {
             "name": "min_participants",

--- a/src/services/crawl-cs/cs_database.service.ts
+++ b/src/services/crawl-cs/cs_database.service.ts
@@ -2,7 +2,6 @@ import { Action, Service } from '@ourparentcenter/moleculer-decorators-extended'
 import { Context, ServiceBroker } from 'moleculer'
 import BullableService from '../../base/bullable.service'
 import { MODULE_DISPLAY_NAMES, ModulesParamsNamesTypes, SERVICE } from '../../common'
-import { validateParticipantParam } from '../../common/utils/accountValidation'
 import { buildActivityTimeline } from '../../common/utils/activity_timeline_helper'
 import ApiResponder from '../../common/utils/apiResponse'
 import { isValidISO8601UTC } from '../../common/utils/date_utils'
@@ -1473,7 +1472,7 @@ export default class CredentialSchemaDatabaseService extends BullableService {
     rest: 'GET list',
     params: {
       ecosystem_id: { type: 'number', optional: true },
-      participant: { type: 'any', optional: true },
+      participant_corporation_id: { type: 'number', integer: true, optional: true },
       modified_after: { type: 'string', optional: true },
       archived: { type: 'any', optional: true },
       only_active: {
@@ -1517,7 +1516,7 @@ export default class CredentialSchemaDatabaseService extends BullableService {
   async list(
     ctx: Context<{
       ecosystem_id?: number
-      participant?: string
+      participant_corporation_id?: number
       modified_after?: string
       archived?: any
       only_active?: any
@@ -1557,7 +1556,7 @@ export default class CredentialSchemaDatabaseService extends BullableService {
     try {
       const {
         ecosystem_id: ecosystemId,
-        participant,
+        participant_corporation_id: participantCorporationIdRaw,
         modified_after: modifiedAfter,
         archived: archivedParam,
         only_active: onlyActive,
@@ -1600,11 +1599,13 @@ export default class CredentialSchemaDatabaseService extends BullableService {
       const holderOmTrimmed = holderOnboardingModeParam !== undefined ? String(holderOnboardingModeParam).trim() : ''
       const effectiveHolderOnboarding: string | undefined = holderOmTrimmed !== '' ? holderOmTrimmed : undefined
 
-      const participantValidation = validateParticipantParam(participant, 'participant')
-      if (!participantValidation.valid) {
-        return ApiResponder.error(ctx, participantValidation.error, 400)
+      let participantCorporationId: number | undefined
+      if (participantCorporationIdRaw !== undefined && participantCorporationIdRaw !== null) {
+        if (!Number.isInteger(participantCorporationIdRaw) || participantCorporationIdRaw <= 0) {
+          return ApiResponder.error(ctx, 'Invalid "participant_corporation_id". Must be a positive integer.', 400)
+        }
+        participantCorporationId = participantCorporationIdRaw
       }
-      const participantAccount = participantValidation.value
 
       const pageParsed = parseCorporationListPagination(ctx.params)
       if (!pageParsed.ok) {
@@ -1646,8 +1647,11 @@ export default class CredentialSchemaDatabaseService extends BullableService {
         const hasHeightColumn = await checkHeightColumnExists()
         const hasHistoryMetricColumns = await checkHistoryMetricColumnsExist()
         let schemaIdsAtHeight: number[]
-        if (participantAccount) {
-          schemaIdsAtHeight = await this.getCredentialSchemaIdsForParticipantAtHeight(participantAccount, blockHeight)
+        if (participantCorporationId) {
+          schemaIdsAtHeight = await this.getCredentialSchemaIdsForParticipantCorporationAtHeight(
+            participantCorporationId,
+            blockHeight
+          )
           if (schemaIdsAtHeight.length === 0) {
             return ApiResponder.success(ctx, { schemas: [] }, 200)
           }
@@ -2088,8 +2092,9 @@ export default class CredentialSchemaDatabaseService extends BullableService {
       }
 
       const query = knex('credential_schemas')
-      if (participantAccount) {
-        const participantSchemaIds = await this.getCredentialSchemaIdsForParticipant(participantAccount)
+      if (participantCorporationId) {
+        const participantSchemaIds =
+          await this.getCredentialSchemaIdsForParticipantCorporation(participantCorporationId)
         if (participantSchemaIds.length === 0) {
           return ApiResponder.success(ctx, { schemas: [] }, 200)
         }
@@ -2354,9 +2359,9 @@ export default class CredentialSchemaDatabaseService extends BullableService {
     }
   }
 
-  private async getCredentialSchemaIdsForParticipant(account: string): Promise<number[]> {
+  private async getCredentialSchemaIdsForParticipantCorporation(corporationId: number): Promise<number[]> {
     const trPart = await resolveEcosystemParticipantColumn(knex)
-    const controllerTrRows = await knex('ecosystem').where(trPart, account).select('id')
+    const controllerTrRows = await knex('ecosystem').where(trPart, corporationId).select('id')
     const controllerEcosystemIds = controllerTrRows.map((r: { id: number }) => r.id)
     const schemaIdsFromController =
       controllerEcosystemIds.length === 0
@@ -2366,7 +2371,7 @@ export default class CredentialSchemaDatabaseService extends BullableService {
           )
 
     const participantPart = await resolveParticipantsParticipantColumn(knex)
-    const corpRows = await knex('participants').where(participantPart, account).distinct('schema_id')
+    const corpRows = await knex('participants').where(participantPart, corporationId).distinct('schema_id')
     const schemaIdsFromCorp = corpRows
       .map((r: { schema_id: string }) => (r.schema_id != null ? parseFloat(r.schema_id) : null))
       .filter((id): id is number => id != null && !Number.isNaN(id))
@@ -2374,11 +2379,14 @@ export default class CredentialSchemaDatabaseService extends BullableService {
     return [...new Set([...schemaIdsFromController, ...schemaIdsFromCorp])]
   }
 
-  private async getCredentialSchemaIdsForParticipantAtHeight(account: string, blockHeight: number): Promise<number[]> {
+  private async getCredentialSchemaIdsForParticipantCorporationAtHeight(
+    corporationId: number,
+    blockHeight: number
+  ): Promise<number[]> {
     const trHistPart = await resolveEcosystemHistoryParticipantColumn(knex)
     const ecosystemHistoryRows = await knex('ecosystem_history')
       .where('height', '<=', blockHeight)
-      .where(trHistPart, account)
+      .where(trHistPart, corporationId)
       .select('ecosystem_id')
     const controllerEcosystemIds = [
       ...new Set(ecosystemHistoryRows.map((r: { ecosystem_id: number }) => r.ecosystem_id)),
@@ -2404,7 +2412,7 @@ export default class CredentialSchemaDatabaseService extends BullableService {
     const participantHistPart = await resolveParticipantHistoryParticipantColumn(knex)
     const corpParticipantRows = await knex('participant_history')
       .where('height', '<=', blockHeight)
-      .where(participantHistPart, account)
+      .where(participantHistPart, corporationId)
       .distinct('schema_id')
     const schemaIdsFromCorp = corpParticipantRows
       .map((r: { schema_id: number }) => r.schema_id)

--- a/src/services/crawl-cs/cs_database.service.ts
+++ b/src/services/crawl-cs/cs_database.service.ts
@@ -4,6 +4,7 @@ import BullableService from '../../base/bullable.service'
 import { MODULE_DISPLAY_NAMES, ModulesParamsNamesTypes, SERVICE } from '../../common'
 import { buildActivityTimeline } from '../../common/utils/activity_timeline_helper'
 import ApiResponder from '../../common/utils/apiResponse'
+import { getBlockChainTimeAsOf } from '../../common/utils/block_time'
 import { isValidISO8601UTC } from '../../common/utils/date_utils'
 import knex from '../../common/utils/db_connection'
 import {
@@ -2414,9 +2415,23 @@ export default class CredentialSchemaDatabaseService extends BullableService {
     }
 
     const participantHistPart = await resolveParticipantHistoryParticipantColumn(knex)
-    const corpParticipantRows = await knex('participant_history')
+    const asOf = await getBlockChainTimeAsOf(blockHeight, {
+      atOrBefore: true,
+      logContext: '[cs_database:participant_corporation_id]',
+    })
+    const rankedParticipantHistory = knex('participant_history')
+      .select('schema_id', participantHistPart, 'revoked', 'slashed', 'repaid', 'effective_from', 'effective_until')
+      .select(
+        knex.raw('ROW_NUMBER() OVER (PARTITION BY participant_id ORDER BY height DESC, created_at DESC, id DESC) as rn')
+      )
       .where('height', '<=', blockHeight)
+      .as('ranked_participants')
+
+    const corpParticipantRows = await knex
+      .from(rankedParticipantHistory)
+      .where('rn', 1)
       .where(participantHistPart, corporationId)
+      .modify((qb) => applyActiveParticipantFilter(qb, asOf.toISOString()))
       .distinct('schema_id')
     const schemaIdsFromCorp = corpParticipantRows
       .map((r: { schema_id: number }) => r.schema_id)

--- a/src/services/crawl-cs/cs_database.service.ts
+++ b/src/services/crawl-cs/cs_database.service.ts
@@ -2420,7 +2420,16 @@ export default class CredentialSchemaDatabaseService extends BullableService {
       logContext: '[cs_database:participant_corporation_id]',
     })
     const rankedParticipantHistory = knex('participant_history')
-      .select('schema_id', participantHistPart, 'revoked', 'slashed', 'repaid', 'effective_from', 'effective_until')
+      .select(
+        'schema_id',
+        participantHistPart,
+        'revoked',
+        'slashed',
+        'repaid',
+        'effective_from',
+        'effective_until',
+        'op_state'
+      )
       .select(
         knex.raw('ROW_NUMBER() OVER (PARTITION BY participant_id ORDER BY height DESC, created_at DESC, id DESC) as rn')
       )

--- a/src/services/crawl-cs/cs_database.service.ts
+++ b/src/services/crawl-cs/cs_database.service.ts
@@ -28,6 +28,7 @@ import {
 } from '../../modules/cs-height-sync/cs_height_sync_helpers'
 import { compareById, paginateActivityItems, parseCorporationListPagination } from '../crawl-co/co_stats'
 import { calculateEcosystemStats } from '../crawl-ec/ec_stats'
+import { applyActiveParticipantFilter } from '../crawl-pp/pp_state_utils'
 import { calculateCredentialSchemaStats } from './cs_stats'
 
 let heightColumnExistsCache: boolean | null = null
@@ -2371,7 +2372,10 @@ export default class CredentialSchemaDatabaseService extends BullableService {
           )
 
     const participantPart = await resolveParticipantsParticipantColumn(knex)
-    const corpRows = await knex('participants').where(participantPart, corporationId).distinct('schema_id')
+    const corpRows = await knex('participants')
+      .where(participantPart, corporationId)
+      .modify((qb) => applyActiveParticipantFilter(qb, new Date().toISOString()))
+      .distinct('schema_id')
     const schemaIdsFromCorp = corpRows
       .map((r: { schema_id: string }) => (r.schema_id != null ? parseFloat(r.schema_id) : null))
       .filter((id): id is number => id != null && !Number.isNaN(id))

--- a/src/services/crawl-ec/ec_database.service.ts
+++ b/src/services/crawl-ec/ec_database.service.ts
@@ -6,6 +6,7 @@ import BaseService from '../../base/base.service'
 import { MODULE_DISPLAY_NAMES, ModulesParamsNamesTypes, SERVICE } from '../../common'
 import { validateParticipantParam } from '../../common/utils/accountValidation'
 import ApiResponder from '../../common/utils/apiResponse'
+import { getBlockChainTimeAsOf } from '../../common/utils/block_time'
 import knex from '../../common/utils/db_connection'
 import {
   applyExactRangeToQuery,
@@ -2254,9 +2255,23 @@ export default class EcosystemDatabaseService extends BaseService {
     ]
 
     const participantHistPart = await resolveParticipantHistoryParticipantColumn(knex)
-    const corpParticipantRows = await knex('participant_history')
+    const asOf = await getBlockChainTimeAsOf(blockHeight, {
+      atOrBefore: true,
+      logContext: '[ec_database:participant_corporation_id]',
+    })
+    const rankedParticipantHistory = knex('participant_history')
+      .select('schema_id', participantHistPart, 'revoked', 'slashed', 'repaid', 'effective_from', 'effective_until')
+      .select(
+        knex.raw('ROW_NUMBER() OVER (PARTITION BY participant_id ORDER BY height DESC, created_at DESC, id DESC) as rn')
+      )
       .where('height', '<=', blockHeight)
+      .as('ranked_participants')
+
+    const corpParticipantRows = await knex
+      .from(rankedParticipantHistory)
+      .where('rn', 1)
       .where(participantHistPart, corporationId)
+      .modify((qb) => applyActiveParticipantFilter(qb, asOf.toISOString()))
       .distinct('schema_id')
     const schemaIds = corpParticipantRows
       .map((r: { schema_id: number }) => r.schema_id)

--- a/src/services/crawl-ec/ec_database.service.ts
+++ b/src/services/crawl-ec/ec_database.service.ts
@@ -1475,7 +1475,7 @@ export default class EcosystemDatabaseService extends BaseService {
     params: {
       corporation: { type: 'any', optional: true },
       corporation_id: { type: 'any', optional: true },
-      participant: { type: 'any', optional: true },
+      participant_corporation_id: { type: 'number', integer: true, optional: true },
       modified_after: { type: 'string', optional: true },
       archived: { type: 'any', optional: true },
       only_active: { type: 'any', optional: true },
@@ -1519,7 +1519,7 @@ export default class EcosystemDatabaseService extends BaseService {
     ctx: Context<{
       corporation?: string
       corporation_id?: string | number
-      participant?: string
+      participant_corporation_id?: number
       modified_after?: string
       archived?: string | boolean
       only_active?: string | boolean
@@ -1563,7 +1563,7 @@ export default class EcosystemDatabaseService extends BaseService {
       const {
         corporation,
         corporation_id: corporationIdRaw,
-        participant,
+        participant_corporation_id: participantCorporationIdRaw,
         modified_after: modifiedAfter,
         preferred_language: preferredLanguage,
         archived: archivedRaw,
@@ -1607,11 +1607,13 @@ export default class EcosystemDatabaseService extends BaseService {
       }
       const gfDataMode = gfDataModeParsed.mode
 
-      const participantValidation = validateParticipantParam(participant, 'participant')
-      if (!participantValidation.valid) {
-        return ApiResponder.error(ctx, participantValidation.error, 400)
+      let participantCorporationId: number | undefined
+      if (participantCorporationIdRaw !== undefined && participantCorporationIdRaw !== null) {
+        if (!Number.isInteger(participantCorporationIdRaw) || participantCorporationIdRaw <= 0) {
+          return ApiResponder.error(ctx, 'Invalid "participant_corporation_id". Must be a positive integer.', 400)
+        }
+        participantCorporationId = participantCorporationIdRaw
       }
-      const participantAccount = participantValidation.value
 
       const corporationValidation = validateParticipantParam(corporation, 'corporation')
       if (!corporationValidation.valid) {
@@ -1692,8 +1694,11 @@ export default class EcosystemDatabaseService extends BaseService {
 
         if (useHeightSyncList && hasSnapshotTable) {
           let participantEcosystemIds: number[] | undefined
-          if (participantAccount) {
-            participantEcosystemIds = await this.getEcosystemIdsForParticipantAtHeight(participantAccount, blockHeight)
+          if (participantCorporationId) {
+            participantEcosystemIds = await this.getEcosystemIdsForParticipantCorporationAtHeight(
+              participantCorporationId,
+              blockHeight
+            )
             if (participantEcosystemIds.length === 0) {
               return ApiResponder.success(ctx, { ecosystems: [] }, 200)
             }
@@ -1784,8 +1789,11 @@ export default class EcosystemDatabaseService extends BaseService {
         }
 
         let participantEcosystemIds: number[] | undefined
-        if (participantAccount) {
-          participantEcosystemIds = await this.getEcosystemIdsForParticipantAtHeight(participantAccount, blockHeight)
+        if (participantCorporationId) {
+          participantEcosystemIds = await this.getEcosystemIdsForParticipantCorporationAtHeight(
+            participantCorporationId,
+            blockHeight
+          )
           if (participantEcosystemIds.length === 0) {
             return ApiResponder.success(ctx, { ecosystems: [] }, 200)
           }
@@ -1901,8 +1909,8 @@ export default class EcosystemDatabaseService extends BaseService {
 
       if (useHeightSyncListLive && hasVersionTable && hasDocumentTable) {
         let batchQuery = knex('ecosystem')
-        if (participantAccount) {
-          const participantEcosystemIds = await this.getEcosystemIdsForParticipant(participantAccount)
+        if (participantCorporationId) {
+          const participantEcosystemIds = await this.getEcosystemIdsForParticipantCorporation(participantCorporationId)
           if (participantEcosystemIds.length === 0) {
             return ApiResponder.success(ctx, { ecosystems: [] }, 200)
           }
@@ -2082,8 +2090,8 @@ export default class EcosystemDatabaseService extends BaseService {
 
       let query = Ecosystem.query()
 
-      if (participantAccount) {
-        const participantEcosystemIds = await this.getEcosystemIdsForParticipant(participantAccount)
+      if (participantCorporationId) {
+        const participantEcosystemIds = await this.getEcosystemIdsForParticipantCorporation(participantCorporationId)
         if (participantEcosystemIds.length === 0) {
           return ApiResponder.success(ctx, { ecosystems: [] }, 200)
         }
@@ -2206,9 +2214,7 @@ export default class EcosystemDatabaseService extends BaseService {
     }
   }
 
-  private async getEcosystemIdsForParticipant(account: string): Promise<number[]> {
-    const corporationId = await resolveCorporationIdByAddress(account)
-    if (corporationId === null) return []
+  private async getEcosystemIdsForParticipantCorporation(corporationId: number): Promise<number[]> {
     const trPart = await resolveEcosystemParticipantColumn(knex)
     const controllerRows = await knex('ecosystem').where(trPart, corporationId).select('id')
     const controllerIds = controllerRows.map((r: { id: number }) => r.id)
@@ -2230,9 +2236,10 @@ export default class EcosystemDatabaseService extends BaseService {
     return [...new Set([...controllerIds, ...corpEcosystemIds])]
   }
 
-  private async getEcosystemIdsForParticipantAtHeight(account: string, blockHeight: number): Promise<number[]> {
-    const corporationId = await resolveCorporationIdByAddress(account)
-    if (corporationId === null) return []
+  private async getEcosystemIdsForParticipantCorporationAtHeight(
+    corporationId: number,
+    blockHeight: number
+  ): Promise<number[]> {
     const trHistPart = await resolveEcosystemHistoryParticipantColumn(knex)
     const ecosystemHistoryRows = await knex('ecosystem_history')
       .where('height', '<=', blockHeight)

--- a/src/services/crawl-ec/ec_database.service.ts
+++ b/src/services/crawl-ec/ec_database.service.ts
@@ -2260,7 +2260,16 @@ export default class EcosystemDatabaseService extends BaseService {
       logContext: '[ec_database:participant_corporation_id]',
     })
     const rankedParticipantHistory = knex('participant_history')
-      .select('schema_id', participantHistPart, 'revoked', 'slashed', 'repaid', 'effective_from', 'effective_until')
+      .select(
+        'schema_id',
+        participantHistPart,
+        'revoked',
+        'slashed',
+        'repaid',
+        'effective_from',
+        'effective_until',
+        'op_state'
+      )
       .select(
         knex.raw('ROW_NUMBER() OVER (PARTITION BY participant_id ORDER BY height DESC, created_at DESC, id DESC) as rn')
       )

--- a/src/services/crawl-ec/ec_database.service.ts
+++ b/src/services/crawl-ec/ec_database.service.ts
@@ -25,6 +25,7 @@ import { mapEcosystemApiFields } from '../../common/vpr-v4-mapping'
 import { Ecosystem } from '../../models/ecosystem'
 import { compareById, type GfDataMode, parseCorporationListPagination, parseGfDataMode } from '../crawl-co/co_stats'
 import { resolveCorporationIdByAddress } from '../crawl-co/corporation_resolve'
+import { applyActiveParticipantFilter } from '../crawl-pp/pp_state_utils'
 import { enrichTrustDataDeep, parseTrustDataMode } from '../resolver/trust-data-enrichment'
 import { calculateEcosystemStats, TR_STATS_FIELDS } from './ec_stats'
 
@@ -2220,7 +2221,10 @@ export default class EcosystemDatabaseService extends BaseService {
     const controllerIds = controllerRows.map((r: { id: number }) => r.id)
 
     const participantPart = await resolveParticipantsParticipantColumn(knex)
-    const corpSchemaIds = await knex('participants').where(participantPart, corporationId).distinct('schema_id')
+    const corpSchemaIds = await knex('participants')
+      .where(participantPart, corporationId)
+      .modify((qb) => applyActiveParticipantFilter(qb, new Date().toISOString()))
+      .distinct('schema_id')
     const schemaIds = corpSchemaIds
       .map((r: { schema_id: string }) => {
         const id = r.schema_id ? parseFloat(r.schema_id) : null

--- a/src/services/crawl-pp/pp_apis.service.ts
+++ b/src/services/crawl-pp/pp_apis.service.ts
@@ -21,6 +21,7 @@ import { compareById, paginateActivityItems, parseCorporationListPagination } fr
 import { resolveCorporationIdByAddress } from '../crawl-co/corporation_resolve'
 import { enrichTrustDataDeep, parseTrustDataMode, type TrustDataMode } from '../resolver/trust-data-enrichment'
 import {
+  applyActiveParticipantFilter,
   calculateCorporationAvailableActions,
   calculateParticipantState,
   calculateValidatorAvailableActions,
@@ -550,12 +551,7 @@ export default class ParticipantAPIService extends BullableService {
     }
 
     if (participantState === 'ACTIVE') {
-      query.where((qb: any) => {
-        baseNotRepaidSlashed(qb)
-        qb.where(notRevokedAsOfNow)
-        qb.where((q: any) => q.whereNull(col('effective_until')).orWhere(col('effective_until'), '>=', nowIso))
-        qb.whereNotNull(col('effective_from')).andWhere(col('effective_from'), '<=', nowIso)
-      })
+      applyActiveParticipantFilter(query, nowIso, col)
       return { pushedDown: true }
     }
 

--- a/src/services/crawl-pp/pp_state_utils.ts
+++ b/src/services/crawl-pp/pp_state_utils.ts
@@ -110,6 +110,21 @@ export function calculateParticipantState(participant: ParticipantData, now: Dat
   return 'INACTIVE'
 }
 
+export function applyActiveParticipantFilter(
+  query: any,
+  nowIso: string,
+  col: (name: string) => string = (name) => name
+): void {
+  query.where((qb: any) => {
+    qb.whereNull(col('repaid')).whereNull(col('slashed'))
+    qb.where((notRevoked: any) => notRevoked.whereNull(col('revoked')).orWhere(col('revoked'), '>=', nowIso))
+    qb.where((notEnded: any) =>
+      notEnded.whereNull(col('effective_until')).orWhere(col('effective_until'), '>=', nowIso)
+    )
+    qb.whereNotNull(col('effective_from')).andWhere(col('effective_from'), '<=', nowIso)
+  })
+}
+
 function normalizeSchemaMode(mode?: string): SchemaMode {
   if (!mode) return 'OPEN'
   const upper = mode.toUpperCase()

--- a/src/services/crawl-pp/pp_state_utils.ts
+++ b/src/services/crawl-pp/pp_state_utils.ts
@@ -148,7 +148,7 @@ export function applyActiveParticipantFilter(
     qb.where((notEnded: any) =>
       notEnded.whereNull(col('effective_until')).orWhere(col('effective_until'), '>=', nowIso)
     )
-    qb.whereNotNull(col('effective_from')).andWhere(col('effective_from'), '<=', nowIso)
+    applyActiveEffectiveFromFilter(qb, nowIso, col)
   })
 }
 

--- a/test/integration/api-endpoints.spec.ts
+++ b/test/integration/api-endpoints.spec.ts
@@ -409,9 +409,9 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
-      itIf('should list trust registries - with participant filter', async () => {
+      itIf('should list trust registries - with participant_corporation_id filter', async () => {
         const response = await testEndpoint('GET', '/v4/ecosystem/list', {
-          participant: SAMPLE_ACCOUNT,
+          participant_corporation_id: SAMPLE_ID,
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
@@ -617,9 +617,9 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
-      itIf('should list credential schemas - with participant filter', async () => {
+      itIf('should list credential schemas - with participant_corporation_id filter', async () => {
         const response = await testEndpoint('GET', '/v4/credential-schema/list', {
-          participant: SAMPLE_ACCOUNT,
+          participant_corporation_id: SAMPLE_ID,
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
@@ -721,7 +721,7 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
         const response = await testEndpoint('GET', '/v4/credential-schema/list', {
           limit: 50,
           ecosystem_id: SAMPLE_TR_ID,
-          participant: SAMPLE_ACCOUNT,
+          participant_corporation_id: SAMPLE_ID,
           modified_after: timestamps.from,
           only_active: true,
           issuer_onboarding_mode: '2',

--- a/test/unit/services/crawl-pp/pp_active_participant_filter.spec.ts
+++ b/test/unit/services/crawl-pp/pp_active_participant_filter.spec.ts
@@ -1,0 +1,37 @@
+import createKnex from 'knex'
+import { applyActiveParticipantFilter } from '../../../../src/services/crawl-pp/pp_state_utils'
+
+describe('🧪 applyActiveParticipantFilter', () => {
+  const NOW_ISO = '2025-01-10T00:00:00.000Z'
+  const qb = createKnex({ client: 'pg' })
+
+  afterAll(async () => {
+    await qb.destroy()
+  })
+
+  const sqlFor = (col?: (name: string) => string) => {
+    const query = qb('participants').distinct('schema_id')
+    applyActiveParticipantFilter(query, NOW_ISO, col)
+    return query.toQuery()
+  }
+
+  it('excludes repaid and slashed entries', () => {
+    const sql = sqlFor()
+    expect(sql).toContain('"repaid" is null')
+    expect(sql).toContain('"slashed" is null')
+  })
+
+  it('excludes entries revoked at or before the evaluation instant', () => {
+    expect(sqlFor()).toContain(`"revoked" is null or "revoked" >= '${NOW_ISO}'`)
+  })
+
+  it('keeps only entries whose effective window covers the evaluation instant', () => {
+    const sql = sqlFor()
+    expect(sql).toContain(`"effective_until" is null or "effective_until" >= '${NOW_ISO}'`)
+    expect(sql).toContain(`"effective_from" is not null and "effective_from" <= '${NOW_ISO}'`)
+  })
+
+  it('honours the table prefix used by joined queries', () => {
+    expect(sqlFor((name) => `p.${name}`)).toContain('"p"."effective_from"')
+  })
+})

--- a/test/unit/services/crawl-pp/pp_active_participant_filter.spec.ts
+++ b/test/unit/services/crawl-pp/pp_active_participant_filter.spec.ts
@@ -31,6 +31,13 @@ describe('🧪 applyActiveParticipantFilter', () => {
     expect(sql).toContain(`"effective_from" is not null and "effective_from" <= '${NOW_ISO}'`)
   })
 
+  it('keeps onboarded entries that never got an effective_from', () => {
+    const sql = sqlFor()
+    expect(sql).toContain(
+      `"effective_from" is null and ("op_state" is null or "op_state" not in ('PENDING', 'TERMINATED'))`
+    )
+  })
+
   it('honours the table prefix used by joined queries', () => {
     expect(sqlFor((name) => `p.${name}`)).toContain('"p"."effective_from"')
   })


### PR DESCRIPTION
Replaces the account-typed `participant` filter on IDX-ES-QRY-2 List Ecosystems
and IDX-CS-QRY-2 List Credential Schemas with a corporation-typed
`participant_corporation_id` (uint64).