### PR TITLE
fix: make find beneficiaries participant ids conditional

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3887,26 +3887,28 @@
           "Participant"
         ],
         "summary": "Find Beneficiaries",
-        "description": "Find participant beneficiaries based on issuer and verifier participants",
+        "description": "Compute the beneficiary Participants for a credential transaction. Given an issuer Participant and/or a verifier Participant, returns every ancestor Participant in the involved tree branch(es) that participates in the fee-distribution flow. At least one of the two ids must be provided.",
         "operationId": "findBeneficiaries",
         "parameters": [
           {
             "name": "issuer_participant_id",
             "in": "query",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             },
-            "description": "Issuer Participant ID"
+            "description": "Issuer Participant ID. At least one of issuer_participant_id and verifier_participant_id must be provided; supplying neither is HTTP 400. Alone it computes an issuance (credential offer) fee preview"
           },
           {
             "name": "verifier_participant_id",
             "in": "query",
-            "required": true,
+            "required": false,
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "minimum": 1
             },
-            "description": "Verifier Participant ID"
+            "description": "Verifier Participant ID. At least one of issuer_participant_id and verifier_participant_id must be provided; supplying neither is HTTP 400"
           },
           {
             "$ref": "#/components/parameters/At-Block-Height"

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3898,7 +3898,7 @@
               "type": "integer",
               "minimum": 1
             },
-            "description": "Issuer Participant ID. At least one of issuer_participant_id and verifier_participant_id must be provided; supplying neither is HTTP 400. Alone it computes an issuance (credential offer) fee preview"
+            "description": "Issuer Participant ID. MUST reference an active Participant; HTTP 400 otherwise. At least one of issuer_participant_id and verifier_participant_id must be provided; supplying neither is HTTP 400. Alone it computes an issuance (credential offer) fee preview"
           },
           {
             "name": "verifier_participant_id",
@@ -3908,7 +3908,7 @@
               "type": "integer",
               "minimum": 1
             },
-            "description": "Verifier Participant ID. At least one of issuer_participant_id and verifier_participant_id must be provided; supplying neither is HTTP 400"
+            "description": "Verifier Participant ID. MUST reference an active Participant; HTTP 400 otherwise. At least one of issuer_participant_id and verifier_participant_id must be provided; supplying neither is HTTP 400"
           },
           {
             "$ref": "#/components/parameters/At-Block-Height"
@@ -3916,7 +3916,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Successful response with beneficiary participants",
+            "description": "Successful response with beneficiary participants. The set is empty when the referenced Participant has no ancestors, or when every ancestor is revoked or slashed",
             "content": {
               "application/json": {
                 "schema": {
@@ -3926,17 +3926,28 @@
             }
           },
           "400": {
-            "$ref": "#/components/responses/BadRequest"
-          },
-          "404": {
-            "description": "Beneficiaries not found",
+            "description": "Neither id was provided, or a referenced Participant is not active",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Error"
                 },
                 "example": {
-                  "error": "No beneficiaries found for issuer_participant_id: 1 and verifier_participant_id: 2",
+                  "error": "Participant must be active for id(s): 1",
+                  "code": 400
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "A referenced Participant does not exist",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "example": {
+                  "error": "Participant not found for id(s): 1",
                   "code": 404
                 }
               }

--- a/src/services/crawl-pp/pp_apis.service.ts
+++ b/src/services/crawl-pp/pp_apis.service.ts
@@ -5,6 +5,7 @@ import { MODULE_DISPLAY_NAMES, ModulesParamsNamesTypes, SERVICE } from '../../co
 import { validateParticipantParam } from '../../common/utils/accountValidation'
 import { buildActivityTimeline } from '../../common/utils/activity_timeline_helper'
 import ApiResponder from '../../common/utils/apiResponse'
+import { getBlockChainTimeAsOf } from '../../common/utils/block_time'
 import { getBlockHeight, hasBlockHeight } from '../../common/utils/blockHeight'
 import { isValidISO8601UTC } from '../../common/utils/date_utils'
 import knex from '../../common/utils/db_connection'
@@ -1016,12 +1017,6 @@ export default class ParticipantAPIService extends BullableService {
             'ph.issued',
             'ph.verified',
             'ph.participants',
-            'ph.participants_ecosystem',
-            'ph.participants_issuer_grantor',
-            'ph.participants_issuer',
-            'ph.participants_verifier_grantor',
-            'ph.participants_verifier',
-            'ph.participants_holder',
             'ph.ecosystem_slash_events',
             'ph.ecosystem_slashed_amount',
             'ph.ecosystem_slashed_amount_repaid',
@@ -1077,12 +1072,6 @@ export default class ParticipantAPIService extends BullableService {
             'ph.issued',
             'ph.verified',
             'ph.participants',
-            'ph.participants_ecosystem',
-            'ph.participants_issuer_grantor',
-            'ph.participants_issuer',
-            'ph.participants_verifier_grantor',
-            'ph.participants_verifier',
-            'ph.participants_holder',
             'ph.ecosystem_slash_events',
             'ph.ecosystem_slashed_amount',
             'ph.ecosystem_slashed_amount_repaid',
@@ -2341,14 +2330,45 @@ export default class ParticipantAPIService extends BullableService {
     }
 
     try {
-      const rootIds = [issuerParticipantId, verifierParticipantId]
-        .filter((id): id is number => id !== undefined && id !== null)
-        .map((id) => Number(id))
+      const rootIds = [
+        ...new Set(
+          [issuerParticipantId, verifierParticipantId]
+            .filter((id): id is number => id !== undefined && id !== null)
+            .map((id) => Number(id))
+        ),
+      ]
 
       const initialMap = await this.getParticipantsByIdsMap(rootIds, useHistoryQuery ? blockHeight : undefined)
       const missingRootIds = rootIds.filter((rootId) => !initialMap.has(rootId))
       if (missingRootIds.length > 0) {
         return ApiResponder.error(ctx, `Participant not found for id(s): ${missingRootIds.join(', ')}`, 404)
+      }
+
+      const evaluatedAt =
+        useHistoryQuery && blockHeight !== undefined
+          ? await getBlockChainTimeAsOf(blockHeight, { atOrBefore: true, logContext: '[pp_apis:beneficiaries]' })
+          : new Date()
+      const inactiveRootIds = rootIds.filter((rootId) => {
+        const participant = initialMap.get(rootId)
+        return (
+          calculateParticipantState(
+            {
+              repaid: participant.repaid,
+              slashed: participant.slashed,
+              revoked: participant.revoked,
+              effective_from: participant.effective_from,
+              effective_until: participant.effective_until,
+              role: participant.role,
+              op_state: participant.op_state,
+              op_exp: participant.op_exp,
+              validator_participant_id: participant.validator_participant_id,
+            },
+            evaluatedAt
+          ) !== 'ACTIVE'
+        )
+      })
+      if (inactiveRootIds.length > 0) {
+        return ApiResponder.error(ctx, `Participant must be active for id(s): ${inactiveRootIds.join(', ')}`, 400)
       }
 
       const foundParticipantMap = new Map<number, any>()

--- a/src/services/crawl-pp/pp_apis.service.ts
+++ b/src/services/crawl-pp/pp_apis.service.ts
@@ -2323,17 +2323,21 @@ export default class ParticipantAPIService extends BullableService {
   @Action({
     rest: 'GET beneficiaries',
     params: {
-      issuer_participant_id: { type: 'number', integer: true },
-      verifier_participant_id: { type: 'number', integer: true },
+      issuer_participant_id: { type: 'number', integer: true, positive: true, optional: true },
+      verifier_participant_id: { type: 'number', integer: true, positive: true, optional: true },
     },
   })
-  async findBeneficiaries(ctx: Context<{ issuer_participant_id: number; verifier_participant_id: number }>) {
+  async findBeneficiaries(ctx: Context<{ issuer_participant_id?: number; verifier_participant_id?: number }>) {
     const { issuer_participant_id: issuerParticipantId, verifier_participant_id: verifierParticipantId } = ctx.params
     const blockHeight = getBlockHeight(ctx)
     const useHistoryQuery = this.shouldUseHistoryQuery(ctx, blockHeight)
 
     if (!issuerParticipantId && !verifierParticipantId) {
-      return ApiResponder.error(ctx, 'issuer_participant_id and verifier_participant_id must be set', 400)
+      return ApiResponder.error(
+        ctx,
+        'At least one of issuer_participant_id and verifier_participant_id must be set',
+        400
+      )
     }
 
     try {

--- a/test/integration/api-endpoints.spec.ts
+++ b/test/integration/api-endpoints.spec.ts
@@ -1033,7 +1033,7 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
     })
 
     describe('GET /v4/participant/beneficiaries - ALL PARAMETERS', () => {
-      itIf('should get beneficiaries - with both required participant ids', async () => {
+      itIf('should get beneficiaries - with both participant ids', async () => {
         const response = await testEndpoint('GET', '/v4/participant/beneficiaries', {
           issuer_participant_id: SAMPLE_PARTICIPANT_ID,
           verifier_participant_id: SAMPLE_PARTICIPANT_ID,
@@ -1041,15 +1041,23 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
         expect(response.status).not.toBeGreaterThanOrEqual(500)
       })
 
-      itIf('should get beneficiaries - validation: missing verifier_participant_id (should fail)', async () => {
+      itIf('should get beneficiaries - issuance only (issuer_participant_id alone)', async () => {
         const response = await testEndpoint('GET', '/v4/participant/beneficiaries', {
           issuer_participant_id: SAMPLE_PARTICIPANT_ID,
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
-        expect(response.status).toBeGreaterThanOrEqual(400)
+        expect(response.status).toBeLessThan(400)
       })
 
-      itIf('should get beneficiaries - validation: missing both required parameters (should fail)', async () => {
+      itIf('should get beneficiaries - verification only (verifier_participant_id alone)', async () => {
+        const response = await testEndpoint('GET', '/v4/participant/beneficiaries', {
+          verifier_participant_id: SAMPLE_PARTICIPANT_ID,
+        })
+        expect(response.status).not.toBeGreaterThanOrEqual(500)
+        expect(response.status).toBeLessThan(400)
+      })
+
+      itIf('should get beneficiaries - validation: neither participant id (should fail)', async () => {
         const response = await testEndpoint('GET', '/v4/participant/beneficiaries')
         expect(response.status).not.toBeGreaterThanOrEqual(500)
         expect(response.status).toBeGreaterThanOrEqual(400)

--- a/test/integration/api-endpoints.spec.ts
+++ b/test/integration/api-endpoints.spec.ts
@@ -1046,7 +1046,7 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
           issuer_participant_id: SAMPLE_PARTICIPANT_ID,
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
-        expect(response.status).toBeLessThan(400)
+        expect(String(response.data?.error ?? '')).not.toContain('At least one of')
       })
 
       itIf('should get beneficiaries - verification only (verifier_participant_id alone)', async () => {
@@ -1054,13 +1054,24 @@ describeIf('Comprehensive API Endpoints Integration Tests', () => {
           verifier_participant_id: SAMPLE_PARTICIPANT_ID,
         })
         expect(response.status).not.toBeGreaterThanOrEqual(500)
-        expect(response.status).toBeLessThan(400)
+        expect(String(response.data?.error ?? '')).not.toContain('At least one of')
+      })
+
+      itIf('should get beneficiaries - empty set is 200, never 404', async () => {
+        const response = await testEndpoint('GET', '/v4/participant/beneficiaries', {
+          issuer_participant_id: SAMPLE_PARTICIPANT_ID,
+        })
+        expect(response.status).not.toBeGreaterThanOrEqual(500)
+        if (response.status === 200) {
+          expect(Array.isArray(response.data?.participants)).toBe(true)
+        }
+        expect(String(response.data?.error ?? '')).not.toContain('No beneficiaries found')
       })
 
       itIf('should get beneficiaries - validation: neither participant id (should fail)', async () => {
         const response = await testEndpoint('GET', '/v4/participant/beneficiaries')
-        expect(response.status).not.toBeGreaterThanOrEqual(500)
-        expect(response.status).toBeGreaterThanOrEqual(400)
+        expect(response.status).toBe(400)
+        expect(String(response.data?.error ?? '')).toContain('At least one of')
       })
     })
 


### PR DESCRIPTION
Aligns IDX-PP-QRY-4 Find Beneficiaries with VPR MOD-PP-QRY-4: `issuer_participant_id` and `verifier_participant_id` are now conditional; at least one MUST be provided, instead of both being required.