### PR TITLE
feat: group module for Corporation-anchored x/group state (IDX-GR-QRY-1..5)

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3529,6 +3529,125 @@
         }
       }
     },
+    "/v4/group/get/{corporation_id}": {
+      "get": {
+        "tags": ["Group"],
+        "summary": "Get Corporation Group (v4)",
+        "description": "The x/group state backing a Corporation: group, group policy, and the full member list (IDX-GR-QRY-1). Indexer-specific; mirrors Cosmos SDK x/group queries joined with Corporation entries.",
+        "operationId": "getCorporationGroup",
+        "parameters": [
+          { "name": "corporation_id", "in": "path", "required": true, "schema": { "type": "integer", "format": "uint64" } },
+          { "$ref": "#/components/parameters/At-Block-Height" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Corporation group state",
+            "content": { "application/json": { "schema": { "type": "object", "properties": { "group": { "$ref": "#/components/schemas/CorporationGroup" } } } } }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
+    "/v4/group/corporations-by-member": {
+      "get": {
+        "tags": ["Group"],
+        "summary": "List Corporations By Member (v4)",
+        "description": "Corporations whose backing group has the supplied account as a current member (IDX-GR-QRY-2). Single-call group-membership discovery; cursor key is corporation_id.",
+        "operationId": "listCorporationsByMember",
+        "parameters": [
+          { "name": "account", "in": "query", "required": true, "schema": { "type": "string" }, "description": "Member account address" },
+          { "name": "limit", "in": "query", "required": false, "schema": { "type": "integer", "minimum": 1, "maximum": 1024, "default": 64 } },
+          { "name": "min_id", "in": "query", "required": false, "schema": { "type": "string", "pattern": "^[0-9]+$" }, "description": "Cursor: corporation_id lower bound (inclusive)" },
+          { "name": "max_id", "in": "query", "required": false, "schema": { "type": "string", "pattern": "^[0-9]+$" }, "description": "Cursor: corporation_id upper bound (exclusive)" },
+          { "name": "sort", "in": "query", "required": false, "schema": { "type": "string", "enum": ["id", "+id", "-id"], "default": "-id" } },
+          { "$ref": "#/components/parameters/At-Block-Height" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Memberships",
+            "content": { "application/json": { "schema": { "type": "object", "properties": { "memberships": { "type": "array", "items": { "$ref": "#/components/schemas/CorporationMembership" } } } } } }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
+    "/v4/group/proposals": {
+      "get": {
+        "tags": ["Group"],
+        "summary": "List Proposals (v4)",
+        "description": "Paginated, filtered list of x/group proposals targeting Corporation-anchored group policies (IDX-GR-QRY-3). Cursor key is the globally unique x/group proposal id.",
+        "operationId": "listGroupProposals",
+        "parameters": [
+          { "name": "corporation_id", "in": "query", "required": false, "schema": { "type": "integer", "format": "uint64" }, "description": "Filter by the Corporation whose group policy the proposal targets" },
+          { "name": "status", "in": "query", "required": false, "schema": { "type": "string", "enum": ["SUBMITTED", "ACCEPTED", "REJECTED", "ABORTED", "WITHDRAWN"] } },
+          { "name": "proposer", "in": "query", "required": false, "schema": { "type": "string" }, "description": "Proposals whose proposers[] includes this account" },
+          { "name": "pending_voter", "in": "query", "required": false, "schema": { "type": "string" }, "description": "Only SUBMITTED proposals within their voting period where this account is a current group member that has not voted yet" },
+          { "name": "modified_after", "in": "query", "required": false, "schema": { "type": "string", "format": "date-time" } },
+          { "name": "limit", "in": "query", "required": false, "schema": { "type": "integer", "minimum": 1, "maximum": 1024, "default": 64 } },
+          { "name": "min_id", "in": "query", "required": false, "schema": { "type": "string", "pattern": "^[0-9]+$" } },
+          { "name": "max_id", "in": "query", "required": false, "schema": { "type": "string", "pattern": "^[0-9]+$" } },
+          { "name": "sort", "in": "query", "required": false, "schema": { "type": "string", "enum": ["id", "+id", "-id"], "default": "-id" } },
+          { "$ref": "#/components/parameters/At-Block-Height" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Proposals",
+            "content": { "application/json": { "schema": { "type": "object", "properties": { "proposals": { "type": "array", "items": { "$ref": "#/components/schemas/GroupProposal" } } } } } }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
+    "/v4/group/proposal/{id}": {
+      "get": {
+        "tags": ["Group"],
+        "summary": "Get Proposal (v4)",
+        "description": "A single proposal by its x/group proposal id (IDX-GR-QRY-4). 404 for proposals that target no Corporation-anchored group policy.",
+        "operationId": "getGroupProposal",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer", "format": "uint64" } },
+          { "$ref": "#/components/parameters/At-Block-Height" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Proposal",
+            "content": { "application/json": { "schema": { "type": "object", "properties": { "proposal": { "$ref": "#/components/schemas/GroupProposal" } } } } }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
+    "/v4/group/votes": {
+      "get": {
+        "tags": ["Group"],
+        "summary": "List Votes (v4)",
+        "description": "Votes cast on Corporation-anchored proposals (IDX-GR-QRY-5). At least one of proposal_id and voter MUST be provided. Cursor key is the indexer-assigned per-row id.",
+        "operationId": "listGroupVotes",
+        "parameters": [
+          { "name": "proposal_id", "in": "query", "required": false, "schema": { "type": "integer", "format": "uint64" } },
+          { "name": "voter", "in": "query", "required": false, "schema": { "type": "string" } },
+          { "name": "limit", "in": "query", "required": false, "schema": { "type": "integer", "minimum": 1, "maximum": 1024, "default": 64 } },
+          { "name": "min_id", "in": "query", "required": false, "schema": { "type": "string", "pattern": "^[0-9]+$" } },
+          { "name": "max_id", "in": "query", "required": false, "schema": { "type": "string", "pattern": "^[0-9]+$" } },
+          { "name": "sort", "in": "query", "required": false, "schema": { "type": "string", "enum": ["id", "+id", "-id"], "default": "-id" } },
+          { "$ref": "#/components/parameters/At-Block-Height" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Votes",
+            "content": { "application/json": { "schema": { "type": "object", "properties": { "votes": { "type": "array", "items": { "$ref": "#/components/schemas/GroupVote" } } } } } }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
     "/v4/exchange-rate/get": {
       "get": {
         "tags": [
@@ -8231,6 +8350,92 @@
           "records": { "type": "array", "items": { "$ref": "#/components/schemas/ParticipantAuthorizationRecord" } }
         }
       },
+      "GroupMember": {
+        "type": "object",
+        "required": ["address", "weight"],
+        "properties": {
+          "address": { "type": "string" },
+          "weight": { "type": "string", "description": "Decimal string" },
+          "metadata": { "type": "string" },
+          "added_at": { "type": "string", "format": "date-time" }
+        }
+      },
+      "CorporationGroup": {
+        "type": "object",
+        "description": "The x/group state backing a Corporation (IDX-GR-QRY-1). The admin of both group and policy is the policy address itself (group_policy_as_admin is always true).",
+        "required": ["corporation_id", "group_id", "version", "total_weight", "policy", "members"],
+        "properties": {
+          "corporation_id": { "type": "integer", "format": "uint64" },
+          "group_id": { "type": "integer", "format": "uint64" },
+          "version": { "type": "integer", "description": "Bumped on membership changes" },
+          "total_weight": { "type": "string", "description": "Decimal string" },
+          "created_at": { "type": "string", "format": "date-time" },
+          "policy": {
+            "type": "object",
+            "required": ["address", "version"],
+            "properties": {
+              "address": { "type": "string", "description": "Equals the Corporation's policy_address" },
+              "version": { "type": "integer" },
+              "decision_policy": { "type": "object", "description": "x/group decision policy surfaced verbatim (ThresholdDecisionPolicy or PercentageDecisionPolicy)" }
+            }
+          },
+          "members": { "type": "array", "items": { "$ref": "#/components/schemas/GroupMember" }, "description": "Full list inline; corporation groups are small by construction" }
+        }
+      },
+      "CorporationMembership": {
+        "type": "object",
+        "required": ["corporation_id", "weight"],
+        "properties": {
+          "corporation_id": { "type": "integer", "format": "uint64" },
+          "weight": { "type": "string", "description": "The member's weight in that group, decimal string" },
+          "metadata": { "type": "string" },
+          "added_at": { "type": "string", "format": "date-time" }
+        }
+      },
+      "GroupTally": {
+        "type": "object",
+        "required": ["yes_count", "no_count", "abstain_count", "no_with_veto_count"],
+        "properties": {
+          "yes_count": { "type": "string" },
+          "no_count": { "type": "string" },
+          "abstain_count": { "type": "string" },
+          "no_with_veto_count": { "type": "string" }
+        }
+      },
+      "GroupProposal": {
+        "type": "object",
+        "description": "An x/group proposal targeting a Corporation-anchored group policy (IDX-GR-QRY-3/4). corporation_id and tally are indexer-derived; tally is the running tally over indexed votes and equals final_tally_result once the proposal closes.",
+        "required": ["id", "corporation_id", "group_policy_address", "proposers", "submit_time", "status", "executor_result", "messages", "tally"],
+        "properties": {
+          "id": { "type": "integer", "format": "uint64" },
+          "corporation_id": { "type": "integer", "format": "uint64" },
+          "group_policy_address": { "type": "string" },
+          "metadata": { "type": "string" },
+          "proposers": { "type": "array", "items": { "type": "string" } },
+          "submit_time": { "type": "string", "format": "date-time" },
+          "group_version": { "type": "integer", "format": "uint64" },
+          "group_policy_version": { "type": "integer", "format": "uint64" },
+          "status": { "type": "string", "enum": ["SUBMITTED", "ACCEPTED", "REJECTED", "ABORTED", "WITHDRAWN"] },
+          "voting_period_end": { "type": "string", "format": "date-time" },
+          "executor_result": { "type": "string", "enum": ["NOT_RUN", "SUCCESS", "FAILURE"] },
+          "messages": { "type": "array", "items": { "type": "object" }, "description": "The wrapped Msgs JSON-decoded with their @type" },
+          "final_tally_result": { "oneOf": [{ "$ref": "#/components/schemas/GroupTally" }, { "type": "null" }], "description": "null until the proposal closes" },
+          "tally": { "$ref": "#/components/schemas/GroupTally" }
+        }
+      },
+      "GroupVote": {
+        "type": "object",
+        "description": "A vote on a Corporation-anchored proposal (IDX-GR-QRY-5). id is indexer-assigned and serves as the pagination cursor.",
+        "required": ["id", "proposal_id", "voter", "option", "submit_time"],
+        "properties": {
+          "id": { "type": "integer", "format": "uint64" },
+          "proposal_id": { "type": "integer", "format": "uint64" },
+          "voter": { "type": "string" },
+          "option": { "type": "string", "enum": ["YES", "NO", "ABSTAIN", "NO_WITH_VETO"] },
+          "metadata": { "type": "string" },
+          "submit_time": { "type": "string", "format": "date-time" }
+        }
+      },
       "ResolutionResponse": {
         "type": "object",
         "required": ["did", "trusted", "evaluatedAtTime", "evaluatedAtBlock", "expiresAtTime", "corporationId"],
@@ -8598,6 +8803,10 @@
     {
       "name": "Delegation",
       "description": "Operator and VS-operator authorization queries"
+    },
+    {
+      "name": "Group",
+      "description": "Corporation-anchored x/group state: groups, members, policies, proposals, votes"
     },
     {
       "name": "Statistics",

--- a/src/common/constant.ts
+++ b/src/common/constant.ts
@@ -41,6 +41,7 @@ export const BULL_JOB_NAME = {
   HANDLE_TRUST_DEPOSIT: 'handle:trust-deposit',
   HANDLE_DIGEST: 'handle:digest',
   HANDLE_DELEGATION: 'handle:delegation',
+  HANDLE_GROUP: 'handle:group',
   CRAWL_GENESIS_VALIDATOR: 'crawl:genesis-validator',
   CRAWL_SIGNING_INFO: 'crawl:signing-info',
   HANDLE_ADDRESS: 'handle:address',
@@ -328,6 +329,14 @@ export const SERVICE = {
     DelegationDatabaseService: {
       key: 'DelegationDatabaseService',
       path: 'v1.DelegationDatabaseService',
+    },
+    GroupApiService: {
+      key: 'GroupApiService',
+      path: 'v1.GroupApiService',
+    },
+    GroupProcessorService: {
+      key: 'GroupProcessorService',
+      path: 'v1.GroupProcessorService',
     },
     DelegationProcessorService: {
       key: 'DelegationProcessorService',

--- a/src/config.json
+++ b/src/config.json
@@ -89,6 +89,11 @@
     "millisecondCrawl": 300,
     "chunkSize": 500
   },
+  "crawlGroup": {
+    "key": "crawlGroup",
+    "millisecondCrawl": 300,
+    "chunkSize": 500
+  },
   "crawlAccounts": {
     "key": "crawlAccounts",
     "freshStart": {

--- a/src/migrations/20260811000000_create_group_tables.ts
+++ b/src/migrations/20260811000000_create_group_tables.ts
@@ -1,0 +1,92 @@
+import { Knex } from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('corporation_group', (table) => {
+    table.bigInteger('corporation_id').primary()
+    table.bigInteger('group_id').notNullable().unique()
+    table.text('policy_address').notNullable().unique()
+    table.bigInteger('group_version').notNullable().defaultTo(1)
+    table.bigInteger('policy_version').notNullable().defaultTo(1)
+    table.text('total_weight').notNullable().defaultTo('0')
+    table.jsonb('decision_policy').nullable()
+    table.timestamp('created').notNullable()
+    table.timestamp('modified').notNullable()
+    table.bigInteger('height').notNullable()
+
+    table.foreign('corporation_id').references('id').inTable('corporation').onDelete('CASCADE')
+  })
+
+  await knex.schema.createTable('corporation_group_history', (table) => {
+    table.bigIncrements('id').primary()
+    table.bigInteger('corporation_id').notNullable()
+    table.bigInteger('group_id').notNullable()
+    table.bigInteger('group_version').notNullable()
+    table.bigInteger('policy_version').notNullable()
+    table.text('total_weight').notNullable()
+    table.jsonb('decision_policy').nullable()
+    table.jsonb('members').notNullable()
+    table.bigInteger('height').notNullable()
+    table.timestamp('created_at').notNullable().defaultTo(knex.fn.now())
+
+    table.unique(['corporation_id', 'height'])
+    table.index(['height'])
+  })
+
+  await knex.schema.createTable('group_proposal', (table) => {
+    table.bigInteger('id').primary()
+    table.bigInteger('corporation_id').notNullable()
+    table.text('group_policy_address').notNullable()
+    table.text('metadata').nullable()
+    table.jsonb('proposers').notNullable().defaultTo('[]')
+    table.timestamp('submit_time').notNullable()
+    table.bigInteger('group_version').nullable()
+    table.bigInteger('group_policy_version').nullable()
+    table.string('status', 16).notNullable().defaultTo('SUBMITTED')
+    table.string('executor_result', 16).notNullable().defaultTo('NOT_RUN')
+    table.timestamp('voting_period_end').nullable()
+    table.jsonb('messages').notNullable().defaultTo('[]')
+    table.jsonb('final_tally_result').nullable()
+    table.timestamp('modified').notNullable()
+    table.bigInteger('height').notNullable()
+
+    table.foreign('corporation_id').references('corporation_id').inTable('corporation_group').onDelete('CASCADE')
+
+    table.index(['corporation_id'])
+    table.index(['status'])
+    table.index(['modified'])
+  })
+
+  await knex.schema.createTable('group_proposal_history', (table) => {
+    table.bigIncrements('id').primary()
+    table.bigInteger('proposal_id').notNullable()
+    table.jsonb('snapshot').notNullable()
+    table.bigInteger('height').notNullable()
+    table.timestamp('created_at').notNullable().defaultTo(knex.fn.now())
+
+    table.unique(['proposal_id', 'height'])
+    table.index(['height'])
+  })
+
+  await knex.schema.createTable('group_vote', (table) => {
+    table.bigIncrements('id').primary()
+    table.bigInteger('proposal_id').notNullable()
+    table.text('voter').notNullable()
+    table.string('option', 16).notNullable()
+    table.text('metadata').nullable()
+    table.timestamp('submit_time').notNullable()
+    table.bigInteger('height').notNullable()
+
+    table.unique(['proposal_id', 'voter'])
+    table.index(['proposal_id'])
+    table.index(['voter'])
+    table.index(['height'])
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('group_vote')
+  await knex.schema.dropTableIfExists('group_proposal_history')
+  await knex.schema.dropTableIfExists('group_proposal')
+  await knex.schema.dropTableIfExists('corporation_group_history')
+  await knex.schema.dropTableIfExists('corporation_group')
+}

--- a/src/models/corporation_group.ts
+++ b/src/models/corporation_group.ts
@@ -1,0 +1,37 @@
+import BaseModel from './base'
+
+export default class CorporationGroup extends BaseModel {
+  static tableName = 'corporation_group'
+
+  static get idColumn() {
+    return 'corporation_id'
+  }
+
+  corporation_id!: number
+  group_id!: number
+  policy_address!: string
+  group_version!: number
+  policy_version!: number
+  total_weight!: string
+  decision_policy!: Record<string, unknown> | null
+  created!: string
+  modified!: string
+  height!: number
+
+  static get jsonSchema() {
+    return {
+      type: 'object',
+      required: ['corporation_id', 'group_id', 'policy_address', 'height'],
+      properties: {
+        corporation_id: { type: 'integer' },
+        group_id: { type: 'integer' },
+        policy_address: { type: 'string' },
+        group_version: { type: 'integer' },
+        policy_version: { type: 'integer' },
+        total_weight: { type: 'string' },
+        decision_policy: { type: ['object', 'null'] },
+        height: { type: 'integer' },
+      },
+    }
+  }
+}

--- a/src/models/group_proposal.ts
+++ b/src/models/group_proposal.ts
@@ -1,0 +1,42 @@
+import BaseModel from './base'
+
+export default class GroupProposal extends BaseModel {
+  static tableName = 'group_proposal'
+
+  id!: number
+  corporation_id!: number
+  group_policy_address!: string
+  metadata!: string | null
+  proposers!: string[]
+  submit_time!: string
+  group_version!: number | null
+  group_policy_version!: number | null
+  status!: string
+  executor_result!: string
+  voting_period_end!: string | null
+  messages!: Array<Record<string, unknown>>
+  final_tally_result!: Record<string, unknown> | null
+  modified!: string
+  height!: number
+
+  static get jsonSchema() {
+    return {
+      type: 'object',
+      required: ['id', 'corporation_id', 'group_policy_address', 'status', 'executor_result', 'height'],
+      properties: {
+        id: { type: 'integer' },
+        corporation_id: { type: 'integer' },
+        group_policy_address: { type: 'string' },
+        metadata: { type: ['string', 'null'] },
+        proposers: { type: 'array', items: { type: 'string' } },
+        group_version: { type: ['integer', 'null'] },
+        group_policy_version: { type: ['integer', 'null'] },
+        status: { type: 'string', maxLength: 16 },
+        executor_result: { type: 'string', maxLength: 16 },
+        messages: { type: 'array' },
+        final_tally_result: { type: ['object', 'null'] },
+        height: { type: 'integer' },
+      },
+    }
+  }
+}

--- a/src/models/group_vote.ts
+++ b/src/models/group_vote.ts
@@ -1,0 +1,28 @@
+import BaseModel from './base'
+
+export default class GroupVote extends BaseModel {
+  static tableName = 'group_vote'
+
+  id!: number
+  proposal_id!: number
+  voter!: string
+  option!: string
+  metadata!: string | null
+  submit_time!: string
+  height!: number
+
+  static get jsonSchema() {
+    return {
+      type: 'object',
+      required: ['proposal_id', 'voter', 'option', 'height'],
+      properties: {
+        id: { type: 'integer' },
+        proposal_id: { type: 'integer' },
+        voter: { type: 'string' },
+        option: { type: 'string', maxLength: 16 },
+        metadata: { type: ['string', 'null'] },
+        height: { type: 'integer' },
+      },
+    }
+  }
+}

--- a/src/services/api/api.service.ts
+++ b/src/services/api/api.service.ts
@@ -371,6 +371,13 @@ function createRoute(path: string, aliases: Record<string, string>, requireBlock
         'GET vs-operator-authorizations': `${SERVICE.V1.DelegationApiService.path}.listVSOperatorAuthorizations`,
         'GET vs-operator-authorization/:id': `${SERVICE.V1.DelegationApiService.path}.getVSOperatorAuthorization`,
       }),
+      createRoute('/v4/group', {
+        'GET get/:corporation_id': `${SERVICE.V1.GroupApiService.path}.getCorporationGroup`,
+        'GET corporations-by-member': `${SERVICE.V1.GroupApiService.path}.listCorporationsByMember`,
+        'GET proposals': `${SERVICE.V1.GroupApiService.path}.listProposals`,
+        'GET proposal/:id': `${SERVICE.V1.GroupApiService.path}.getProposal`,
+        'GET votes': `${SERVICE.V1.GroupApiService.path}.listVotes`,
+      }),
       createRoute('/v4/trust-deposit', {
         'GET get/:corporation_id': `${SERVICE.V1.TrustDepositApiService.path}.getTrustDeposit`,
         'GET params': `${SERVICE.V1.TrustDepositApiService.path}.getModuleParams`,

--- a/src/services/api/indexer_events_query.ts
+++ b/src/services/api/indexer_events_query.ts
@@ -24,7 +24,14 @@ import {
 
 export type IndexerTxEvent = {
   type: 'transaction-executed'
-  module: 'ecosystem' | 'credential-schema' | 'participant' | 'digital-identity' | 'delegation' | 'corporation'
+  module:
+    | 'ecosystem'
+    | 'credential-schema'
+    | 'participant'
+    | 'digital-identity'
+    | 'delegation'
+    | 'corporation'
+    | 'group'
   action: string
   messageType: string
   blockHeight: number
@@ -822,6 +829,159 @@ async function buildDelegationEvents(blockHeight: number): Promise<IndexerTxEven
   return events
 }
 
+const GROUP_ROUTED_MESSAGE_TYPES = [
+  '/cosmos.group.v1.MsgSubmitProposal',
+  '/cosmos.group.v1.MsgVote',
+  '/cosmos.group.v1.MsgExec',
+  '/cosmos.group.v1.MsgWithdrawProposal',
+  '/cosmos.group.v1.MsgUpdateGroupMembers',
+  '/cosmos.group.v1.MsgUpdateGroupMetadata',
+  '/cosmos.group.v1.MsgUpdateGroupAdmin',
+  '/cosmos.group.v1.MsgUpdateGroupPolicyDecisionPolicy',
+  '/cosmos.group.v1.MsgUpdateGroupPolicyMetadata',
+  '/cosmos.group.v1.MsgUpdateGroupPolicyAdmin',
+  '/cosmos.group.v1.MsgLeaveGroup',
+]
+
+// Anchors on the corporation table itself, so routing does not wait for the (separately checkpointed)
+// group processor to fill corporation_group.
+async function loadCorporationByPolicyAddress(policyAddress: string): Promise<{
+  corporationId?: number
+  did?: string
+}> {
+  const row = await knex('corporation')
+    .where(function () {
+      this.where('policy_address', policyAddress).orWhere('corporation', policyAddress)
+    })
+    .select('id', 'did')
+    .first()
+  if (!row) return {}
+  return { corporationId: toCorporationId(row.id), did: normalizeDid(row.did) }
+}
+
+async function loadCorporationByGroupId(groupId: number): Promise<{ corporationId?: number; did?: string }> {
+  const row = await knex('corporation_group as cg')
+    .innerJoin('corporation as co', 'co.id', 'cg.corporation_id')
+    .where('cg.group_id', groupId)
+    .select('cg.corporation_id', 'co.did')
+    .first()
+  if (!row) return {}
+  return { corporationId: toCorporationId(row.corporation_id), did: normalizeDid(row.did) }
+}
+
+// Falls back to the submit tx stored in the DB, so pruned proposals and not-yet-processed blocks still resolve.
+async function resolveProposalPolicyAddress(proposalId: number): Promise<string | undefined> {
+  const proposal = await knex('group_proposal').select('group_policy_address').where('id', proposalId).first()
+  if (proposal?.group_policy_address) return String(proposal.group_policy_address)
+  const submitAttr = await knex('event_attribute as ea')
+    .innerJoin('event as e', 'e.id', 'ea.event_id')
+    .where('e.type', 'cosmos.group.v1.EventSubmitProposal')
+    .where('ea.key', 'proposal_id')
+    .where('ea.value', JSON.stringify(String(proposalId)))
+    .select('e.tx_id', 'e.tx_msg_index')
+    .first()
+  if (!submitAttr?.tx_id) return undefined
+  // Match the submitting message by index: one tx can batch several MsgSubmitProposal for different policies.
+  const submitMessage = await knex('transaction_message')
+    .where('tx_id', submitAttr.tx_id)
+    .where('type', '/cosmos.group.v1.MsgSubmitProposal')
+    .where('index', Number(submitAttr.tx_msg_index ?? 0))
+    .select('content')
+    .first()
+  const content = submitMessage?.content as Record<string, unknown> | undefined
+  const address = content?.group_policy_address
+  return typeof address === 'string' && address ? address : undefined
+}
+
+// MsgSubmitProposal carries no proposal id (assigned on-chain) — read it from the tx's own event.
+async function resolveSubmittedProposalId(txHash: string, messageIndex: number): Promise<string | undefined> {
+  const row = await knex('event as e')
+    .innerJoin('transaction as tx', 'tx.id', 'e.tx_id')
+    .innerJoin('event_attribute as ea', 'ea.event_id', 'e.id')
+    .where('tx.hash', txHash)
+    .where('e.type', 'cosmos.group.v1.EventSubmitProposal')
+    .where('ea.key', 'proposal_id')
+    .select('ea.value', 'e.tx_msg_index')
+    .orderBy('e.id', 'asc')
+  const match = row.find((entry) => Number(entry.tx_msg_index ?? 0) === messageIndex) ?? row[0]
+  if (!match) return undefined
+  const value = String(match.value ?? '').replace(/^"|"$/g, '')
+  return /^\d+$/.test(value) ? value : undefined
+}
+
+async function buildGroupEvents(blockHeight: number): Promise<IndexerTxEvent[]> {
+  const rows = (await knex('transaction_message as tm')
+    .innerJoin('transaction as tx', 'tx.id', 'tm.tx_id')
+    .where('tx.height', blockHeight)
+    .andWhere('tx.code', 0)
+    .whereIn('tm.type', GROUP_ROUTED_MESSAGE_TYPES)
+    .select(
+      'tm.index as message_index',
+      'tm.type as message_type',
+      'tm.sender',
+      'tm.content',
+      'tx.height as block_height',
+      'tx.hash as tx_hash',
+      'tx.index as tx_index',
+      'tx.timestamp'
+    )
+    .orderBy('tx.index', 'asc')
+    .orderBy('tm.index', 'asc')) as EventRow[]
+  if (rows.length === 0) return []
+
+  const events: IndexerTxEvent[] = []
+  for (const row of rows) {
+    const content = row.content && typeof row.content === 'object' ? (row.content as Record<string, unknown>) : {}
+    const action = toShortMessageType(row.message_type).replace(/^Msg/, '')
+
+    let anchor: { corporationId?: number; did?: string } = {}
+    let entityType = 'CorporationGroup'
+    let entityId: string | undefined
+    const policyAddress = readAddress(content.group_policy_address)
+    const groupId = readFirstPositiveInteger(content, ['group_id', 'groupId'])
+    const proposalId = readFirstPositiveInteger(content, ['proposal_id', 'proposalId'])
+    if (policyAddress) {
+      anchor = await loadCorporationByPolicyAddress(policyAddress)
+    } else if (groupId) {
+      anchor = await loadCorporationByGroupId(groupId)
+    } else if (proposalId) {
+      const resolvedAddress = await resolveProposalPolicyAddress(proposalId)
+      if (resolvedAddress) anchor = await loadCorporationByPolicyAddress(resolvedAddress)
+      entityType = 'GroupProposal'
+      entityId = String(proposalId)
+    }
+    if (row.message_type === '/cosmos.group.v1.MsgSubmitProposal') {
+      entityType = 'GroupProposal'
+      entityId = await resolveSubmittedProposalId(row.tx_hash, Number(row.message_index))
+    }
+    // CorporationGroup entities are keyed by corporation_id; group_id lives in a different id space.
+    if (entityType === 'CorporationGroup' && anchor.corporationId) entityId = String(anchor.corporationId)
+
+    // Group events anchoring no Corporation stay wildcard-only (did null, no corporation scope).
+    events.push({
+      type: 'transaction-executed',
+      module: 'group',
+      action,
+      messageType: row.message_type,
+      blockHeight: Number(row.block_height),
+      txHash: row.tx_hash,
+      txIndex: Number(row.tx_index),
+      messageIndex: Number(row.message_index),
+      sender: row.sender ?? '',
+      did: anchor.did ?? null,
+      relatedDids: anchor.did ? [anchor.did] : [],
+      entityType,
+      entityId,
+      corporationId: anchor.corporationId,
+      relatedCorporationIds: [],
+      timestamp: toIsoSeconds(row.timestamp),
+    })
+  }
+  return events
+}
+
+export const buildGroupEventsForTest = buildGroupEvents
+
 export async function persistIndexerEventsForBlock(blockHeight: number): Promise<IndexerEventRecord[]> {
   const rows: Array<Record<string, unknown>> = []
   const pageSize = 500
@@ -834,6 +994,8 @@ export async function persistIndexerEventsForBlock(blockHeight: number): Promise
   }
   const delegationEvents = await buildDelegationEvents(blockHeight)
   rows.push(...delegationEvents.map(toEventRow))
+  const groupEvents = await buildGroupEvents(blockHeight)
+  rows.push(...groupEvents.map(toEventRow))
   let insertedIds: number[] = []
 
   if (rows.length > 0) {

--- a/src/services/api/indexer_events_query.ts
+++ b/src/services/api/indexer_events_query.ts
@@ -9,6 +9,7 @@ import {
   VeranaGovernanceFrameworkMessageTypes,
   VeranaParticipantMessageTypes,
 } from '../../common/verana-message-types'
+import { GROUP_ROUTED_MESSAGE_TYPES } from '../crawl-group/group_helpers'
 import { applyBlockHeightFilter, toIsoSeconds } from './api_shared'
 import { fetchCorporationById, fetchParticipantDid } from './indexer_event_chain_lookup'
 import {
@@ -828,20 +829,6 @@ async function buildDelegationEvents(blockHeight: number): Promise<IndexerTxEven
   }
   return events
 }
-
-const GROUP_ROUTED_MESSAGE_TYPES = [
-  '/cosmos.group.v1.MsgSubmitProposal',
-  '/cosmos.group.v1.MsgVote',
-  '/cosmos.group.v1.MsgExec',
-  '/cosmos.group.v1.MsgWithdrawProposal',
-  '/cosmos.group.v1.MsgUpdateGroupMembers',
-  '/cosmos.group.v1.MsgUpdateGroupMetadata',
-  '/cosmos.group.v1.MsgUpdateGroupAdmin',
-  '/cosmos.group.v1.MsgUpdateGroupPolicyDecisionPolicy',
-  '/cosmos.group.v1.MsgUpdateGroupPolicyMetadata',
-  '/cosmos.group.v1.MsgUpdateGroupPolicyAdmin',
-  '/cosmos.group.v1.MsgLeaveGroup',
-]
 
 // Anchors on the corporation table itself, so routing does not wait for the (separately checkpointed)
 // group processor to fill corporation_group.

--- a/src/services/api/indexer_events_query.ts
+++ b/src/services/api/indexer_events_query.ts
@@ -859,14 +859,38 @@ async function loadCorporationByPolicyAddress(policyAddress: string): Promise<{
   return { corporationId: toCorporationId(row.id), did: normalizeDid(row.did) }
 }
 
+// Falls back to the create events so routing never waits for the group processor's checkpoint.
 async function loadCorporationByGroupId(groupId: number): Promise<{ corporationId?: number; did?: string }> {
   const row = await knex('corporation_group as cg')
     .innerJoin('corporation as co', 'co.id', 'cg.corporation_id')
     .where('cg.group_id', groupId)
     .select('cg.corporation_id', 'co.did')
     .first()
-  if (!row) return {}
-  return { corporationId: toCorporationId(row.corporation_id), did: normalizeDid(row.did) }
+  if (row) return { corporationId: toCorporationId(row.corporation_id), did: normalizeDid(row.did) }
+
+  const createGroup = await knex('event as e')
+    .innerJoin('event_attribute as ea', 'ea.event_id', 'e.id')
+    .where('e.type', 'cosmos.group.v1.EventCreateGroup')
+    .where('ea.key', 'group_id')
+    .where('ea.value', JSON.stringify(String(groupId)))
+    .select('e.id', 'e.tx_id', 'e.tx_msg_index')
+    .orderBy('e.id', 'asc')
+    .first()
+  if (!createGroup?.tx_id) return {}
+
+  // Same tx and message index: one tx can create several corporations.
+  const policyAddress = await knex('event as e')
+    .innerJoin('event_attribute as ea', 'ea.event_id', 'e.id')
+    .where('e.type', 'cosmos.group.v1.EventCreateGroupPolicy')
+    .where('e.tx_id', createGroup.tx_id)
+    .whereRaw('COALESCE(e.tx_msg_index, 0) = ?', [Number(createGroup.tx_msg_index ?? 0)])
+    .where('ea.key', 'address')
+    .where('e.id', '>', Number(createGroup.id))
+    .select('ea.value')
+    .orderBy('e.id', 'asc')
+    .first()
+  const address = String(policyAddress?.value ?? '').replace(/^"|"$/g, '')
+  return address ? loadCorporationByPolicyAddress(address) : {}
 }
 
 // Falls back to the submit tx stored in the DB, so pruned proposals and not-yet-processed blocks still resolve.

--- a/src/services/crawl-group/group_api.service.ts
+++ b/src/services/crawl-group/group_api.service.ts
@@ -8,7 +8,7 @@ import { getBlockChainTimeAsOf } from '../../common/utils/block_time'
 import { getBlockHeight } from '../../common/utils/blockHeight'
 import { dateToIsoOrNull } from '../../common/utils/date_utils'
 import knex from '../../common/utils/db_connection'
-import { compareById, parseCorporationListPagination } from '../crawl-co/co_stats'
+import { parseCorporationListPagination } from '../crawl-co/co_stats'
 import { normalizeTallyResult, PROPOSAL_STATUSES } from './group_helpers'
 
 type GroupMember = { address: string; weight: string; metadata: string; added_at: string | null }
@@ -223,30 +223,22 @@ export default class GroupApiService extends BaseService {
       const blockHeight = getBlockHeight(ctx)
 
       if (blockHeight !== undefined) {
-        const rows = await this.latestGroupHistoryQuery(blockHeight).whereRaw('gh.members @> ?::jsonb', [
+        let query = this.latestGroupHistoryQuery(blockHeight).whereRaw('gh.members @> ?::jsonb', [
           JSON.stringify([{ address: account }]),
         ])
+        if (minId !== undefined) query = query.where('gh.corporation_id', '>=', minId)
+        if (maxId !== undefined) query = query.where('gh.corporation_id', '<', maxId)
+        const rows = await query.orderBy('gh.corporation_id', direction).limit(limit)
         const memberships = rows
-          .map((row) => {
+          .map((row: Record<string, unknown>) => {
             const members = Array.isArray(row.members) ? (row.members as Array<Record<string, unknown>>) : []
             const member = members.find((entry) => String(entry.address) === account)
             if (!member) return null
-            return {
-              id: Number(row.corporation_id),
-              corporation_id: Number(row.corporation_id),
-              ...serializeMember(member),
-            }
+            const { address: _address, ...rest } = serializeMember(member)
+            return { corporation_id: Number(row.corporation_id), ...rest }
           })
-          .filter(Boolean) as Array<{ id: number; corporation_id: number } & GroupMember>
-        const paged = memberships
-          .filter(
-            (entry) =>
-              (minId === undefined || entry.id >= Number(minId)) && (maxId === undefined || entry.id < Number(maxId))
-          )
-          .sort((a, b) => compareById(a.id, b.id, direction))
-          .slice(0, limit)
-          .map(({ id: _id, address: _address, ...rest }) => rest)
-        return ApiResponder.success(ctx, { memberships: paged })
+          .filter(Boolean)
+        return ApiResponder.success(ctx, { memberships })
       }
 
       let query = knex('corporation_member as cm')
@@ -321,7 +313,7 @@ export default class GroupApiService extends BaseService {
       // All four pending_voter predicates run in SQL so the cursors and limit bound the scan.
       const pendingVoterNowIso =
         pendingVoter && blockHeight !== undefined
-          ? (await getBlockChainTimeAsOf(blockHeight, { logger: this.logger })).toISOString()
+          ? (await getBlockChainTimeAsOf(blockHeight, { logger: this.logger, atOrBefore: true })).toISOString()
           : new Date().toISOString()
 
       let candidates: Array<Record<string, unknown>>

--- a/src/services/crawl-group/group_api.service.ts
+++ b/src/services/crawl-group/group_api.service.ts
@@ -1,4 +1,5 @@
 import { Action, Service } from '@ourparentcenter/moleculer-decorators-extended'
+import type { Knex } from 'knex'
 import { Context, ServiceBroker } from 'moleculer'
 import BaseService from '../../base/base.service'
 import { SERVICE } from '../../common'
@@ -317,6 +318,12 @@ export default class GroupApiService extends BaseService {
       const blockHeight = getBlockHeight(ctx)
       const pendingVoter = p.pending_voter?.trim() || undefined
 
+      // All four pending_voter predicates run in SQL so the cursors and limit bound the scan.
+      const pendingVoterNowIso =
+        pendingVoter && blockHeight !== undefined
+          ? (await getBlockChainTimeAsOf(blockHeight, { logger: this.logger })).toISOString()
+          : new Date().toISOString()
+
       let candidates: Array<Record<string, unknown>>
       if (blockHeight !== undefined) {
         let query = this.latestProposalHistoryQuery(blockHeight).select('ph.proposal_id', 'ph.snapshot')
@@ -328,11 +335,34 @@ export default class GroupApiService extends BaseService {
         if (modifiedAfterIso) {
           query = query.whereRaw("(ph.snapshot->>'modified')::timestamptz > ?::timestamptz", [modifiedAfterIso])
         }
-        if (!pendingVoter) {
-          if (minId !== undefined) query = query.where('ph.proposal_id', '>=', minId)
-          if (maxId !== undefined) query = query.where('ph.proposal_id', '<', maxId)
-          query = query.orderBy('ph.proposal_id', direction).limit(limit)
+        if (pendingVoter) {
+          query = query
+            .whereRaw("ph.snapshot->>'status' = ?", ['SUBMITTED'])
+            .whereRaw("(ph.snapshot->>'voting_period_end')::timestamptz > ?::timestamptz", [pendingVoterNowIso])
+            .whereNotExists((qb: Knex.QueryBuilder) =>
+              qb
+                .select(knex.raw('1'))
+                .from('group_vote as gv')
+                .whereRaw('gv.proposal_id = ph.proposal_id')
+                .where('gv.voter', pendingVoter)
+                .where('gv.height', '<=', blockHeight)
+            )
+            .whereExists((qb: Knex.QueryBuilder) =>
+              qb
+                .select(knex.raw('1'))
+                .from(
+                  knex.raw(
+                    '(select distinct on (corporation_id) corporation_id, members from corporation_group_history where height <= ? order by corporation_id asc, height desc) as gh',
+                    [blockHeight]
+                  )
+                )
+                .whereRaw("gh.corporation_id = (ph.snapshot->>'corporation_id')::bigint")
+                .whereRaw('gh.members @> ?::jsonb', [JSON.stringify([{ address: pendingVoter }])])
+            )
         }
+        if (minId !== undefined) query = query.where('ph.proposal_id', '>=', minId)
+        if (maxId !== undefined) query = query.where('ph.proposal_id', '<', maxId)
+        query = query.orderBy('ph.proposal_id', direction).limit(limit)
         const rows = await query
         candidates = rows.map((row: Record<string, unknown>) => ({
           ...(row.snapshot as Record<string, unknown>),
@@ -344,57 +374,30 @@ export default class GroupApiService extends BaseService {
         if (p.status) query = query.where('status', p.status)
         if (p.proposer) query = query.whereRaw('proposers @> ?::jsonb', [JSON.stringify([p.proposer])])
         if (modifiedAfterIso) query = query.where('modified', '>', modifiedAfterIso)
-        if (!pendingVoter) {
-          if (minId !== undefined) query = query.where('id', '>=', minId)
-          if (maxId !== undefined) query = query.where('id', '<', maxId)
-          query = query.orderBy('id', direction).limit(limit)
+        if (pendingVoter) {
+          query = query
+            .where('status', 'SUBMITTED')
+            .whereNotNull('voting_period_end')
+            .where('voting_period_end', '>', pendingVoterNowIso)
+            .whereNotExists((qb: Knex.QueryBuilder) =>
+              qb
+                .select(knex.raw('1'))
+                .from('group_vote as gv')
+                .whereRaw('gv.proposal_id = group_proposal.id')
+                .where('gv.voter', pendingVoter)
+            )
+            .whereExists((qb: Knex.QueryBuilder) =>
+              qb
+                .select(knex.raw('1'))
+                .from('corporation_member as cm')
+                .whereRaw('cm.corporation_id = group_proposal.corporation_id')
+                .where('cm.address', pendingVoter)
+            )
         }
+        if (minId !== undefined) query = query.where('id', '>=', minId)
+        if (maxId !== undefined) query = query.where('id', '<', maxId)
+        query = query.orderBy('id', direction).limit(limit)
         candidates = await query
-      }
-
-      if (pendingVoter) {
-        const now =
-          blockHeight !== undefined ? await getBlockChainTimeAsOf(blockHeight, { logger: this.logger }) : new Date()
-        candidates = candidates.filter(
-          (proposal) =>
-            String(proposal.status) === 'SUBMITTED' &&
-            proposal.voting_period_end != null &&
-            new Date(String(proposal.voting_period_end)).getTime() > now.getTime()
-        )
-        const proposalIds = candidates.map((proposal) => Number(proposal.id))
-        let votesQuery = knex('group_vote')
-          .select('proposal_id')
-          .where('voter', pendingVoter)
-          .whereIn('proposal_id', proposalIds.length > 0 ? proposalIds : [0])
-        if (blockHeight !== undefined) votesQuery = votesQuery.where('height', '<=', blockHeight)
-        const voted = new Set((await votesQuery).map((vote) => Number(vote.proposal_id)))
-
-        const corporationIds = [...new Set(candidates.map((proposal) => Number(proposal.corporation_id)))]
-        const memberCorporations = new Set<number>()
-        if (blockHeight !== undefined) {
-          const historyRows = await this.latestGroupHistoryQuery(blockHeight)
-            .whereIn('gh.corporation_id', corporationIds.length > 0 ? corporationIds : [0])
-            .whereRaw('gh.members @> ?::jsonb', [JSON.stringify([{ address: pendingVoter }])])
-          for (const row of historyRows) memberCorporations.add(Number(row.corporation_id))
-        } else {
-          const memberRows = await knex('corporation_member')
-            .select('corporation_id')
-            .where('address', pendingVoter)
-            .whereIn('corporation_id', corporationIds.length > 0 ? corporationIds : [0])
-          for (const row of memberRows) memberCorporations.add(Number(row.corporation_id))
-        }
-
-        candidates = candidates
-          .filter(
-            (proposal) => !voted.has(Number(proposal.id)) && memberCorporations.has(Number(proposal.corporation_id))
-          )
-          .filter(
-            (proposal) =>
-              (minId === undefined || Number(proposal.id) >= Number(minId)) &&
-              (maxId === undefined || Number(proposal.id) < Number(maxId))
-          )
-          .sort((a, b) => compareById(a.id, b.id, direction))
-          .slice(0, limit)
       }
 
       const tallies = await this.computeTallies(candidates, blockHeight)

--- a/src/services/crawl-group/group_api.service.ts
+++ b/src/services/crawl-group/group_api.service.ts
@@ -1,0 +1,495 @@
+import { Action, Service } from '@ourparentcenter/moleculer-decorators-extended'
+import { Context, ServiceBroker } from 'moleculer'
+import BaseService from '../../base/base.service'
+import { SERVICE } from '../../common'
+import ApiResponder from '../../common/utils/apiResponse'
+import { getBlockChainTimeAsOf } from '../../common/utils/block_time'
+import { getBlockHeight } from '../../common/utils/blockHeight'
+import { dateToIsoOrNull } from '../../common/utils/date_utils'
+import knex from '../../common/utils/db_connection'
+import { compareById, parseCorporationListPagination } from '../crawl-co/co_stats'
+import { normalizeTallyResult, PROPOSAL_STATUSES } from './group_helpers'
+
+type GroupMember = { address: string; weight: string; metadata: string; added_at: string | null }
+
+function serializeMember(member: Record<string, unknown>): GroupMember {
+  return {
+    address: String(member.address ?? ''),
+    weight: String(member.weight ?? '0'),
+    metadata: member.metadata != null ? String(member.metadata) : '',
+    added_at: dateToIsoOrNull(member.added_at ?? member.created ?? null),
+  }
+}
+
+function serializeCorporationGroup(row: Record<string, unknown>, members: GroupMember[]) {
+  return {
+    corporation_id: Number(row.corporation_id),
+    group_id: Number(row.group_id),
+    version: Number(row.group_version),
+    total_weight: String(row.total_weight ?? '0'),
+    created_at: dateToIsoOrNull(row.created ?? null),
+    policy: {
+      address: String(row.policy_address ?? ''),
+      version: Number(row.policy_version),
+      decision_policy: (row.decision_policy as Record<string, unknown> | null) ?? null,
+    },
+    members,
+  }
+}
+
+function serializeProposal(row: Record<string, unknown>, tally: Record<string, string>) {
+  const finalTally = row.final_tally_result as Record<string, unknown> | null
+  return {
+    id: Number(row.id),
+    corporation_id: Number(row.corporation_id),
+    group_policy_address: String(row.group_policy_address ?? ''),
+    metadata: row.metadata != null ? String(row.metadata) : '',
+    proposers: Array.isArray(row.proposers) ? row.proposers : [],
+    submit_time: dateToIsoOrNull(row.submit_time ?? null),
+    group_version: row.group_version != null ? Number(row.group_version) : null,
+    group_policy_version: row.group_policy_version != null ? Number(row.group_policy_version) : null,
+    status: String(row.status ?? 'SUBMITTED'),
+    voting_period_end: dateToIsoOrNull(row.voting_period_end ?? null),
+    executor_result: String(row.executor_result ?? 'NOT_RUN'),
+    messages: Array.isArray(row.messages) ? row.messages : [],
+    final_tally_result: finalTally ?? null,
+    tally,
+  }
+}
+
+function serializeVote(row: Record<string, unknown>) {
+  return {
+    id: Number(row.id),
+    proposal_id: Number(row.proposal_id),
+    voter: String(row.voter ?? ''),
+    option: String(row.option ?? ''),
+    metadata: row.metadata != null ? String(row.metadata) : '',
+    submit_time: dateToIsoOrNull(row.submit_time ?? null),
+  }
+}
+
+@Service({
+  name: SERVICE.V1.GroupApiService.key,
+  version: 1,
+})
+export default class GroupApiService extends BaseService {
+  public constructor(public broker: ServiceBroker) {
+    super(broker)
+  }
+
+  private latestGroupHistoryQuery(blockHeight: number) {
+    const latest = knex('corporation_group_history')
+      .distinctOn('corporation_id')
+      .select('*')
+      .where('height', '<=', blockHeight)
+      .orderBy('corporation_id', 'asc')
+      .orderBy('height', 'desc')
+    return knex.from(latest.as('gh')).select('*')
+  }
+
+  private latestProposalHistoryQuery(blockHeight: number) {
+    const latest = knex('group_proposal_history')
+      .distinctOn('proposal_id')
+      .select('*')
+      .where('height', '<=', blockHeight)
+      .orderBy('proposal_id', 'asc')
+      .orderBy('height', 'desc')
+    return knex.from(latest.as('ph'))
+  }
+
+  // Weighted running tally per proposal (x/group semantics: counts are member-weight sums).
+  private async computeTallies(
+    proposals: Array<Record<string, unknown>>,
+    blockHeight: number | undefined
+  ): Promise<Map<number, Record<string, string>>> {
+    const result = new Map<number, Record<string, string>>()
+    if (proposals.length === 0) return result
+    const proposalIds = proposals.map((proposal) => Number(proposal.id))
+
+    let votesQuery = knex('group_vote').select('proposal_id', 'voter', 'option').whereIn('proposal_id', proposalIds)
+    if (blockHeight !== undefined) votesQuery = votesQuery.where('height', '<=', blockHeight)
+    const votes = await votesQuery
+
+    const corporationIds = [...new Set(proposals.map((proposal) => Number(proposal.corporation_id)))]
+    const weightByCorporation = new Map<number, Map<string, number>>()
+    if (blockHeight !== undefined) {
+      const historyRows = await this.latestGroupHistoryQuery(blockHeight).whereIn('gh.corporation_id', corporationIds)
+      for (const row of historyRows) {
+        const members = Array.isArray(row.members) ? (row.members as Array<Record<string, unknown>>) : []
+        weightByCorporation.set(
+          Number(row.corporation_id),
+          new Map(members.map((member) => [String(member.address), Number(member.weight) || 0]))
+        )
+      }
+    } else {
+      const memberRows = await knex('corporation_member')
+        .select('corporation_id', 'address', 'weight')
+        .whereIn('corporation_id', corporationIds)
+      for (const member of memberRows) {
+        const bucket = weightByCorporation.get(Number(member.corporation_id)) ?? new Map<string, number>()
+        bucket.set(String(member.address), Number(member.weight) || 0)
+        weightByCorporation.set(Number(member.corporation_id), bucket)
+      }
+    }
+
+    for (const proposal of proposals) {
+      const proposalId = Number(proposal.id)
+      // Spec: once a proposal closes, tally equals the chain's final_tally_result — never recompute it
+      // from current weights, which drift as membership changes.
+      const finalTally = normalizeTallyResult(proposal.final_tally_result)
+      if (String(proposal.status) !== 'SUBMITTED' && finalTally) {
+        result.set(proposalId, finalTally)
+        continue
+      }
+      const weights = weightByCorporation.get(Number(proposal.corporation_id)) ?? new Map<string, number>()
+      const sums: Record<string, number> = { YES: 0, NO: 0, ABSTAIN: 0, NO_WITH_VETO: 0 }
+      for (const vote of votes.filter((v) => Number(v.proposal_id) === proposalId)) {
+        if (sums[vote.option] !== undefined) sums[vote.option] += weights.get(String(vote.voter)) ?? 0
+      }
+      result.set(proposalId, {
+        yes_count: String(sums.YES),
+        no_count: String(sums.NO),
+        abstain_count: String(sums.ABSTAIN),
+        no_with_veto_count: String(sums.NO_WITH_VETO),
+      })
+    }
+    return result
+  }
+
+  // IDX-GR-QRY-1 Get Corporation Group
+  @Action({
+    rest: 'GET get/:corporation_id',
+    params: { corporation_id: { type: 'number', integer: true, positive: true, convert: true } },
+  })
+  public async getCorporationGroup(ctx: Context<{ corporation_id: number }>) {
+    try {
+      const corporationId = ctx.params.corporation_id
+      const blockHeight = getBlockHeight(ctx)
+
+      if (blockHeight !== undefined) {
+        const row = await this.latestGroupHistoryQuery(blockHeight).where('gh.corporation_id', corporationId).first()
+        if (!row) return ApiResponder.error(ctx, `Corporation ${corporationId} group not found`, 404)
+        // policy_address and created are immutable, so they come from the live row; history carries neither.
+        const live = await knex('corporation_group')
+          .select('created', 'policy_address')
+          .where('corporation_id', corporationId)
+          .first()
+        const members = (Array.isArray(row.members) ? row.members : []).map(serializeMember)
+        return ApiResponder.success(ctx, {
+          group: serializeCorporationGroup(
+            { ...row, created: live?.created ?? null, policy_address: live?.policy_address ?? null },
+            members
+          ),
+        })
+      }
+
+      const row = await knex('corporation_group').where('corporation_id', corporationId).first()
+      if (!row) return ApiResponder.error(ctx, `Corporation ${corporationId} group not found`, 404)
+      const members = await knex('corporation_member')
+        .select('address', 'weight', 'metadata', 'created')
+        .where('corporation_id', corporationId)
+        .orderBy('id', 'asc')
+      return ApiResponder.success(ctx, {
+        group: serializeCorporationGroup(row, members.map(serializeMember)),
+      })
+    } catch (err) {
+      this.logger.error('Error in Group.getCorporationGroup:', err)
+      return ApiResponder.error(ctx, 'Internal Server Error', 500)
+    }
+  }
+
+  // IDX-GR-QRY-2 List Corporations By Member
+  @Action({
+    rest: 'GET corporations-by-member',
+    params: {
+      account: { type: 'string' },
+      limit: { type: 'string', optional: true, convert: true },
+      min_id: { type: 'string', optional: true, convert: true },
+      max_id: { type: 'string', optional: true, convert: true },
+      sort: { type: 'string', optional: true },
+    },
+  })
+  public async listCorporationsByMember(
+    ctx: Context<{ account: string; limit?: string; min_id?: string; max_id?: string; sort?: string }>
+  ) {
+    try {
+      const account = String(ctx.params.account ?? '').trim()
+      if (!account) return ApiResponder.error(ctx, '"account" is required', 400)
+
+      const pageParsed = parseCorporationListPagination(ctx.params)
+      if (!pageParsed.ok) return ApiResponder.error(ctx, pageParsed.message, 400)
+      const { limit, minId, maxId, direction } = pageParsed.value
+      const blockHeight = getBlockHeight(ctx)
+
+      if (blockHeight !== undefined) {
+        const rows = await this.latestGroupHistoryQuery(blockHeight).whereRaw('gh.members @> ?::jsonb', [
+          JSON.stringify([{ address: account }]),
+        ])
+        const memberships = rows
+          .map((row) => {
+            const members = Array.isArray(row.members) ? (row.members as Array<Record<string, unknown>>) : []
+            const member = members.find((entry) => String(entry.address) === account)
+            if (!member) return null
+            return {
+              id: Number(row.corporation_id),
+              corporation_id: Number(row.corporation_id),
+              ...serializeMember(member),
+            }
+          })
+          .filter(Boolean) as Array<{ id: number; corporation_id: number } & GroupMember>
+        const paged = memberships
+          .filter(
+            (entry) =>
+              (minId === undefined || entry.id >= Number(minId)) && (maxId === undefined || entry.id < Number(maxId))
+          )
+          .sort((a, b) => compareById(a.id, b.id, direction))
+          .slice(0, limit)
+          .map(({ id: _id, address: _address, ...rest }) => rest)
+        return ApiResponder.success(ctx, { memberships: paged })
+      }
+
+      let query = knex('corporation_member as cm')
+        .innerJoin('corporation_group as cg', 'cg.corporation_id', 'cm.corporation_id')
+        .where('cm.address', account)
+        .select('cm.corporation_id', 'cm.weight', 'cm.metadata', 'cm.created')
+      if (minId !== undefined) query = query.where('cm.corporation_id', '>=', minId)
+      if (maxId !== undefined) query = query.where('cm.corporation_id', '<', maxId)
+      const rows = await query.orderBy('cm.corporation_id', direction).limit(limit)
+
+      return ApiResponder.success(ctx, {
+        memberships: rows.map((row) => {
+          const { address: _address, ...rest } = serializeMember(row)
+          return { corporation_id: Number(row.corporation_id), ...rest }
+        }),
+      })
+    } catch (err) {
+      this.logger.error('Error in Group.listCorporationsByMember:', err)
+      return ApiResponder.error(ctx, 'Internal Server Error', 500)
+    }
+  }
+
+  // IDX-GR-QRY-3 List Proposals
+  @Action({
+    rest: 'GET proposals',
+    params: {
+      corporation_id: { type: 'number', integer: true, positive: true, optional: true, convert: true },
+      status: { type: 'string', optional: true },
+      proposer: { type: 'string', optional: true },
+      pending_voter: { type: 'string', optional: true },
+      modified_after: { type: 'string', optional: true },
+      limit: { type: 'string', optional: true, convert: true },
+      min_id: { type: 'string', optional: true, convert: true },
+      max_id: { type: 'string', optional: true, convert: true },
+      sort: { type: 'string', optional: true },
+    },
+  })
+  public async listProposals(
+    ctx: Context<{
+      corporation_id?: number
+      status?: string
+      proposer?: string
+      pending_voter?: string
+      modified_after?: string
+      limit?: string
+      min_id?: string
+      max_id?: string
+      sort?: string
+    }>
+  ) {
+    try {
+      const p = ctx.params
+      const pageParsed = parseCorporationListPagination(p)
+      if (!pageParsed.ok) return ApiResponder.error(ctx, pageParsed.message, 400)
+      const { limit, minId, maxId, direction } = pageParsed.value
+
+      if (p.status !== undefined && !(PROPOSAL_STATUSES as readonly string[]).includes(p.status)) {
+        return ApiResponder.error(ctx, `"status" must be one of ${PROPOSAL_STATUSES.join(', ')}`, 400)
+      }
+      let modifiedAfterIso: string | undefined
+      if (p.modified_after) {
+        const ts = new Date(p.modified_after)
+        if (Number.isNaN(ts.getTime())) {
+          return ApiResponder.error(ctx, '"modified_after" must be a valid ISO 8601 datetime', 400)
+        }
+        modifiedAfterIso = ts.toISOString()
+      }
+
+      const blockHeight = getBlockHeight(ctx)
+      const pendingVoter = p.pending_voter?.trim() || undefined
+
+      let candidates: Array<Record<string, unknown>>
+      if (blockHeight !== undefined) {
+        let query = this.latestProposalHistoryQuery(blockHeight).select('ph.proposal_id', 'ph.snapshot')
+        if (p.corporation_id !== undefined) {
+          query = query.whereRaw("(ph.snapshot->>'corporation_id')::bigint = ?", [p.corporation_id])
+        }
+        if (p.status) query = query.whereRaw("ph.snapshot->>'status' = ?", [p.status])
+        if (p.proposer) query = query.whereRaw("ph.snapshot->'proposers' @> ?::jsonb", [JSON.stringify([p.proposer])])
+        if (modifiedAfterIso) {
+          query = query.whereRaw("(ph.snapshot->>'modified')::timestamptz > ?::timestamptz", [modifiedAfterIso])
+        }
+        if (!pendingVoter) {
+          if (minId !== undefined) query = query.where('ph.proposal_id', '>=', minId)
+          if (maxId !== undefined) query = query.where('ph.proposal_id', '<', maxId)
+          query = query.orderBy('ph.proposal_id', direction).limit(limit)
+        }
+        const rows = await query
+        candidates = rows.map((row: Record<string, unknown>) => ({
+          ...(row.snapshot as Record<string, unknown>),
+          id: Number(row.proposal_id),
+        }))
+      } else {
+        let query = knex('group_proposal').select('*')
+        if (p.corporation_id !== undefined) query = query.where('corporation_id', p.corporation_id)
+        if (p.status) query = query.where('status', p.status)
+        if (p.proposer) query = query.whereRaw('proposers @> ?::jsonb', [JSON.stringify([p.proposer])])
+        if (modifiedAfterIso) query = query.where('modified', '>', modifiedAfterIso)
+        if (!pendingVoter) {
+          if (minId !== undefined) query = query.where('id', '>=', minId)
+          if (maxId !== undefined) query = query.where('id', '<', maxId)
+          query = query.orderBy('id', direction).limit(limit)
+        }
+        candidates = await query
+      }
+
+      if (pendingVoter) {
+        const now =
+          blockHeight !== undefined ? await getBlockChainTimeAsOf(blockHeight, { logger: this.logger }) : new Date()
+        candidates = candidates.filter(
+          (proposal) =>
+            String(proposal.status) === 'SUBMITTED' &&
+            proposal.voting_period_end != null &&
+            new Date(String(proposal.voting_period_end)).getTime() > now.getTime()
+        )
+        const proposalIds = candidates.map((proposal) => Number(proposal.id))
+        let votesQuery = knex('group_vote')
+          .select('proposal_id')
+          .where('voter', pendingVoter)
+          .whereIn('proposal_id', proposalIds.length > 0 ? proposalIds : [0])
+        if (blockHeight !== undefined) votesQuery = votesQuery.where('height', '<=', blockHeight)
+        const voted = new Set((await votesQuery).map((vote) => Number(vote.proposal_id)))
+
+        const corporationIds = [...new Set(candidates.map((proposal) => Number(proposal.corporation_id)))]
+        const memberCorporations = new Set<number>()
+        if (blockHeight !== undefined) {
+          const historyRows = await this.latestGroupHistoryQuery(blockHeight)
+            .whereIn('gh.corporation_id', corporationIds.length > 0 ? corporationIds : [0])
+            .whereRaw('gh.members @> ?::jsonb', [JSON.stringify([{ address: pendingVoter }])])
+          for (const row of historyRows) memberCorporations.add(Number(row.corporation_id))
+        } else {
+          const memberRows = await knex('corporation_member')
+            .select('corporation_id')
+            .where('address', pendingVoter)
+            .whereIn('corporation_id', corporationIds.length > 0 ? corporationIds : [0])
+          for (const row of memberRows) memberCorporations.add(Number(row.corporation_id))
+        }
+
+        candidates = candidates
+          .filter(
+            (proposal) => !voted.has(Number(proposal.id)) && memberCorporations.has(Number(proposal.corporation_id))
+          )
+          .filter(
+            (proposal) =>
+              (minId === undefined || Number(proposal.id) >= Number(minId)) &&
+              (maxId === undefined || Number(proposal.id) < Number(maxId))
+          )
+          .sort((a, b) => compareById(a.id, b.id, direction))
+          .slice(0, limit)
+      }
+
+      const tallies = await this.computeTallies(candidates, blockHeight)
+      return ApiResponder.success(ctx, {
+        proposals: candidates.map((proposal) =>
+          serializeProposal(proposal, tallies.get(Number(proposal.id)) ?? tallyFromNothing())
+        ),
+      })
+    } catch (err) {
+      this.logger.error('Error in Group.listProposals:', err)
+      return ApiResponder.error(ctx, 'Internal Server Error', 500)
+    }
+  }
+
+  // IDX-GR-QRY-4 Get Proposal
+  @Action({
+    rest: 'GET proposal/:id',
+    params: { id: { type: 'number', integer: true, positive: true, convert: true } },
+  })
+  public async getProposal(ctx: Context<{ id: number }>) {
+    try {
+      const { id } = ctx.params
+      const blockHeight = getBlockHeight(ctx)
+
+      let row: Record<string, unknown> | undefined
+      if (blockHeight !== undefined) {
+        const history = await this.latestProposalHistoryQuery(blockHeight)
+          .select('ph.proposal_id', 'ph.snapshot')
+          .where('ph.proposal_id', id)
+          .first()
+        if (history) row = { ...(history.snapshot as Record<string, unknown>), id: Number(history.proposal_id) }
+      } else {
+        row = await knex('group_proposal').where('id', id).first()
+      }
+      if (!row) return ApiResponder.error(ctx, `Proposal ${id} not found`, 404)
+
+      const tallies = await this.computeTallies([row], blockHeight)
+      return ApiResponder.success(ctx, {
+        proposal: serializeProposal(row, tallies.get(Number(row.id)) ?? tallyFromNothing()),
+      })
+    } catch (err) {
+      this.logger.error('Error in Group.getProposal:', err)
+      return ApiResponder.error(ctx, 'Internal Server Error', 500)
+    }
+  }
+
+  // IDX-GR-QRY-5 List Votes
+  @Action({
+    rest: 'GET votes',
+    params: {
+      proposal_id: { type: 'number', integer: true, positive: true, optional: true, convert: true },
+      voter: { type: 'string', optional: true },
+      limit: { type: 'string', optional: true, convert: true },
+      min_id: { type: 'string', optional: true, convert: true },
+      max_id: { type: 'string', optional: true, convert: true },
+      sort: { type: 'string', optional: true },
+    },
+  })
+  public async listVotes(
+    ctx: Context<{
+      proposal_id?: number
+      voter?: string
+      limit?: string
+      min_id?: string
+      max_id?: string
+      sort?: string
+    }>
+  ) {
+    try {
+      const p = ctx.params
+      const voter = p.voter?.trim() || undefined
+      if (p.proposal_id === undefined && !voter) {
+        return ApiResponder.error(ctx, 'At least one of "proposal_id" and "voter" must be provided', 400)
+      }
+      const pageParsed = parseCorporationListPagination(p)
+      if (!pageParsed.ok) return ApiResponder.error(ctx, pageParsed.message, 400)
+      const { limit, minId, maxId, direction } = pageParsed.value
+      const blockHeight = getBlockHeight(ctx)
+
+      let query = knex('group_vote').select('*')
+      if (p.proposal_id !== undefined) query = query.where('proposal_id', p.proposal_id)
+      if (voter) query = query.where('voter', voter)
+      if (blockHeight !== undefined) query = query.where('height', '<=', blockHeight)
+      if (minId !== undefined) query = query.where('id', '>=', minId)
+      if (maxId !== undefined) query = query.where('id', '<', maxId)
+      const rows = await query.orderBy('id', direction).limit(limit)
+
+      return ApiResponder.success(ctx, { votes: rows.map(serializeVote) })
+    } catch (err) {
+      this.logger.error('Error in Group.listVotes:', err)
+      return ApiResponder.error(ctx, 'Internal Server Error', 500)
+    }
+  }
+}
+
+function tallyFromNothing(): Record<string, string> {
+  return { yes_count: '0', no_count: '0', abstain_count: '0', no_with_veto_count: '0' }
+}

--- a/src/services/crawl-group/group_helpers.ts
+++ b/src/services/crawl-group/group_helpers.ts
@@ -1,0 +1,176 @@
+export const GROUP_MSG_TYPES = {
+  CreateCorporation: '/verana.co.v1.MsgCreateCorporation',
+  SubmitProposal: '/cosmos.group.v1.MsgSubmitProposal',
+  Vote: '/cosmos.group.v1.MsgVote',
+  Exec: '/cosmos.group.v1.MsgExec',
+  WithdrawProposal: '/cosmos.group.v1.MsgWithdrawProposal',
+  UpdateGroupMembers: '/cosmos.group.v1.MsgUpdateGroupMembers',
+  UpdateGroupMetadata: '/cosmos.group.v1.MsgUpdateGroupMetadata',
+  UpdateGroupAdmin: '/cosmos.group.v1.MsgUpdateGroupAdmin',
+  UpdateGroupPolicyDecisionPolicy: '/cosmos.group.v1.MsgUpdateGroupPolicyDecisionPolicy',
+  UpdateGroupPolicyMetadata: '/cosmos.group.v1.MsgUpdateGroupPolicyMetadata',
+  UpdateGroupPolicyAdmin: '/cosmos.group.v1.MsgUpdateGroupPolicyAdmin',
+  LeaveGroup: '/cosmos.group.v1.MsgLeaveGroup',
+} as const
+
+export const GROUP_EVENT_TYPES = {
+  CreateGroup: 'cosmos.group.v1.EventCreateGroup',
+  CreateGroupPolicy: 'cosmos.group.v1.EventCreateGroupPolicy',
+  SubmitProposal: 'cosmos.group.v1.EventSubmitProposal',
+  Vote: 'cosmos.group.v1.EventVote',
+  Exec: 'cosmos.group.v1.EventExec',
+  WithdrawProposal: 'cosmos.group.v1.EventWithdrawProposal',
+  ProposalPruned: 'cosmos.group.v1.EventProposalPruned',
+  UpdateGroup: 'cosmos.group.v1.EventUpdateGroup',
+  UpdateGroupPolicy: 'cosmos.group.v1.EventUpdateGroupPolicy',
+} as const
+
+export const PROPOSAL_STATUSES = ['SUBMITTED', 'ACCEPTED', 'REJECTED', 'ABORTED', 'WITHDRAWN'] as const
+export const EXECUTOR_RESULTS = ['NOT_RUN', 'SUCCESS', 'FAILURE'] as const
+export const VOTE_OPTIONS = ['YES', 'NO', 'ABSTAIN', 'NO_WITH_VETO'] as const
+
+// Maps x/group enum names (or their numeric wire values) to the spec's short forms.
+export function shortProposalStatus(raw: unknown): string | null {
+  const byNumber: Record<number, string> = {
+    1: 'SUBMITTED',
+    2: 'ACCEPTED',
+    3: 'REJECTED',
+    4: 'ABORTED',
+    5: 'WITHDRAWN',
+  }
+  if (typeof raw === 'number') return byNumber[raw] ?? null
+  if (typeof raw !== 'string') return null
+  const name = raw.replace(/^PROPOSAL_STATUS_/, '')
+  return (PROPOSAL_STATUSES as readonly string[]).includes(name) ? name : null
+}
+
+export function shortExecutorResult(raw: unknown): string | null {
+  const byNumber: Record<number, string> = { 1: 'NOT_RUN', 2: 'SUCCESS', 3: 'FAILURE' }
+  if (typeof raw === 'number') return byNumber[raw] ?? null
+  if (typeof raw !== 'string') return null
+  const name = raw.replace(/^PROPOSAL_EXECUTOR_RESULT_/, '')
+  return (EXECUTOR_RESULTS as readonly string[]).includes(name) ? name : null
+}
+
+export function shortVoteOption(raw: unknown): string | null {
+  const byNumber: Record<number, string> = { 1: 'YES', 2: 'ABSTAIN', 3: 'NO', 4: 'NO_WITH_VETO' }
+  if (typeof raw === 'number') return byNumber[raw] ?? null
+  if (typeof raw !== 'string') return null
+  const name = raw.replace(/^VOTE_OPTION_/, '')
+  return (VOTE_OPTIONS as readonly string[]).includes(name) ? name : null
+}
+
+// Typed-event attribute values are raw JSON: uint64s and strings arrive quoted ("5").
+export function parseEventAttrValue(raw: unknown): string | null {
+  if (raw === undefined || raw === null) return null
+  const s = String(raw).trim()
+  if (s.startsWith('"') && s.endsWith('"') && s.length >= 2) return s.slice(1, -1)
+  return s
+}
+
+export function parseEventAttrJson(raw: unknown): Record<string, unknown> | null {
+  if (typeof raw !== 'string') return null
+  try {
+    const parsed = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : null
+  } catch {
+    return null
+  }
+}
+
+export function readPositiveInt(value: unknown): number | null {
+  const n = Number(typeof value === 'string' ? value.trim() : value)
+  return Number.isInteger(n) && n > 0 ? n : null
+}
+
+// Cosmos Duration JSON ("300s") -> seconds.
+export function durationToSeconds(raw: unknown): number | null {
+  if (typeof raw !== 'string') return null
+  const match = raw.trim().match(/^(\d+(?:\.\d+)?)s$/)
+  return match ? Number(match[1]) : null
+}
+
+export function votingPeriodSecondsFromDecisionPolicy(decisionPolicy: unknown): number | null {
+  if (!decisionPolicy || typeof decisionPolicy !== 'object') return null
+  const windows = (decisionPolicy as Record<string, unknown>).windows
+  if (!windows || typeof windows !== 'object') return null
+  return durationToSeconds((windows as Record<string, unknown>).voting_period)
+}
+
+// x/group TallyResult JSON field names -> the spec's tally counter names.
+export function normalizeTallyResult(raw: unknown): Record<string, string> | null {
+  if (!raw || typeof raw !== 'object') return null
+  const source = raw as Record<string, unknown>
+  const pick = (...keys: string[]) => {
+    for (const key of keys) {
+      const value = source[key]
+      if (value !== undefined && value !== null && String(value).trim() !== '') return String(value)
+    }
+    return '0'
+  }
+  return {
+    yes_count: pick('yes_count', 'yesCount'),
+    no_count: pick('no_count', 'noCount'),
+    abstain_count: pick('abstain_count', 'abstainCount'),
+    no_with_veto_count: pick('no_with_veto_count', 'noWithVetoCount'),
+  }
+}
+
+export function tallyFromVotes(votes: Array<{ option: string }>): Record<string, string> {
+  const counts: Record<string, number> = { YES: 0, NO: 0, ABSTAIN: 0, NO_WITH_VETO: 0 }
+  for (const vote of votes) {
+    if (counts[vote.option] !== undefined) counts[vote.option] += 1
+  }
+  return {
+    yes_count: String(counts.YES),
+    no_count: String(counts.NO),
+    abstain_count: String(counts.ABSTAIN),
+    no_with_veto_count: String(counts.NO_WITH_VETO),
+  }
+}
+
+// Final-tally outcome for the two x/group decision policies. Returns null when the policy cannot be
+// evaluated, so callers leave the status alone instead of inventing a terminal state.
+export function decideProposalOutcome(
+  decisionPolicy: unknown,
+  yesWeight: number,
+  totalWeight: number
+): 'ACCEPTED' | 'REJECTED' | null {
+  if (!decisionPolicy || typeof decisionPolicy !== 'object') return null
+  const policy = decisionPolicy as Record<string, unknown>
+  const type = String(policy['@type'] ?? '')
+
+  if (type.endsWith('ThresholdDecisionPolicy') || policy.threshold !== undefined) {
+    const threshold = Number(policy.threshold)
+    if (!Number.isFinite(threshold)) return null
+    return yesWeight >= threshold ? 'ACCEPTED' : 'REJECTED'
+  }
+
+  if (type.endsWith('PercentageDecisionPolicy') || policy.percentage !== undefined) {
+    const percentage = Number(policy.percentage)
+    if (!Number.isFinite(percentage) || totalWeight <= 0) return null
+    return yesWeight / totalWeight >= percentage ? 'ACCEPTED' : 'REJECTED'
+  }
+
+  return null
+}
+
+export type AnyMessage = {
+  '@type'?: string
+  type_url?: string
+  typeUrl?: string
+  value?: unknown
+  [key: string]: unknown
+}
+
+export function anyTypeUrl(message: AnyMessage): string | null {
+  const url = message['@type'] ?? message.type_url ?? message.typeUrl
+  return typeof url === 'string' && url.length > 0 ? url : null
+}
+
+// True when the Any still carries an undecoded base64 payload rather than JSON fields.
+export function isUndecodedAny(message: AnyMessage): boolean {
+  if (typeof message.value !== 'string') return false
+  const keys = Object.keys(message).filter((key) => !['@type', 'type_url', 'typeUrl', 'value'].includes(key))
+  return keys.length === 0
+}

--- a/src/services/crawl-group/group_helpers.ts
+++ b/src/services/crawl-group/group_helpers.ts
@@ -23,6 +23,8 @@ export const GROUP_EVENT_TYPES = {
   ProposalPruned: 'cosmos.group.v1.EventProposalPruned',
   UpdateGroup: 'cosmos.group.v1.EventUpdateGroup',
   UpdateGroupPolicy: 'cosmos.group.v1.EventUpdateGroupPolicy',
+  // A leave emits only this event, never EventUpdateGroup.
+  LeaveGroup: 'cosmos.group.v1.EventLeaveGroup',
 } as const
 
 export const PROPOSAL_STATUSES = ['SUBMITTED', 'ACCEPTED', 'REJECTED', 'ABORTED', 'WITHDRAWN'] as const
@@ -143,7 +145,9 @@ export function decideProposalOutcome(
   if (type.endsWith('ThresholdDecisionPolicy') || policy.threshold !== undefined) {
     const threshold = Number(policy.threshold)
     if (!Number.isFinite(threshold)) return null
-    return yesWeight >= threshold ? 'ACCEPTED' : 'REJECTED'
+    // x/group caps the threshold at total weight, so a shrunken group can still accept.
+    const realThreshold = totalWeight > 0 ? Math.min(threshold, totalWeight) : threshold
+    return yesWeight >= realThreshold ? 'ACCEPTED' : 'REJECTED'
   }
 
   if (type.endsWith('PercentageDecisionPolicy') || policy.percentage !== undefined) {

--- a/src/services/crawl-group/group_helpers.ts
+++ b/src/services/crawl-group/group_helpers.ts
@@ -13,6 +13,11 @@ export const GROUP_MSG_TYPES = {
   LeaveGroup: '/cosmos.group.v1.MsgLeaveGroup',
 } as const
 
+// Every x/group message routed as an event of its Corporation; the create message is a verana Msg.
+export const GROUP_ROUTED_MESSAGE_TYPES: string[] = Object.entries(GROUP_MSG_TYPES)
+  .filter(([key]) => key !== 'CreateCorporation')
+  .map(([, type]) => type)
+
 export const GROUP_EVENT_TYPES = {
   CreateGroup: 'cosmos.group.v1.EventCreateGroup',
   CreateGroupPolicy: 'cosmos.group.v1.EventCreateGroupPolicy',

--- a/src/services/crawl-group/group_processor.service.ts
+++ b/src/services/crawl-group/group_processor.service.ts
@@ -1,0 +1,717 @@
+import { fromBase64 } from '@cosmjs/encoding'
+import { Registry } from '@cosmjs/proto-signing'
+import { defaultRegistryTypes } from '@cosmjs/stargate'
+import { Action, Service } from '@ourparentcenter/moleculer-decorators-extended'
+import { ServiceBroker } from 'moleculer'
+import BullableService from '../../base/bullable.service'
+import { BULL_JOB_NAME, SERVICE } from '../../common'
+import { getLcdBaseUrl } from '../../common/utils/account_balance_utils'
+import { CheckpointManager } from '../../common/utils/checkpoint_manager'
+import knex from '../../common/utils/db_connection'
+import { detectStartMode } from '../../common/utils/start_mode_detector'
+import { veranaRegistry } from '../../common/utils/veranaChain.client'
+import config from '../../config.json' with { type: 'json' }
+import { BlockCheckpoint } from '../../models/block_checkpoint'
+import { indexerStatusManager } from '../manager/indexer_status.manager'
+import {
+  type AnyMessage,
+  anyTypeUrl,
+  decideProposalOutcome,
+  GROUP_EVENT_TYPES,
+  GROUP_MSG_TYPES,
+  isUndecodedAny,
+  normalizeTallyResult,
+  parseEventAttrJson,
+  parseEventAttrValue,
+  readPositiveInt,
+  shortExecutorResult,
+  shortProposalStatus,
+  shortVoteOption,
+  votingPeriodSecondsFromDecisionPolicy,
+} from './group_helpers'
+
+const LCD_TIMEOUT_MS = 8000
+
+type MessageRow = {
+  tx_id: number
+  message_index: number
+  message_type: string
+  sender: string | null
+  content: Record<string, unknown>
+  block_height: number
+  tx_hash: string
+  timestamp: Date | string
+}
+
+type GroupEventRow = {
+  event_id: number
+  type: string
+  tx_id: number | null
+  tx_msg_index: number | null
+  block_height: number
+  attrs: Record<string, string>
+}
+
+@Service({
+  name: SERVICE.V1.GroupProcessorService.key,
+  version: 1,
+})
+export default class GroupProcessorService extends BullableService {
+  private timer: NodeJS.Timeout | null = null
+  private checkpointManager: CheckpointManager
+  private isProcessing = false
+  private decodeRegistry = new Registry([...defaultRegistryTypes, ...veranaRegistry] as ConstructorParameters<
+    typeof Registry
+  >[0])
+
+  public constructor(public broker: ServiceBroker) {
+    super(broker)
+    this.checkpointManager = new CheckpointManager(this.logger)
+  }
+
+  public async started() {
+    try {
+      await detectStartMode(BULL_JOB_NAME.HANDLE_GROUP)
+      const [startBlock] = await BlockCheckpoint.getCheckpoint(BULL_JOB_NAME.HANDLE_GROUP, [])
+      await this.checkpointManager.ensureCheckpoint(BULL_JOB_NAME.HANDLE_GROUP, startBlock || 0)
+      const crawlInterval = config.crawlGroup.millisecondCrawl
+
+      this.processBlocks().catch((err) => {
+        this.logger.error('[GroupProcessorService] Error in initial processBlocks:', err)
+      })
+      this.timer = setInterval(() => {
+        if (!indexerStatusManager.isCrawlingActive()) return
+        if (!this.isProcessing) {
+          this.processBlocks().catch((err) => {
+            this.logger.error('[GroupProcessorService] Error in scheduled processBlocks:', err)
+          })
+        }
+      }, crawlInterval)
+      this.logger.info(`[GroupProcessorService] Service started | Interval: ${crawlInterval}ms`)
+    } catch (err) {
+      this.logger.error('[GroupProcessorService] Failed to start', err)
+    }
+  }
+
+  public async stopped() {
+    if (this.timer) clearInterval(this.timer)
+  }
+
+  @Action({ name: 'processBlocks' })
+  public async processBlocks() {
+    if (this.isProcessing) return
+    if (!indexerStatusManager.isCrawlingActive()) return
+    this.isProcessing = true
+    try {
+      const jobName = BULL_JOB_NAME.HANDLE_GROUP
+      const [startBlock, dependencyHeight] = await BlockCheckpoint.getCheckpoint(jobName, [
+        BULL_JOB_NAME.HANDLE_TRANSACTION,
+      ])
+      const chunkSize = config.crawlGroup.chunkSize || 500
+      const endBlock = Math.min(dependencyHeight, startBlock + chunkSize)
+      if (endBlock > startBlock) {
+        await this.processRange(startBlock, endBlock)
+        await this.checkpointManager.updateCheckpoint(jobName, endBlock, { logger: this.logger })
+      }
+      await this.healMissingDecisionPolicies()
+      await this.reconcileOpenProposals(endBlock > startBlock ? endBlock : startBlock)
+    } catch (error) {
+      this.logger.error('[GroupProcessorService] Fatal error in processBlocks:', error)
+    } finally {
+      this.isProcessing = false
+    }
+  }
+
+  private async processRange(startBlock: number, endBlock: number) {
+    const messages = (await knex('transaction_message as tm')
+      .innerJoin('transaction as tx', 'tx.id', 'tm.tx_id')
+      .where('tx.code', 0)
+      .where('tx.height', '>', startBlock)
+      .where('tx.height', '<=', endBlock)
+      .whereIn('tm.type', [
+        GROUP_MSG_TYPES.CreateCorporation,
+        GROUP_MSG_TYPES.SubmitProposal,
+        GROUP_MSG_TYPES.Vote,
+        GROUP_MSG_TYPES.WithdrawProposal,
+      ])
+      .select(
+        'tm.tx_id',
+        'tm.index as message_index',
+        'tm.type as message_type',
+        'tm.sender',
+        'tm.content',
+        'tx.height as block_height',
+        'tx.hash as tx_hash',
+        'tx.timestamp'
+      )
+      .orderBy('tx.height', 'asc')
+      .orderBy('tx.index', 'asc')
+      .orderBy('tm.index', 'asc')) as MessageRow[]
+
+    const events = await this.loadGroupEvents(startBlock, endBlock)
+    if (messages.length === 0 && events.length === 0) return
+
+    const heights = [...new Set([...messages.map((m) => m.block_height), ...events.map((e) => e.block_height)])]
+    const blockTimes = new Map<number, string>()
+    if (heights.length > 0) {
+      const rows = await knex('block').select('height', 'time').whereIn('height', heights)
+      for (const row of rows) blockTimes.set(Number(row.height), new Date(row.time).toISOString())
+    }
+
+    const byHeight = new Map<number, { messages: MessageRow[]; events: GroupEventRow[] }>()
+    for (const height of heights.sort((a, b) => a - b)) byHeight.set(height, { messages: [], events: [] })
+    for (const message of messages) byHeight.get(message.block_height)?.messages.push(message)
+    for (const event of events) byHeight.get(event.block_height)?.events.push(event)
+
+    for (const [height, bucket] of byHeight) {
+      const blockTime = blockTimes.get(height) ?? new Date().toISOString()
+      // Group/policy ids created in this block: their admin-handover update events are already covered by the create seed.
+      const createdGroupIds = new Set<string>()
+      const createTxIds = new Set(
+        bucket.messages.filter((m) => m.message_type === GROUP_MSG_TYPES.CreateCorporation).map((m) => m.tx_id)
+      )
+      for (const event of bucket.events) {
+        if (event.tx_id === null || !createTxIds.has(event.tx_id)) continue
+        if (event.type === GROUP_EVENT_TYPES.CreateGroup) {
+          const id = parseEventAttrValue(event.attrs.group_id)
+          if (id) createdGroupIds.add(`g:${id}`)
+        }
+        if (event.type === GROUP_EVENT_TYPES.CreateGroupPolicy) {
+          const address = parseEventAttrValue(event.attrs.address)
+          if (address) createdGroupIds.add(`p:${address}`)
+        }
+      }
+      for (const message of bucket.messages) {
+        if (message.message_type === GROUP_MSG_TYPES.CreateCorporation) {
+          await this.handleCreateCorporation(message, bucket.events, blockTime)
+        }
+      }
+      for (const message of bucket.messages) {
+        if (message.message_type === GROUP_MSG_TYPES.SubmitProposal) {
+          await this.handleSubmitProposal(message, bucket.events, blockTime)
+        }
+      }
+      for (const message of bucket.messages) {
+        if (message.message_type === GROUP_MSG_TYPES.Vote) await this.handleVote(message, blockTime)
+      }
+      for (const message of bucket.messages) {
+        if (message.message_type === GROUP_MSG_TYPES.WithdrawProposal) {
+          await this.handleWithdraw(message, height, blockTime)
+        }
+      }
+      for (const event of bucket.events) {
+        if (event.type === GROUP_EVENT_TYPES.Exec) await this.handleExecEvent(event, height, blockTime)
+      }
+      for (const event of bucket.events) {
+        if (event.type === GROUP_EVENT_TYPES.ProposalPruned) await this.handlePrunedEvent(event, height, blockTime)
+      }
+      for (const event of bucket.events) {
+        // The create tx emits update events for the admin handover; those are covered by the create seed.
+        if (event.type === GROUP_EVENT_TYPES.UpdateGroup) {
+          if (createdGroupIds.has(`g:${parseEventAttrValue(event.attrs.group_id)}`)) continue
+          await this.handleGroupUpdated(event, height, blockTime)
+        }
+        if (event.type === GROUP_EVENT_TYPES.UpdateGroupPolicy) {
+          if (createdGroupIds.has(`p:${parseEventAttrValue(event.attrs.address)}`)) continue
+          await this.handlePolicyUpdated(event, height, blockTime)
+        }
+      }
+    }
+  }
+
+  private async loadGroupEvents(startBlock: number, endBlock: number): Promise<GroupEventRow[]> {
+    const rows = (await knex('event as e')
+      .leftJoin('transaction as tx', 'tx.id', 'e.tx_id')
+      .where('e.block_height', '>', startBlock)
+      .where('e.block_height', '<=', endBlock)
+      .whereIn('e.type', [
+        GROUP_EVENT_TYPES.CreateGroup,
+        GROUP_EVENT_TYPES.CreateGroupPolicy,
+        GROUP_EVENT_TYPES.SubmitProposal,
+        GROUP_EVENT_TYPES.Exec,
+        GROUP_EVENT_TYPES.ProposalPruned,
+        GROUP_EVENT_TYPES.UpdateGroup,
+        GROUP_EVENT_TYPES.UpdateGroupPolicy,
+      ])
+      .where(function () {
+        this.whereNull('e.tx_id').orWhere('tx.code', 0)
+      })
+      .select('e.id as event_id', 'e.type', 'e.tx_id', 'e.tx_msg_index', 'e.block_height')
+      .orderBy('e.id', 'asc')) as Array<Omit<GroupEventRow, 'attrs'>>
+
+    if (rows.length === 0) return []
+    const attributeRows = (await knex('event_attribute')
+      .whereIn(
+        'event_id',
+        rows.map((row) => row.event_id)
+      )
+      .where('block_height', '>', startBlock)
+      .where('block_height', '<=', endBlock)
+      .select('event_id', 'key', 'value')) as Array<{ event_id: number; key: string; value: string }>
+
+    const attrsByEvent = new Map<number, Record<string, string>>()
+    for (const attribute of attributeRows) {
+      const bucket = attrsByEvent.get(attribute.event_id) ?? {}
+      bucket[attribute.key] = attribute.value
+      attrsByEvent.set(attribute.event_id, bucket)
+    }
+    return rows.map((row) => ({ ...row, attrs: attrsByEvent.get(row.event_id) ?? {} }))
+  }
+
+  private async lcdGet(path: string, height?: number): Promise<Record<string, unknown> | null> {
+    const baseUrl = getLcdBaseUrl()
+    if (!baseUrl) return null
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), LCD_TIMEOUT_MS)
+    try {
+      const headers: Record<string, string> = {}
+      if (height !== undefined) headers['x-cosmos-block-height'] = String(height)
+      const res = await fetch(`${baseUrl}${path}`, { headers, signal: controller.signal })
+      if (!res.ok) return null
+      return (await res.json().catch(() => null)) as Record<string, unknown> | null
+    } catch {
+      return null
+    } finally {
+      clearTimeout(timeoutId)
+    }
+  }
+
+  // Historical state queries only answer on an archive node; on a pruning node fall back to current
+  // state rather than losing the update entirely.
+  private async lcdGetAtHeightOrLatest(path: string, height?: number): Promise<Record<string, unknown> | null> {
+    if (height === undefined) return this.lcdGet(path)
+    return (await this.lcdGet(path, height)) ?? (await this.lcdGet(path))
+  }
+
+  private async fetchGroupMembers(groupId: number, height?: number): Promise<Array<Record<string, unknown>>> {
+    const data = await this.lcdGetAtHeightOrLatest(
+      `/cosmos/group/v1/group_members/${groupId}?pagination.limit=500`,
+      height
+    )
+    const members = Array.isArray(data?.members) ? (data?.members as Array<Record<string, unknown>>) : []
+    return members.map((entry) => {
+      const member = (entry.member ?? {}) as Record<string, unknown>
+      return {
+        address: String(member.address ?? ''),
+        weight: String(member.weight ?? '0'),
+        metadata: String(member.metadata ?? ''),
+        added_at: member.added_at ?? null,
+      }
+    })
+  }
+
+  private decodeProposalMessages(rawMessages: unknown): Array<Record<string, unknown>> {
+    if (!Array.isArray(rawMessages)) return []
+    return rawMessages.map((raw) => {
+      const message = (raw ?? {}) as AnyMessage
+      const typeUrl = anyTypeUrl(message)
+      if (!typeUrl) return message as Record<string, unknown>
+      if (!isUndecodedAny(message)) {
+        const { type_url: _tu, typeUrl: _tuc, ...rest } = message
+        return { '@type': typeUrl, ...rest }
+      }
+      try {
+        const decoded = this.decodeRegistry.decode({ typeUrl, value: fromBase64(String(message.value)) })
+        const generated = this.decodeRegistry.lookupType(typeUrl) as { toJSON?: (value: unknown) => unknown }
+        const json = generated?.toJSON ? generated.toJSON(decoded) : decoded
+        return { '@type': typeUrl, ...(json as Record<string, unknown>) }
+      } catch {
+        return { '@type': typeUrl, value: message.value } as Record<string, unknown>
+      }
+    })
+  }
+
+  private async handleCreateCorporation(message: MessageRow, events: GroupEventRow[], blockTime: string) {
+    const content = message.content ?? {}
+    const createGroupEvent = events.find(
+      (event) =>
+        event.type === GROUP_EVENT_TYPES.CreateGroup &&
+        event.tx_id === message.tx_id &&
+        (readPositiveInt(parseEventAttrValue(event.attrs.msg_index)) ?? 0) === message.message_index
+    )
+    const groupId = readPositiveInt(parseEventAttrValue(createGroupEvent?.attrs.group_id))
+    if (!groupId) {
+      this.logger.warn(`[GroupProcessorService] create at height=${message.block_height} without EventCreateGroup`)
+      return
+    }
+
+    // Resolve by the tx's own policy address — corporation.height is the last-modified height, not the create height.
+    const groupPolicyEvent = events.find(
+      (event) =>
+        event.type === GROUP_EVENT_TYPES.CreateGroupPolicy &&
+        event.tx_id === message.tx_id &&
+        (readPositiveInt(parseEventAttrValue(event.attrs.msg_index)) ?? 0) === message.message_index
+    )
+    const policyAddress = parseEventAttrValue(groupPolicyEvent?.attrs.address)
+    if (!policyAddress) {
+      this.logger.warn(
+        `[GroupProcessorService] create at height=${message.block_height} without EventCreateGroupPolicy`
+      )
+      return
+    }
+    const corporation = await knex('corporation').select('id').where('policy_address', policyAddress).first()
+    if (!corporation) {
+      this.logger.warn(
+        `[GroupProcessorService] create at height=${message.block_height}: no corporation for ${policyAddress}`
+      )
+      return
+    }
+
+    const policyInfo = await this.lcdGetAtHeightOrLatest(
+      `/cosmos/group/v1/group_policy_info/${policyAddress}`,
+      message.block_height
+    )
+    const info = (policyInfo?.info ?? {}) as Record<string, unknown>
+    const groupInfoData = await this.lcdGetAtHeightOrLatest(
+      `/cosmos/group/v1/group_info/${groupId}`,
+      message.block_height
+    )
+    const groupInfo = (groupInfoData?.info ?? groupInfoData?.group ?? {}) as Record<string, unknown>
+
+    const members = Array.isArray(content.members)
+      ? (content.members as Array<Record<string, unknown>>).map((member) => ({
+          address: String(member.address ?? ''),
+          weight: String(member.weight ?? '0'),
+          metadata: String(member.metadata ?? ''),
+          added_at: blockTime,
+        }))
+      : await this.fetchGroupMembers(groupId, message.block_height)
+
+    const row = {
+      corporation_id: Number(corporation.id),
+      group_id: groupId,
+      policy_address: policyAddress,
+      group_version: readPositiveInt(groupInfo.version) ?? 1,
+      policy_version: readPositiveInt(info.version) ?? 1,
+      total_weight: String(groupInfo.total_weight ?? members.reduce((sum, m) => sum + Number(m.weight || 0), 0)),
+      decision_policy: (info.decision_policy as Record<string, unknown> | undefined) ?? null,
+      created: blockTime,
+      modified: blockTime,
+      height: message.block_height,
+    }
+    await knex('corporation_group').insert(row).onConflict('corporation_id').merge()
+    await this.snapshotGroup(row.corporation_id, message.block_height, members)
+  }
+
+  // LCD may have been unreachable when the group was first seen; decision_policy drives voting_period_end
+  // and reconciliation, so re-fetch it on later passes until it lands.
+  private async healMissingDecisionPolicies() {
+    const pending = await knex('corporation_group').whereNull('decision_policy').select('*')
+    for (const group of pending) {
+      const policyInfo = await this.lcdGet(`/cosmos/group/v1/group_policy_info/${group.policy_address}`)
+      const info = (policyInfo?.info ?? {}) as Record<string, unknown>
+      if (!info.decision_policy) continue
+      await knex('corporation_group')
+        .where('corporation_id', group.corporation_id)
+        .update({
+          decision_policy: JSON.stringify(info.decision_policy),
+          policy_version: readPositiveInt(info.version) ?? group.policy_version,
+        })
+      const seconds = votingPeriodSecondsFromDecisionPolicy(info.decision_policy)
+      if (seconds === null) continue
+      const open = await knex('group_proposal')
+        .where('corporation_id', group.corporation_id)
+        .whereNull('voting_period_end')
+      for (const proposal of open) {
+        await knex('group_proposal')
+          .where('id', proposal.id)
+          .update({
+            voting_period_end: new Date(new Date(proposal.submit_time).getTime() + seconds * 1000).toISOString(),
+          })
+      }
+    }
+  }
+
+  private async snapshotGroup(corporationId: number, height: number, membersOverride?: Array<Record<string, unknown>>) {
+    const group = await knex('corporation_group').where('corporation_id', corporationId).first()
+    if (!group) return
+    const members =
+      membersOverride ??
+      (
+        await knex('corporation_member')
+          .select('address', 'weight', 'metadata', 'created')
+          .where('corporation_id', corporationId)
+          .orderBy('id', 'asc')
+      ).map((member) => ({
+        address: member.address,
+        weight: String(member.weight),
+        metadata: member.metadata ?? '',
+        added_at: member.created,
+      }))
+    await knex('corporation_group_history')
+      .insert({
+        corporation_id: corporationId,
+        group_id: group.group_id,
+        group_version: group.group_version,
+        policy_version: group.policy_version,
+        total_weight: group.total_weight,
+        decision_policy: group.decision_policy,
+        members: JSON.stringify(members),
+        height,
+      })
+      .onConflict(['corporation_id', 'height'])
+      .merge()
+  }
+
+  private async handleSubmitProposal(message: MessageRow, events: GroupEventRow[], blockTime: string) {
+    const content = message.content ?? {}
+    const policyAddress = String(content.group_policy_address ?? '')
+    if (!policyAddress) return
+    const group = await knex('corporation_group').where('policy_address', policyAddress).first()
+    if (!group) return
+
+    const submitEvent = events.find(
+      (event) =>
+        event.type === GROUP_EVENT_TYPES.SubmitProposal &&
+        event.tx_id === message.tx_id &&
+        (readPositiveInt(parseEventAttrValue(event.attrs.msg_index)) ?? 0) === message.message_index
+    )
+    const proposalId = readPositiveInt(parseEventAttrValue(submitEvent?.attrs.proposal_id))
+    if (!proposalId) {
+      this.logger.warn(`[GroupProcessorService] submit at height=${message.block_height} without EventSubmitProposal`)
+      return
+    }
+
+    const votingPeriodSeconds = votingPeriodSecondsFromDecisionPolicy(group.decision_policy)
+    const votingPeriodEnd =
+      votingPeriodSeconds !== null
+        ? new Date(new Date(blockTime).getTime() + votingPeriodSeconds * 1000).toISOString()
+        : null
+
+    await knex('group_proposal')
+      .insert({
+        id: proposalId,
+        corporation_id: Number(group.corporation_id),
+        group_policy_address: policyAddress,
+        metadata: content.metadata != null ? String(content.metadata) : null,
+        proposers: JSON.stringify(Array.isArray(content.proposers) ? content.proposers : []),
+        submit_time: blockTime,
+        group_version: readPositiveInt(group.group_version),
+        group_policy_version: readPositiveInt(group.policy_version),
+        status: 'SUBMITTED',
+        executor_result: 'NOT_RUN',
+        voting_period_end: votingPeriodEnd,
+        messages: JSON.stringify(this.decodeProposalMessages(content.messages)),
+        final_tally_result: null,
+        modified: blockTime,
+        height: message.block_height,
+      })
+      .onConflict('id')
+      .merge()
+
+    // exec=EXEC_TRY makes x/group cast a YES vote per proposer inside this same tx, with no MsgVote message
+    // and an EventVote that carries only proposal_id — record them here or they are lost.
+    if (String(content.exec ?? '') === 'EXEC_TRY') {
+      const proposers = Array.isArray(content.proposers) ? content.proposers : []
+      for (const proposer of proposers) {
+        await knex('group_vote')
+          .insert({
+            proposal_id: proposalId,
+            voter: String(proposer),
+            option: 'YES',
+            metadata: null,
+            submit_time: blockTime,
+            height: message.block_height,
+          })
+          .onConflict(['proposal_id', 'voter'])
+          .ignore()
+      }
+    }
+    await this.snapshotProposal(proposalId, message.block_height)
+  }
+
+  private async snapshotProposal(proposalId: number, height: number) {
+    const row = await knex('group_proposal').where('id', proposalId).first()
+    if (!row) return
+    await knex('group_proposal_history')
+      .insert({ proposal_id: proposalId, snapshot: JSON.stringify(row), height })
+      .onConflict(['proposal_id', 'height'])
+      .merge()
+  }
+
+  private async handleVote(message: MessageRow, blockTime: string) {
+    const content = message.content ?? {}
+    const proposalId = readPositiveInt(content.proposal_id)
+    const voter = String(content.voter ?? '')
+    const option = shortVoteOption(content.option)
+    if (!proposalId || !voter || !option) return
+    const proposal = await knex('group_proposal').where('id', proposalId).first()
+    if (!proposal) return
+
+    await knex('group_vote')
+      .insert({
+        proposal_id: proposalId,
+        voter,
+        option,
+        metadata: content.metadata != null ? String(content.metadata) : null,
+        submit_time: blockTime,
+        height: message.block_height,
+      })
+      .onConflict(['proposal_id', 'voter'])
+      .ignore()
+    await knex('group_proposal').where('id', proposalId).update({ modified: blockTime })
+    await this.snapshotProposal(proposalId, message.block_height)
+  }
+
+  private async handleWithdraw(message: MessageRow, height: number, blockTime: string) {
+    const proposalId = readPositiveInt((message.content ?? {}).proposal_id)
+    if (!proposalId) return
+    const updated = await knex('group_proposal')
+      .where('id', proposalId)
+      .update({ status: 'WITHDRAWN', modified: blockTime })
+    if (updated > 0) await this.snapshotProposal(proposalId, height)
+  }
+
+  private async handleExecEvent(event: GroupEventRow, height: number, blockTime: string) {
+    const proposalId = readPositiveInt(parseEventAttrValue(event.attrs.proposal_id))
+    const result = shortExecutorResult(parseEventAttrValue(event.attrs.result))
+    if (!proposalId || !result) return
+    const patch: Record<string, unknown> = { executor_result: result, modified: blockTime }
+    if (result === 'SUCCESS') patch.status = 'ACCEPTED'
+    const updated = await knex('group_proposal').where('id', proposalId).update(patch)
+    if (updated > 0) await this.snapshotProposal(proposalId, height)
+  }
+
+  private async handlePrunedEvent(event: GroupEventRow, height: number, blockTime: string) {
+    const proposalId = readPositiveInt(parseEventAttrValue(event.attrs.proposal_id))
+    if (!proposalId) return
+    const status = shortProposalStatus(parseEventAttrValue(event.attrs.status))
+    const tally = normalizeTallyResult(parseEventAttrJson(event.attrs.tally_result))
+    const patch: Record<string, unknown> = { modified: blockTime }
+    if (status) patch.status = status
+    if (tally) patch.final_tally_result = JSON.stringify(tally)
+    const updated = await knex('group_proposal').where('id', proposalId).update(patch)
+    if (updated > 0) await this.snapshotProposal(proposalId, height)
+  }
+
+  private async handleGroupUpdated(event: GroupEventRow, height: number, blockTime: string) {
+    const groupId = readPositiveInt(parseEventAttrValue(event.attrs.group_id))
+    if (!groupId) return
+    const group = await knex('corporation_group').where('group_id', groupId).first()
+    if (!group) return
+
+    const groupInfoData = await this.lcdGetAtHeightOrLatest(`/cosmos/group/v1/group_info/${groupId}`, height)
+    const groupInfo = (groupInfoData?.info ?? groupInfoData?.group ?? {}) as Record<string, unknown>
+    const members = await this.fetchGroupMembers(groupId, height)
+
+    await knex('corporation_group')
+      .where('group_id', groupId)
+      .update({
+        group_version: readPositiveInt(groupInfo.version) ?? group.group_version,
+        total_weight: String(groupInfo.total_weight ?? group.total_weight),
+        modified: blockTime,
+        height,
+      })
+    if (members.length > 0) {
+      await knex.transaction(async (trx) => {
+        await trx('corporation_member').where('corporation_id', group.corporation_id).delete()
+        await trx('corporation_member').insert(
+          members.map((member) => ({
+            corporation_id: group.corporation_id,
+            address: member.address,
+            weight: member.weight,
+            metadata: member.metadata,
+            created: member.added_at ?? blockTime,
+          }))
+        )
+      })
+    }
+    await this.snapshotGroup(Number(group.corporation_id), height, members.length > 0 ? members : undefined)
+  }
+
+  private async handlePolicyUpdated(event: GroupEventRow, height: number, blockTime: string) {
+    const address = parseEventAttrValue(event.attrs.address)
+    if (!address) return
+    const group = await knex('corporation_group').where('policy_address', address).first()
+    if (!group) return
+
+    const policyInfo = await this.lcdGetAtHeightOrLatest(`/cosmos/group/v1/group_policy_info/${address}`, height)
+    const info = (policyInfo?.info ?? {}) as Record<string, unknown>
+    await knex('corporation_group')
+      .where('policy_address', address)
+      .update({
+        policy_version: readPositiveInt(info.version) ?? group.policy_version,
+        decision_policy: info.decision_policy ? JSON.stringify(info.decision_policy) : group.decision_policy,
+        modified: blockTime,
+        height,
+      })
+    await this.snapshotGroup(Number(group.corporation_id), height)
+    // A decision-policy update aborts live proposals on-chain; reconcile them now.
+    await this.reconcileProposalsForCorporation(Number(group.corporation_id), height)
+  }
+
+  private async chainTimeAt(height: number): Promise<string> {
+    const block = await knex('block').select('time').where('height', height).first()
+    return block ? new Date(block.time).toISOString() : new Date().toISOString()
+  }
+
+  private async reconcileProposalsForCorporation(corporationId: number, height: number) {
+    const open = await knex('group_proposal').where('corporation_id', corporationId).where('status', 'SUBMITTED')
+    const chainNow = await this.chainTimeAt(height)
+    for (const proposal of open) await this.reconcileProposal(proposal, height, chainNow)
+  }
+
+  private async reconcileOpenProposals(height: number) {
+    if (!height) return
+    const chainNow = await this.chainTimeAt(height)
+    const due = await knex('group_proposal')
+      .where('status', 'SUBMITTED')
+      .whereNotNull('voting_period_end')
+      .where('voting_period_end', '<=', chainNow)
+    for (const proposal of due) await this.reconcileProposal(proposal, height, chainNow)
+  }
+
+  private async reconcileProposal(proposal: Record<string, unknown>, height: number, chainNow: string) {
+    const proposalId = Number(proposal.id)
+    const data = await this.lcdGet(`/cosmos/group/v1/proposal/${proposalId}`)
+    const chainProposal = (data?.proposal ?? null) as Record<string, unknown> | null
+
+    const patch: Record<string, unknown> = {}
+    if (chainProposal) {
+      const status = shortProposalStatus(chainProposal.status)
+      const executorResult = shortExecutorResult(chainProposal.executor_result)
+      const tally = normalizeTallyResult(chainProposal.final_tally_result)
+      if (status && status !== proposal.status) patch.status = status
+      if (executorResult && executorResult !== proposal.executor_result) patch.executor_result = executorResult
+      const hasFinalTally = tally && Object.values(tally).some((count) => count !== '0')
+      if (hasFinalTally && (patch.status ?? proposal.status) !== 'SUBMITTED') {
+        patch.final_tally_result = JSON.stringify(tally)
+      }
+    } else {
+      // Pruned without an indexed prune event: settle from the indexed votes and threshold.
+      const votes = await knex('group_vote').select('voter', 'option').where('proposal_id', proposalId)
+      const members = await knex('corporation_member')
+        .select('address', 'weight')
+        .where('corporation_id', Number(proposal.corporation_id))
+      const weightByAddress = new Map(members.map((member) => [member.address, Number(member.weight) || 0]))
+      const weightFor = (option: string) =>
+        votes
+          .filter((vote) => vote.option === option)
+          .reduce((sum, vote) => sum + (weightByAddress.get(vote.voter) ?? 0), 0)
+      const tally = {
+        yes_count: String(weightFor('YES')),
+        no_count: String(weightFor('NO')),
+        abstain_count: String(weightFor('ABSTAIN')),
+        no_with_veto_count: String(weightFor('NO_WITH_VETO')),
+      }
+      const groupRow = await knex('corporation_group').where('corporation_id', Number(proposal.corporation_id)).first()
+      const totalWeight =
+        Number(groupRow?.total_weight ?? 0) || members.reduce((sum, member) => sum + (Number(member.weight) || 0), 0)
+      const outcome = decideProposalOutcome(groupRow?.decision_policy, Number(tally.yes_count), totalWeight)
+      if (!outcome) {
+        this.logger.warn(
+          `[GroupProcessorService] proposal ${proposalId} is gone from state and its decision policy cannot be evaluated; leaving status unchanged`
+        )
+        return
+      }
+      patch.status = outcome
+      patch.final_tally_result = JSON.stringify(tally)
+    }
+
+    if (Object.keys(patch).length > 0) {
+      patch.modified = chainNow
+      await knex('group_proposal').where('id', proposalId).update(patch)
+      await this.snapshotProposal(proposalId, height)
+    }
+  }
+}

--- a/src/services/crawl-group/group_processor.service.ts
+++ b/src/services/crawl-group/group_processor.service.ts
@@ -211,6 +211,10 @@ export default class GroupProcessorService extends BullableService {
           if (createdGroupIds.has(`g:${parseEventAttrValue(event.attrs.group_id)}`)) continue
           await this.handleGroupUpdated(event, height, blockTime)
         }
+        // A leave carries the same group_id and can never occur in the create tx.
+        if (event.type === GROUP_EVENT_TYPES.LeaveGroup) {
+          await this.handleGroupUpdated(event, height, blockTime)
+        }
         if (event.type === GROUP_EVENT_TYPES.UpdateGroupPolicy) {
           if (createdGroupIds.has(`p:${parseEventAttrValue(event.attrs.address)}`)) continue
           await this.handlePolicyUpdated(event, height, blockTime)
@@ -232,6 +236,7 @@ export default class GroupProcessorService extends BullableService {
         GROUP_EVENT_TYPES.ProposalPruned,
         GROUP_EVENT_TYPES.UpdateGroup,
         GROUP_EVENT_TYPES.UpdateGroupPolicy,
+        GROUP_EVENT_TYPES.LeaveGroup,
       ])
       .where(function () {
         this.whereNull('e.tx_id').orWhere('tx.code', 0)
@@ -283,12 +288,14 @@ export default class GroupProcessorService extends BullableService {
     return (await this.lcdGet(path, height)) ?? (await this.lcdGet(path))
   }
 
-  private async fetchGroupMembers(groupId: number, height?: number): Promise<Array<Record<string, unknown>>> {
+  // null means the lookup failed; an empty array means the group genuinely has no members left.
+  private async fetchGroupMembers(groupId: number, height?: number): Promise<Array<Record<string, unknown>> | null> {
     const data = await this.lcdGetAtHeightOrLatest(
       `/cosmos/group/v1/group_members/${groupId}?pagination.limit=500`,
       height
     )
-    const members = Array.isArray(data?.members) ? (data?.members as Array<Record<string, unknown>>) : []
+    if (!data || !Array.isArray(data.members)) return null
+    const members = data.members as Array<Record<string, unknown>>
     return members.map((entry) => {
       const member = (entry.member ?? {}) as Record<string, unknown>
       return {
@@ -375,7 +382,7 @@ export default class GroupProcessorService extends BullableService {
           metadata: String(member.metadata ?? ''),
           added_at: blockTime,
         }))
-      : await this.fetchGroupMembers(groupId, message.block_height)
+      : ((await this.fetchGroupMembers(groupId, message.block_height)) ?? [])
 
     const row = {
       corporation_id: Number(corporation.id),
@@ -567,9 +574,16 @@ export default class GroupProcessorService extends BullableService {
     const result = shortExecutorResult(parseEventAttrValue(event.attrs.result))
     if (!proposalId || !result) return
     const patch: Record<string, unknown> = { executor_result: result, modified: blockTime }
-    if (result === 'SUCCESS') patch.status = 'ACCEPTED'
+    // x/group only executes an ACCEPTED proposal, so SUCCESS and FAILURE both imply ACCEPTED.
+    if (result !== 'NOT_RUN') patch.status = 'ACCEPTED'
     const updated = await knex('group_proposal').where('id', proposalId).update(patch)
-    if (updated > 0) await this.snapshotProposal(proposalId, height)
+    if (updated === 0) return
+    // NOT_RUN is ambiguous and FAILURE leaves a frozen final tally; both stay queryable.
+    if (result !== 'SUCCESS') {
+      const row = await knex('group_proposal').where('id', proposalId).first()
+      if (row) await this.reconcileProposal(row, height, blockTime)
+    }
+    await this.snapshotProposal(proposalId, height)
   }
 
   private async handlePrunedEvent(event: GroupEventRow, height: number, blockTime: string) {
@@ -602,21 +616,24 @@ export default class GroupProcessorService extends BullableService {
         modified: blockTime,
         height,
       })
-    if (members.length > 0) {
+    // Only rewrite when the lookup succeeded; an empty result means the last member left.
+    if (members !== null) {
       await knex.transaction(async (trx) => {
         await trx('corporation_member').where('corporation_id', group.corporation_id).delete()
-        await trx('corporation_member').insert(
-          members.map((member) => ({
-            corporation_id: group.corporation_id,
-            address: member.address,
-            weight: member.weight,
-            metadata: member.metadata,
-            created: member.added_at ?? blockTime,
-          }))
-        )
+        if (members.length > 0) {
+          await trx('corporation_member').insert(
+            members.map((member) => ({
+              corporation_id: group.corporation_id,
+              address: member.address,
+              weight: member.weight,
+              metadata: member.metadata,
+              created: member.added_at ?? blockTime,
+            }))
+          )
+        }
       })
     }
-    await this.snapshotGroup(Number(group.corporation_id), height, members.length > 0 ? members : undefined)
+    await this.snapshotGroup(Number(group.corporation_id), height, members ?? undefined)
   }
 
   private async handlePolicyUpdated(event: GroupEventRow, height: number, blockTime: string) {
@@ -663,7 +680,8 @@ export default class GroupProcessorService extends BullableService {
 
   private async reconcileProposal(proposal: Record<string, unknown>, height: number, chainNow: string) {
     const proposalId = Number(proposal.id)
-    const data = await this.lcdGet(`/cosmos/group/v1/proposal/${proposalId}`)
+    // Pinned to this block, falling back to current state on a node that no longer retains it.
+    const data = await this.lcdGetAtHeightOrLatest(`/cosmos/group/v1/proposal/${proposalId}`, height)
     const chainProposal = (data?.proposal ?? null) as Record<string, unknown> | null
 
     const patch: Record<string, unknown> = {}
@@ -673,11 +691,27 @@ export default class GroupProcessorService extends BullableService {
       const tally = normalizeTallyResult(chainProposal.final_tally_result)
       if (status && status !== proposal.status) patch.status = status
       if (executorResult && executorResult !== proposal.executor_result) patch.executor_result = executorResult
+      // The chain's window wins over the value derived from the stored policy.
+      const chainVotingPeriodEnd = chainProposal.voting_period_end
+      if (typeof chainVotingPeriodEnd === 'string' && chainVotingPeriodEnd) {
+        const parsed = new Date(chainVotingPeriodEnd)
+        const current = proposal.voting_period_end ? new Date(String(proposal.voting_period_end)) : null
+        if (!Number.isNaN(parsed.getTime()) && parsed.getTime() !== current?.getTime()) {
+          patch.voting_period_end = parsed.toISOString()
+        }
+      }
       const hasFinalTally = tally && Object.values(tally).some((count) => count !== '0')
       if (hasFinalTally && (patch.status ?? proposal.status) !== 'SUBMITTED') {
         patch.final_tally_result = JSON.stringify(tally)
       }
     } else {
+      // A null read also means "LCD unreachable", so only settle a proposal that is still open here
+      // AND whose voting window has closed. Inventing a terminal status is not recoverable.
+      if (String(proposal.status) !== 'SUBMITTED') return
+      const votingPeriodEnd = proposal.voting_period_end ? new Date(String(proposal.voting_period_end)) : null
+      if (!votingPeriodEnd || Number.isNaN(votingPeriodEnd.getTime())) return
+      if (new Date(chainNow).getTime() <= votingPeriodEnd.getTime()) return
+
       // Pruned without an indexed prune event: settle from the indexed votes and threshold.
       const votes = await knex('group_vote').select('voter', 'option').where('proposal_id', proposalId)
       const members = await knex('corporation_member')

--- a/test/unit/services/crawl-group/group_api.spec.ts
+++ b/test/unit/services/crawl-group/group_api.spec.ts
@@ -28,10 +28,13 @@ function chainable(table: string, rows: unknown[]) {
     'whereIn',
     'whereRaw',
     'whereNotNull',
+    'whereExists',
+    'whereNotExists',
     'orderBy',
     'limit',
     'innerJoin',
     'distinctOn',
+    'from',
     'as',
   ]) {
     qb[method] = record(method)
@@ -46,6 +49,7 @@ jest.mock('../../../../src/common/utils/db_connection', () => ({
   __esModule: true,
   default: Object.assign((table: string) => chainable(table.split(' ')[0], tables[table.split(' ')[0]] ?? []), {
     from: () => chainable('__from', tables.__from ?? []),
+    raw: (sql: string, bindings?: unknown) => ({ sql, bindings }),
   }),
 }))
 
@@ -317,73 +321,90 @@ describe('GroupApiService', () => {
     })
 
     describe('pending_voter', () => {
-      const open = (over: Record<string, unknown> = {}) =>
-        proposalRow({
-          status: 'SUBMITTED',
-          executor_result: 'NOT_RUN',
-          final_tally_result: null,
-          voting_period_end: '2099-01-01T00:00:00.000Z',
-          ...over,
-        })
+      const subBuilder = () => {
+        const sub: any = {}
+        for (const m of ['select', 'from', 'where', 'whereRaw']) sub[m] = jest.fn(() => sub)
+        return sub
+      }
+      const runSubquery = (method: string) => {
+        const call = calls.find((c) => c.method === method)
+        expect(call).toBeDefined()
+        const sub = subBuilder()
+        ;(call!.args[0] as (qb: unknown) => void)(sub)
+        return sub
+      }
 
-      it('keeps only SUBMITTED proposals inside the voting window for a member who has not voted', async () => {
-        tables.group_proposal = [open({ id: 4 })]
-        tables.group_vote = []
-        tables.corporation_member = [{ corporation_id: 1, address: 'verana1voter', weight: '1' }]
+      it('pushes status and voting-window predicates into SQL', async () => {
+        tables.group_proposal = []
+        await service.listProposals({ params: { pending_voter: 'verana1voter' }, meta: {} } as any)
 
-        const res: any = await service.listProposals({ params: { pending_voter: 'verana1voter' }, meta: {} } as any)
-        expect(res.proposals.map((p: any) => p.id)).toEqual([4])
+        expect(called('group_proposal', 'where', (args) => args[0] === 'status' && args[1] === 'SUBMITTED')).toBe(true)
+        expect(called('group_proposal', 'whereNotNull', (args) => args[0] === 'voting_period_end')).toBe(true)
+        expect(called('group_proposal', 'where', (args) => args[0] === 'voting_period_end' && args[1] === '>')).toBe(
+          true
+        )
       })
 
-      it('drops proposals the account already voted on', async () => {
-        tables.group_proposal = [open({ id: 4 })]
-        tables.group_vote = [{ proposal_id: 4, voter: 'verana1voter', option: 'YES' }]
-        tables.corporation_member = [{ corporation_id: 1, address: 'verana1voter', weight: '1' }]
+      it('excludes proposals the account already voted on via NOT EXISTS on group_vote', async () => {
+        tables.group_proposal = []
+        await service.listProposals({ params: { pending_voter: 'verana1voter' }, meta: {} } as any)
 
-        const res: any = await service.listProposals({ params: { pending_voter: 'verana1voter' }, meta: {} } as any)
-        expect(res.proposals).toEqual([])
+        const sub = runSubquery('whereNotExists')
+        expect(sub.from).toHaveBeenCalledWith('group_vote as gv')
+        expect(sub.where).toHaveBeenCalledWith('gv.voter', 'verana1voter')
+        // correlated to the outer row, else it degenerates into "has this account voted on anything"
+        expect(sub.whereRaw).toHaveBeenCalledWith('gv.proposal_id = group_proposal.id')
       })
 
-      it('drops proposals of groups the account is not a member of', async () => {
-        tables.group_proposal = [open({ id: 4 })]
-        tables.group_vote = []
-        tables.corporation_member = [{ corporation_id: 1, address: 'verana1someone-else', weight: '1' }]
+      it('requires current membership via EXISTS on corporation_member', async () => {
+        tables.group_proposal = []
+        await service.listProposals({ params: { pending_voter: 'verana1voter' }, meta: {} } as any)
 
-        const res: any = await service.listProposals({ params: { pending_voter: 'verana1voter' }, meta: {} } as any)
-        expect(res.proposals).toEqual([])
+        const sub = runSubquery('whereExists')
+        expect(sub.from).toHaveBeenCalledWith('corporation_member as cm')
+        expect(sub.where).toHaveBeenCalledWith('cm.address', 'verana1voter')
+        expect(sub.whereRaw).toHaveBeenCalledWith('cm.corporation_id = group_proposal.corporation_id')
       })
 
-      it('drops proposals whose voting period already ended', async () => {
-        tables.group_proposal = [open({ id: 4, voting_period_end: '2020-01-01T00:00:00.000Z' })]
-        tables.group_vote = []
-        tables.corporation_member = [{ corporation_id: 1, address: 'verana1voter', weight: '1' }]
+      it('still applies cursors, sort and limit in SQL', async () => {
+        tables.group_proposal = []
+        await service.listProposals({
+          params: { pending_voter: 'verana1voter', min_id: '5', max_id: '9', limit: '3', sort: '+id' },
+          meta: {},
+        } as any)
 
-        const res: any = await service.listProposals({ params: { pending_voter: 'verana1voter' }, meta: {} } as any)
-        expect(res.proposals).toEqual([])
+        expect(
+          called('group_proposal', 'where', (args) => args[0] === 'id' && args[1] === '>=' && args[2] === '5')
+        ).toBe(true)
+        expect(
+          called('group_proposal', 'where', (args) => args[0] === 'id' && args[1] === '<' && args[2] === '9')
+        ).toBe(true)
+        expect(called('group_proposal', 'orderBy', (args) => args[0] === 'id' && args[1] === 'asc')).toBe(true)
+        expect(called('group_proposal', 'limit', (args) => args[0] === 3)).toBe(true)
       })
 
-      it('drops closed proposals even inside the window', async () => {
-        tables.group_proposal = [open({ id: 4, status: 'WITHDRAWN' })]
-        tables.group_vote = []
-        tables.corporation_member = [{ corporation_id: 1, address: 'verana1voter', weight: '1' }]
+      it('at height, bounds votes by block height and reads membership from the history snapshot', async () => {
+        tables.__from = []
+        await service.listProposals({
+          params: { pending_voter: 'verana1voter' },
+          meta: { blockHeight: 50 },
+        } as any)
 
-        const res: any = await service.listProposals({ params: { pending_voter: 'verana1voter' }, meta: {} } as any)
-        expect(res.proposals).toEqual([])
-      })
-
-      it('uses chain time at the requested At-Block-Height', async () => {
-        tables.__from = [
-          {
-            proposal_id: 4,
-            snapshot: open({ id: 4 }),
-            members: [{ address: 'verana1voter', weight: '1' }],
-            corporation_id: 1,
-          },
-        ]
-        tables.group_vote = []
-        const ctx: any = { params: { pending_voter: 'verana1voter' }, meta: { blockHeight: 50 } }
-        await service.listProposals(ctx)
         expect(getBlockChainTimeAsOf).toHaveBeenCalledWith(50, expect.anything())
+        const votes = runSubquery('whereNotExists')
+        expect(votes.where).toHaveBeenCalledWith('gv.height', '<=', 50)
+        expect(votes.whereRaw).toHaveBeenCalledWith('gv.proposal_id = ph.proposal_id')
+        const members = runSubquery('whereExists')
+        expect(members.whereRaw).toHaveBeenCalledWith('gh.members @> ?::jsonb', [
+          JSON.stringify([{ address: 'verana1voter' }]),
+        ])
+        expect(called('__from', 'limit', (args) => typeof args[0] === 'number')).toBe(true)
+      })
+
+      it('does not query chain time when pending_voter is absent', async () => {
+        tables.__from = []
+        await service.listProposals({ params: {}, meta: { blockHeight: 50 } } as any)
+        expect(getBlockChainTimeAsOf).not.toHaveBeenCalled()
       })
     })
 

--- a/test/unit/services/crawl-group/group_api.spec.ts
+++ b/test/unit/services/crawl-group/group_api.spec.ts
@@ -229,6 +229,19 @@ describe('GroupApiService', () => {
       ])
     })
 
+    it('at height, applies cursors, sort and limit in SQL', async () => {
+      tables.__from = []
+      await service.listCorporationsByMember({
+        params: { account: 'verana1member', min_id: '2', max_id: '9', limit: '3', sort: '+id' },
+        meta: { blockHeight: 30 },
+      } as any)
+
+      expect(called('__from', 'where', (args) => args[0] === 'gh.corporation_id' && args[1] === '>=')).toBe(true)
+      expect(called('__from', 'where', (args) => args[0] === 'gh.corporation_id' && args[1] === '<')).toBe(true)
+      expect(called('__from', 'orderBy', (args) => args[0] === 'gh.corporation_id' && args[1] === 'asc')).toBe(true)
+      expect(called('__from', 'limit', (args) => args[0] === 3)).toBe(true)
+    })
+
     it('rejects invalid pagination', async () => {
       const ctx: any = { params: { account: 'verana1member', limit: '0' }, meta: {} }
       expect(await service.listCorporationsByMember(ctx)).toMatchObject({ code: 400 })
@@ -390,7 +403,7 @@ describe('GroupApiService', () => {
           meta: { blockHeight: 50 },
         } as any)
 
-        expect(getBlockChainTimeAsOf).toHaveBeenCalledWith(50, expect.anything())
+        expect(getBlockChainTimeAsOf).toHaveBeenCalledWith(50, expect.objectContaining({ atOrBefore: true }))
         const votes = runSubquery('whereNotExists')
         expect(votes.where).toHaveBeenCalledWith('gv.height', '<=', 50)
         expect(votes.whereRaw).toHaveBeenCalledWith('gv.proposal_id = ph.proposal_id')

--- a/test/unit/services/crawl-group/group_api.spec.ts
+++ b/test/unit/services/crawl-group/group_api.spec.ts
@@ -1,0 +1,460 @@
+const tables: Record<string, unknown[]> = {}
+const calls: Array<{ table: string; method: string; args: unknown[] }> = []
+
+// Records every builder call so tests can assert the filters actually reach the query,
+// and applies the filters it can evaluate in-memory so results reflect them.
+function chainable(table: string, rows: unknown[]) {
+  let current = [...rows]
+  const qb: any = {}
+  const record =
+    (method: string) =>
+    (...args: unknown[]) => {
+      calls.push({ table, method, args })
+      if (method === 'where' && args.length === 2 && typeof args[0] === 'string') {
+        const column = String(args[0]).split('.').pop() as string
+        current = current.filter((row: any) => String(row?.[column]) === String(args[1]))
+      }
+      if (method === 'whereIn' && args.length === 2 && Array.isArray(args[1])) {
+        const column = String(args[0]).split('.').pop() as string
+        const wanted = (args[1] as unknown[]).map(String)
+        current = current.filter((row: any) => wanted.includes(String(row?.[column])))
+      }
+      if (method === 'limit' && typeof args[0] === 'number') current = current.slice(0, args[0])
+      return qb
+    }
+  for (const method of [
+    'select',
+    'where',
+    'whereIn',
+    'whereRaw',
+    'whereNotNull',
+    'orderBy',
+    'limit',
+    'innerJoin',
+    'distinctOn',
+    'as',
+  ]) {
+    qb[method] = record(method)
+  }
+  qb.first = jest.fn(async () => current[0])
+  qb.then = (resolve: (v: unknown) => void, reject?: (e: unknown) => void) =>
+    Promise.resolve(current).then(resolve, reject)
+  return qb
+}
+
+jest.mock('../../../../src/common/utils/db_connection', () => ({
+  __esModule: true,
+  default: Object.assign((table: string) => chainable(table.split(' ')[0], tables[table.split(' ')[0]] ?? []), {
+    from: () => chainable('__from', tables.__from ?? []),
+  }),
+}))
+
+jest.mock('../../../../src/common/utils/apiResponse', () => ({
+  __esModule: true,
+  default: {
+    success: jest.fn((_ctx: unknown, data: unknown) => data),
+    error: jest.fn((_ctx: unknown, message: string, code: number) => ({ error: message, code })),
+  },
+}))
+
+jest.mock('../../../../src/common/utils/block_time', () => ({
+  getBlockChainTimeAsOf: jest.fn(async () => new Date('2026-08-10T16:00:00.000Z')),
+}))
+
+import { ServiceBroker } from 'moleculer'
+import { getBlockChainTimeAsOf } from '../../../../src/common/utils/block_time'
+import GroupApiService from '../../../../src/services/crawl-group/group_api.service'
+
+function called(table: string, method: string, predicate: (args: unknown[]) => boolean) {
+  return calls.some((call) => call.table === table && call.method === method && predicate(call.args))
+}
+
+function proposalRow(over: Record<string, unknown> = {}) {
+  return {
+    id: 4,
+    corporation_id: 1,
+    group_policy_address: 'verana1policy',
+    metadata: '',
+    proposers: ['verana1admin'],
+    submit_time: '2026-08-10T15:45:00.000Z',
+    group_version: 1,
+    group_policy_version: 2,
+    status: 'ACCEPTED',
+    executor_result: 'SUCCESS',
+    voting_period_end: '2026-08-10T15:50:00.000Z',
+    messages: [{ '@type': '/verana.de.v1.MsgGrantOperatorAuthorization' }],
+    final_tally_result: { yes_count: '2', no_count: '0', abstain_count: '0', no_with_veto_count: '0' },
+    modified: '2026-08-10T15:46:00.000Z',
+    height: 40,
+    ...over,
+  }
+}
+
+describe('GroupApiService', () => {
+  const broker = new ServiceBroker({ logger: false })
+  const service = new GroupApiService(broker)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    calls.length = 0
+    for (const key of Object.keys(tables)) delete tables[key]
+  })
+
+  describe('IDX-GR-QRY-1 getCorporationGroup', () => {
+    beforeEach(() => {
+      tables.corporation_group = [
+        {
+          corporation_id: 1,
+          group_id: 9,
+          policy_address: 'verana1policy',
+          group_version: 3,
+          policy_version: 2,
+          total_weight: '3',
+          decision_policy: { '@type': '/cosmos.group.v1.ThresholdDecisionPolicy', threshold: '2' },
+          created: '2026-08-10T15:44:00.000Z',
+        },
+      ]
+      tables.corporation_member = [
+        {
+          corporation_id: 1,
+          address: 'verana1admin',
+          weight: '1',
+          metadata: 'member_1',
+          created: '2026-08-10T15:44:00.000Z',
+        },
+      ]
+    })
+
+    it('returns the spec shape with nested policy and members', async () => {
+      const ctx: any = { params: { corporation_id: 1 }, meta: {} }
+      const res: any = await service.getCorporationGroup(ctx)
+
+      expect(res.group).toMatchObject({
+        corporation_id: 1,
+        group_id: 9,
+        version: 3,
+        total_weight: '3',
+        policy: { address: 'verana1policy', version: 2 },
+      })
+      expect(res.group.members).toEqual([
+        { address: 'verana1admin', weight: '1', metadata: 'member_1', added_at: '2026-08-10T15:44:00.000Z' },
+      ])
+    })
+
+    it('404s when no group is anchored', async () => {
+      tables.corporation_group = []
+      const ctx: any = { params: { corporation_id: 42 }, meta: {} }
+      expect(await service.getCorporationGroup(ctx)).toMatchObject({ code: 404 })
+    })
+
+    it('At-Block-Height serves the history snapshot and keeps policy.address from the live row', async () => {
+      tables.__from = [
+        {
+          corporation_id: 1,
+          group_id: 9,
+          group_version: 2,
+          policy_version: 1,
+          total_weight: '2',
+          decision_policy: { threshold: '2' },
+          members: [{ address: 'verana1admin', weight: '1', metadata: '', added_at: '2026-08-10T15:44:00.000Z' }],
+          height: 30,
+        },
+      ]
+      const ctx: any = { params: { corporation_id: 1 }, meta: { blockHeight: 35 } }
+      const res: any = await service.getCorporationGroup(ctx)
+
+      expect(res.group).toMatchObject({
+        version: 2,
+        total_weight: '2',
+        policy: { address: 'verana1policy', version: 1 },
+      })
+      expect(res.group.members).toHaveLength(1)
+      expect(called('corporation_group_history', 'where', (args) => args[0] === 'height' && args[1] === '<='))
+    })
+
+    it('At-Block-Height 404s before the group existed', async () => {
+      tables.__from = []
+      const ctx: any = { params: { corporation_id: 1 }, meta: { blockHeight: 5 } }
+      expect(await service.getCorporationGroup(ctx)).toMatchObject({ code: 404 })
+    })
+  })
+
+  describe('IDX-GR-QRY-2 listCorporationsByMember', () => {
+    it('rejects a missing/blank account', async () => {
+      const ctx: any = { params: { account: '  ' }, meta: {} }
+      expect(await service.listCorporationsByMember(ctx)).toMatchObject({ code: 400 })
+    })
+
+    it('filters by account and returns memberships without the address key', async () => {
+      tables.corporation_member = [
+        {
+          corporation_id: 3,
+          address: 'verana1member',
+          weight: '1',
+          metadata: 'member_2',
+          created: '2026-08-10T15:44:00.000Z',
+        },
+        { corporation_id: 9, address: 'verana1other', weight: '1', metadata: '', created: '2026-08-10T15:44:00.000Z' },
+      ]
+      const ctx: any = { params: { account: 'verana1member' }, meta: {} }
+      const res: any = await service.listCorporationsByMember(ctx)
+
+      expect(res.memberships).toEqual([
+        { corporation_id: 3, weight: '1', metadata: 'member_2', added_at: '2026-08-10T15:44:00.000Z' },
+      ])
+      expect(
+        called('corporation_member', 'where', (args) => args[0] === 'cm.address' && args[1] === 'verana1member')
+      ).toBe(true)
+    })
+
+    it('At-Block-Height resolves membership from the history snapshot', async () => {
+      tables.__from = [
+        {
+          corporation_id: 7,
+          members: [
+            { address: 'verana1member', weight: '2', metadata: 'm', added_at: '2026-08-10T15:44:00.000Z' },
+            { address: 'verana1other', weight: '1', metadata: '', added_at: '2026-08-10T15:44:00.000Z' },
+          ],
+        },
+      ]
+      const ctx: any = { params: { account: 'verana1member' }, meta: { blockHeight: 30 } }
+      const res: any = await service.listCorporationsByMember(ctx)
+
+      expect(res.memberships).toEqual([
+        { corporation_id: 7, weight: '2', metadata: 'm', added_at: '2026-08-10T15:44:00.000Z' },
+      ])
+    })
+
+    it('rejects invalid pagination', async () => {
+      const ctx: any = { params: { account: 'verana1member', limit: '0' }, meta: {} }
+      expect(await service.listCorporationsByMember(ctx)).toMatchObject({ code: 400 })
+    })
+  })
+
+  describe('IDX-GR-QRY-3 listProposals', () => {
+    it('rejects an unknown status and an invalid modified_after', async () => {
+      expect(await service.listProposals({ params: { status: 'OPEN' }, meta: {} } as any)).toMatchObject({ code: 400 })
+      expect(await service.listProposals({ params: { modified_after: 'nope' }, meta: {} } as any)).toMatchObject({
+        code: 400,
+      })
+    })
+
+    it('pushes corporation_id, status, proposer and modified_after into the query', async () => {
+      tables.group_proposal = []
+      const ctx: any = {
+        params: {
+          corporation_id: 1,
+          status: 'SUBMITTED',
+          proposer: 'verana1admin',
+          modified_after: '2026-08-01T00:00:00Z',
+        },
+        meta: {},
+      }
+      await service.listProposals(ctx)
+
+      expect(called('group_proposal', 'where', (args) => args[0] === 'corporation_id' && args[1] === 1)).toBe(true)
+      expect(called('group_proposal', 'where', (args) => args[0] === 'status' && args[1] === 'SUBMITTED')).toBe(true)
+      expect(
+        called(
+          'group_proposal',
+          'whereRaw',
+          (args) => String(args[0]).includes('proposers') && JSON.stringify(args[1]).includes('verana1admin')
+        )
+      ).toBe(true)
+      expect(
+        called(
+          'group_proposal',
+          'where',
+          (args) => args[0] === 'modified' && args[1] === '>' && args[2] === '2026-08-01T00:00:00.000Z'
+        )
+      ).toBe(true)
+    })
+
+    it('closed proposals report tally equal to final_tally_result, ignoring current weights', async () => {
+      tables.group_proposal = [proposalRow()]
+      tables.group_vote = []
+      tables.corporation_member = [{ corporation_id: 1, address: 'verana1admin', weight: '5' }]
+
+      const res: any = await service.listProposals({ params: {}, meta: {} } as any)
+      expect(res.proposals[0].tally).toEqual(res.proposals[0].final_tally_result)
+      expect(res.proposals[0].tally.yes_count).toBe('2')
+    })
+
+    it('open proposals report a weight-summed running tally', async () => {
+      tables.group_proposal = [
+        proposalRow({ status: 'SUBMITTED', executor_result: 'NOT_RUN', final_tally_result: null }),
+      ]
+      tables.group_vote = [
+        { proposal_id: 4, voter: 'verana1heavy', option: 'YES' },
+        { proposal_id: 4, voter: 'verana1light', option: 'NO' },
+      ]
+      tables.corporation_member = [
+        { corporation_id: 1, address: 'verana1heavy', weight: '7' },
+        { corporation_id: 1, address: 'verana1light', weight: '2' },
+      ]
+
+      const res: any = await service.listProposals({ params: {}, meta: {} } as any)
+      expect(res.proposals[0].tally).toEqual({
+        yes_count: '7',
+        no_count: '2',
+        abstain_count: '0',
+        no_with_veto_count: '0',
+      })
+    })
+
+    it('serializes the spec proposal shape including decoded messages', async () => {
+      tables.group_proposal = [proposalRow()]
+      const res: any = await service.listProposals({ params: {}, meta: {} } as any)
+      expect(res.proposals[0]).toMatchObject({
+        id: 4,
+        corporation_id: 1,
+        group_policy_address: 'verana1policy',
+        status: 'ACCEPTED',
+        executor_result: 'SUCCESS',
+        group_policy_version: 2,
+      })
+      expect(res.proposals[0].messages).toEqual([{ '@type': '/verana.de.v1.MsgGrantOperatorAuthorization' }])
+    })
+
+    describe('pending_voter', () => {
+      const open = (over: Record<string, unknown> = {}) =>
+        proposalRow({
+          status: 'SUBMITTED',
+          executor_result: 'NOT_RUN',
+          final_tally_result: null,
+          voting_period_end: '2099-01-01T00:00:00.000Z',
+          ...over,
+        })
+
+      it('keeps only SUBMITTED proposals inside the voting window for a member who has not voted', async () => {
+        tables.group_proposal = [open({ id: 4 })]
+        tables.group_vote = []
+        tables.corporation_member = [{ corporation_id: 1, address: 'verana1voter', weight: '1' }]
+
+        const res: any = await service.listProposals({ params: { pending_voter: 'verana1voter' }, meta: {} } as any)
+        expect(res.proposals.map((p: any) => p.id)).toEqual([4])
+      })
+
+      it('drops proposals the account already voted on', async () => {
+        tables.group_proposal = [open({ id: 4 })]
+        tables.group_vote = [{ proposal_id: 4, voter: 'verana1voter', option: 'YES' }]
+        tables.corporation_member = [{ corporation_id: 1, address: 'verana1voter', weight: '1' }]
+
+        const res: any = await service.listProposals({ params: { pending_voter: 'verana1voter' }, meta: {} } as any)
+        expect(res.proposals).toEqual([])
+      })
+
+      it('drops proposals of groups the account is not a member of', async () => {
+        tables.group_proposal = [open({ id: 4 })]
+        tables.group_vote = []
+        tables.corporation_member = [{ corporation_id: 1, address: 'verana1someone-else', weight: '1' }]
+
+        const res: any = await service.listProposals({ params: { pending_voter: 'verana1voter' }, meta: {} } as any)
+        expect(res.proposals).toEqual([])
+      })
+
+      it('drops proposals whose voting period already ended', async () => {
+        tables.group_proposal = [open({ id: 4, voting_period_end: '2020-01-01T00:00:00.000Z' })]
+        tables.group_vote = []
+        tables.corporation_member = [{ corporation_id: 1, address: 'verana1voter', weight: '1' }]
+
+        const res: any = await service.listProposals({ params: { pending_voter: 'verana1voter' }, meta: {} } as any)
+        expect(res.proposals).toEqual([])
+      })
+
+      it('drops closed proposals even inside the window', async () => {
+        tables.group_proposal = [open({ id: 4, status: 'WITHDRAWN' })]
+        tables.group_vote = []
+        tables.corporation_member = [{ corporation_id: 1, address: 'verana1voter', weight: '1' }]
+
+        const res: any = await service.listProposals({ params: { pending_voter: 'verana1voter' }, meta: {} } as any)
+        expect(res.proposals).toEqual([])
+      })
+
+      it('uses chain time at the requested At-Block-Height', async () => {
+        tables.__from = [
+          {
+            proposal_id: 4,
+            snapshot: open({ id: 4 }),
+            members: [{ address: 'verana1voter', weight: '1' }],
+            corporation_id: 1,
+          },
+        ]
+        tables.group_vote = []
+        const ctx: any = { params: { pending_voter: 'verana1voter' }, meta: { blockHeight: 50 } }
+        await service.listProposals(ctx)
+        expect(getBlockChainTimeAsOf).toHaveBeenCalledWith(50, expect.anything())
+      })
+    })
+
+    it('At-Block-Height reads proposals from the history snapshots', async () => {
+      tables.__from = [{ proposal_id: 4, snapshot: proposalRow({ status: 'SUBMITTED', final_tally_result: null }) }]
+      tables.group_vote = []
+      const ctx: any = { params: {}, meta: { blockHeight: 50 } }
+      const res: any = await service.listProposals(ctx)
+
+      expect(res.proposals.map((p: any) => p.id)).toEqual([4])
+      expect(called('group_proposal_history', 'where', (args) => args[0] === 'height' && args[1] === '<=')).toBe(true)
+    })
+  })
+
+  describe('IDX-GR-QRY-4 getProposal', () => {
+    it('404s for unknown proposals', async () => {
+      tables.group_proposal = []
+      expect(await service.getProposal({ params: { id: 999 }, meta: {} } as any)).toMatchObject({ code: 404 })
+    })
+
+    it('returns the proposal with its tally', async () => {
+      tables.group_proposal = [proposalRow()]
+      const res: any = await service.getProposal({ params: { id: 4 }, meta: {} } as any)
+      expect(res.proposal).toMatchObject({ id: 4, status: 'ACCEPTED' })
+      expect(res.proposal.tally).toEqual(res.proposal.final_tally_result)
+    })
+  })
+
+  describe('IDX-GR-QRY-5 listVotes', () => {
+    it('requires proposal_id or voter', async () => {
+      expect(await service.listVotes({ params: {}, meta: {} } as any)).toMatchObject({ code: 400 })
+    })
+
+    it('serializes votes with the indexer-assigned cursor id', async () => {
+      tables.group_vote = [
+        {
+          id: 11,
+          proposal_id: 4,
+          voter: 'verana1admin',
+          option: 'YES',
+          metadata: null,
+          submit_time: '2026-08-10T15:45:30.000Z',
+        },
+      ]
+      const res: any = await service.listVotes({ params: { proposal_id: 4 }, meta: {} } as any)
+      expect(res.votes).toEqual([
+        {
+          id: 11,
+          proposal_id: 4,
+          voter: 'verana1admin',
+          option: 'YES',
+          metadata: '',
+          submit_time: '2026-08-10T15:45:30.000Z',
+        },
+      ])
+    })
+
+    it('filters by voter and bounds votes by At-Block-Height', async () => {
+      tables.group_vote = []
+      const ctx: any = { params: { voter: 'verana1admin' }, meta: { blockHeight: 40 } }
+      await service.listVotes(ctx)
+      expect(called('group_vote', 'where', (args) => args[0] === 'voter' && args[1] === 'verana1admin')).toBe(true)
+      expect(called('group_vote', 'where', (args) => args[0] === 'height' && args[1] === '<=' && args[2] === 40)).toBe(
+        true
+      )
+    })
+
+    it('rejects bad pagination with 400', async () => {
+      expect(await service.listVotes({ params: { proposal_id: 4, limit: '0' }, meta: {} } as any)).toMatchObject({
+        code: 400,
+      })
+    })
+  })
+})

--- a/test/unit/services/crawl-group/group_events_routing.spec.ts
+++ b/test/unit/services/crawl-group/group_events_routing.spec.ts
@@ -143,6 +143,27 @@ describe('buildGroupEvents (IDX-INDEXER-SUB-1 x/group routing)', () => {
     expect(event.corporationId).toBeUndefined()
   })
 
+  it('resolves a group_id through the create events when corporation_group is not yet written', async () => {
+    tables.corporation_group = []
+    tables.transaction_message = [messageRow({ message_type: UPDATE_MEMBERS, content: { group_id: 9 } })]
+    // EventCreateGroup(group_id 9) and EventCreateGroupPolicy(address) from the same create tx
+    tables.event = [
+      { id: 10, tx_id: 4, tx_msg_index: 0, type: 'cosmos.group.v1.EventCreateGroup', key: 'group_id', value: '"9"' },
+      {
+        id: 11,
+        tx_id: 4,
+        tx_msg_index: 0,
+        type: 'cosmos.group.v1.EventCreateGroupPolicy',
+        key: 'address',
+        value: '"verana1policy"',
+      },
+    ]
+    const [event] = await buildGroupEventsForTest(40)
+
+    expect(event.corporationId).toBe(3)
+    expect(event.did).toBe('did:example:corp')
+  })
+
   it('returns nothing when the block has no group messages', async () => {
     tables.transaction_message = []
     expect(await buildGroupEventsForTest(40)).toEqual([])

--- a/test/unit/services/crawl-group/group_events_routing.spec.ts
+++ b/test/unit/services/crawl-group/group_events_routing.spec.ts
@@ -1,0 +1,150 @@
+const tables: Record<string, unknown[]> = {}
+
+function chainable(table: string, rows: unknown[]) {
+  let current = [...rows]
+  const qb: any = {}
+  const apply =
+    (method: string) =>
+    (...args: unknown[]) => {
+      if (method === 'where' && args.length === 2 && typeof args[0] === 'string') {
+        const column = String(args[0]).split('.').pop() as string
+        current = current.filter((row: any) => String(row?.[column]) === String(args[1]))
+      }
+      if (method === 'whereIn' && args.length === 2 && Array.isArray(args[1])) {
+        const column = String(args[0]).split('.').pop() as string
+        const wanted = (args[1] as unknown[]).map(String)
+        current = current.filter((row: any) => wanted.includes(String(row?.[column])))
+      }
+      return qb
+    }
+  for (const method of [
+    'select',
+    'where',
+    'andWhere',
+    'whereIn',
+    'whereRaw',
+    'orderBy',
+    'limit',
+    'innerJoin',
+    'leftJoin',
+  ]) {
+    qb[method] = apply(method)
+  }
+  qb.first = jest.fn(async () => current[0])
+  qb.then = (resolve: (v: unknown) => void, reject?: (e: unknown) => void) =>
+    Promise.resolve(current).then(resolve, reject)
+  qb.insert = jest.fn(() => qb)
+  qb.onConflict = jest.fn(() => qb)
+  qb.ignore = jest.fn(() => qb)
+  qb.returning = jest.fn(async () => [])
+  return qb
+}
+
+jest.mock('../../../../src/common/utils/db_connection', () => ({
+  __esModule: true,
+  default: (table: string) => chainable(table.split(' ')[0], tables[table.split(' ')[0]] ?? []),
+}))
+
+import { buildGroupEventsForTest } from '../../../../src/services/api/indexer_events_query'
+
+const SUBMIT = '/cosmos.group.v1.MsgSubmitProposal'
+const VOTE = '/cosmos.group.v1.MsgVote'
+const UPDATE_MEMBERS = '/cosmos.group.v1.MsgUpdateGroupMembers'
+
+// Carries both the raw join columns the query filters on (height/code/type) and the aliased output names.
+function messageRow(over: Record<string, unknown> = {}) {
+  const row = {
+    message_index: 0,
+    message_type: SUBMIT,
+    sender: 'verana1sender',
+    content: { group_policy_address: 'verana1policy' },
+    block_height: 40,
+    tx_hash: 'HASH1',
+    tx_index: 0,
+    timestamp: '2026-08-10T15:45:00.000Z',
+    ...over,
+  }
+  return { ...row, height: row.block_height, code: 0, type: row.message_type }
+}
+
+describe('buildGroupEvents (IDX-INDEXER-SUB-1 x/group routing)', () => {
+  beforeEach(() => {
+    for (const key of Object.keys(tables)) delete tables[key]
+    tables.corporation = [
+      { id: 3, did: 'did:example:corp', policy_address: 'verana1policy', corporation: 'verana1policy' },
+    ]
+    // innerJoin is a no-op in the mock, so the joined corporation did rides along on the fixture
+    tables.corporation_group = [
+      { corporation_id: 3, group_id: 9, policy_address: 'verana1policy', did: 'did:example:corp' },
+    ]
+  })
+
+  it('routes a policy-addressed message to its Corporation with module group', async () => {
+    tables.transaction_message = [messageRow({ message_type: UPDATE_MEMBERS, content: { group_id: 9 } })]
+    const [event] = await buildGroupEventsForTest(40)
+
+    expect(event.module).toBe('group')
+    expect(event.action).toBe('UpdateGroupMembers')
+    expect(event.did).toBe('did:example:corp')
+    expect(event.corporationId).toBe(3)
+    expect(event.entityType).toBe('CorporationGroup')
+    // CorporationGroup entities are keyed by corporation_id, never the x/group group_id
+    expect(event.entityId).toBe('3')
+  })
+
+  it('anchors on the corporation table alone, before the group processor has written corporation_group', async () => {
+    tables.corporation_group = []
+    tables.transaction_message = [messageRow()]
+    tables.event = []
+    const [event] = await buildGroupEventsForTest(40)
+
+    expect(event.corporationId).toBe(3)
+    expect(event.did).toBe('did:example:corp')
+  })
+
+  it('stamps the chain-assigned proposal id on SubmitProposal events', async () => {
+    tables.transaction_message = [messageRow()]
+    tables.event = [
+      {
+        value: '"12"',
+        tx_msg_index: 0,
+        hash: 'HASH1',
+        type: 'cosmos.group.v1.EventSubmitProposal',
+        key: 'proposal_id',
+      },
+    ]
+    const [event] = await buildGroupEventsForTest(40)
+
+    expect(event.entityType).toBe('GroupProposal')
+    expect(event.entityId).toBe('12')
+  })
+
+  it('resolves a Vote to its proposal and Corporation', async () => {
+    tables.transaction_message = [messageRow({ message_type: VOTE, content: { proposal_id: '12', voter: 'verana1v' } })]
+    tables.group_proposal = [{ id: 12, group_policy_address: 'verana1policy' }]
+    const [event] = await buildGroupEventsForTest(40)
+
+    expect(event.action).toBe('Vote')
+    expect(event.entityType).toBe('GroupProposal')
+    expect(event.entityId).toBe('12')
+    expect(event.corporationId).toBe(3)
+    expect(event.did).toBe('did:example:corp')
+  })
+
+  it('leaves group events that anchor no Corporation unscoped (wildcard-only)', async () => {
+    tables.corporation = []
+    tables.corporation_group = []
+    tables.transaction_message = [messageRow({ content: { group_policy_address: 'verana1unrelated' } })]
+    tables.event = []
+    const [event] = await buildGroupEventsForTest(40)
+
+    expect(event.did).toBeNull()
+    expect(event.relatedDids).toEqual([])
+    expect(event.corporationId).toBeUndefined()
+  })
+
+  it('returns nothing when the block has no group messages', async () => {
+    tables.transaction_message = []
+    expect(await buildGroupEventsForTest(40)).toEqual([])
+  })
+})

--- a/test/unit/services/crawl-group/group_helpers.spec.ts
+++ b/test/unit/services/crawl-group/group_helpers.spec.ts
@@ -124,6 +124,16 @@ describe('group_helpers.decideProposalOutcome', () => {
     expect(decideProposalOutcome(percentage, 1, 4)).toBe('REJECTED')
   })
 
+  it('caps the threshold at total weight, so a shrunken group can still accept', () => {
+    // members left until total weight (2) fell below the threshold (3)
+    expect(decideProposalOutcome({ '@type': '/cosmos.group.v1.ThresholdDecisionPolicy', threshold: '3' }, 2, 2)).toBe(
+      'ACCEPTED'
+    )
+    expect(decideProposalOutcome({ '@type': '/cosmos.group.v1.ThresholdDecisionPolicy', threshold: '3' }, 1, 2)).toBe(
+      'REJECTED'
+    )
+  })
+
   it('returns null rather than guessing when the policy cannot be evaluated', () => {
     expect(decideProposalOutcome(null, 5, 5)).toBeNull()
     expect(decideProposalOutcome({}, 5, 5)).toBeNull()

--- a/test/unit/services/crawl-group/group_helpers.spec.ts
+++ b/test/unit/services/crawl-group/group_helpers.spec.ts
@@ -1,0 +1,155 @@
+import {
+  anyTypeUrl,
+  decideProposalOutcome,
+  durationToSeconds,
+  isUndecodedAny,
+  normalizeTallyResult,
+  parseEventAttrJson,
+  parseEventAttrValue,
+  readPositiveInt,
+  shortExecutorResult,
+  shortProposalStatus,
+  shortVoteOption,
+  tallyFromVotes,
+  votingPeriodSecondsFromDecisionPolicy,
+} from '../../../../src/services/crawl-group/group_helpers'
+
+describe('group_helpers enum mapping', () => {
+  it('maps proposal statuses from names and numbers to spec short forms', () => {
+    expect(shortProposalStatus('PROPOSAL_STATUS_SUBMITTED')).toBe('SUBMITTED')
+    expect(shortProposalStatus('PROPOSAL_STATUS_WITHDRAWN')).toBe('WITHDRAWN')
+    expect(shortProposalStatus('ACCEPTED')).toBe('ACCEPTED')
+    expect(shortProposalStatus(3)).toBe('REJECTED')
+    expect(shortProposalStatus(4)).toBe('ABORTED')
+    expect(shortProposalStatus('PROPOSAL_STATUS_UNSPECIFIED')).toBeNull()
+    expect(shortProposalStatus(undefined)).toBeNull()
+  })
+
+  it('maps executor results', () => {
+    expect(shortExecutorResult('PROPOSAL_EXECUTOR_RESULT_NOT_RUN')).toBe('NOT_RUN')
+    expect(shortExecutorResult('PROPOSAL_EXECUTOR_RESULT_SUCCESS')).toBe('SUCCESS')
+    expect(shortExecutorResult(3)).toBe('FAILURE')
+    expect(shortExecutorResult('bogus')).toBeNull()
+  })
+
+  it('maps vote options including the 2=ABSTAIN/3=NO wire order', () => {
+    expect(shortVoteOption('VOTE_OPTION_YES')).toBe('YES')
+    expect(shortVoteOption('VOTE_OPTION_NO_WITH_VETO')).toBe('NO_WITH_VETO')
+    expect(shortVoteOption(2)).toBe('ABSTAIN')
+    expect(shortVoteOption(3)).toBe('NO')
+    expect(shortVoteOption(0)).toBeNull()
+  })
+})
+
+describe('group_helpers event attribute parsing', () => {
+  it('strips the JSON quoting of typed-event attribute values', () => {
+    expect(parseEventAttrValue('"5"')).toBe('5')
+    expect(parseEventAttrValue('"verana1abc"')).toBe('verana1abc')
+    expect(parseEventAttrValue('5')).toBe('5')
+    expect(parseEventAttrValue(undefined)).toBeNull()
+  })
+
+  it('parses embedded JSON objects (EventProposalPruned tally_result)', () => {
+    expect(parseEventAttrJson('{"yes_count":"2","no_count":"0"}')).toEqual({ yes_count: '2', no_count: '0' })
+    expect(parseEventAttrJson('not-json')).toBeNull()
+    expect(parseEventAttrJson(undefined)).toBeNull()
+  })
+
+  it('reads positive integers from strings', () => {
+    expect(readPositiveInt('7')).toBe(7)
+    expect(readPositiveInt('0')).toBeNull()
+    expect(readPositiveInt('abc')).toBeNull()
+  })
+})
+
+describe('group_helpers durations and tallies', () => {
+  it('parses cosmos duration JSON', () => {
+    expect(durationToSeconds('300s')).toBe(300)
+    expect(durationToSeconds('0.5s')).toBe(0.5)
+    expect(durationToSeconds('300')).toBeNull()
+    expect(durationToSeconds(300)).toBeNull()
+  })
+
+  it('extracts the voting period from a verbatim decision policy', () => {
+    const policy = {
+      '@type': '/cosmos.group.v1.ThresholdDecisionPolicy',
+      threshold: '2',
+      windows: { voting_period: '300s', min_execution_period: '0s' },
+    }
+    expect(votingPeriodSecondsFromDecisionPolicy(policy)).toBe(300)
+    expect(votingPeriodSecondsFromDecisionPolicy(null)).toBeNull()
+    expect(votingPeriodSecondsFromDecisionPolicy({})).toBeNull()
+  })
+
+  it('normalizes x/group TallyResult field names', () => {
+    expect(
+      normalizeTallyResult({ yes_count: '2', no_count: '1', abstain_count: '0', no_with_veto_count: '0' })
+    ).toEqual({ yes_count: '2', no_count: '1', abstain_count: '0', no_with_veto_count: '0' })
+    expect(normalizeTallyResult({ yesCount: '3' })).toEqual({
+      yes_count: '3',
+      no_count: '0',
+      abstain_count: '0',
+      no_with_veto_count: '0',
+    })
+    expect(normalizeTallyResult(null)).toBeNull()
+  })
+
+  it('counts votes per option', () => {
+    expect(tallyFromVotes([{ option: 'YES' }, { option: 'YES' }, { option: 'NO' }, { option: 'ABSTAIN' }])).toEqual({
+      yes_count: '2',
+      no_count: '1',
+      abstain_count: '1',
+      no_with_veto_count: '0',
+    })
+  })
+})
+
+describe('group_helpers.decideProposalOutcome', () => {
+  const threshold = { '@type': '/cosmos.group.v1.ThresholdDecisionPolicy', threshold: '2' }
+  const percentage = { '@type': '/cosmos.group.v1.PercentageDecisionPolicy', percentage: '0.5' }
+
+  it('accepts a threshold policy once yes weight reaches the threshold', () => {
+    expect(decideProposalOutcome(threshold, 2, 3)).toBe('ACCEPTED')
+    expect(decideProposalOutcome(threshold, 3, 3)).toBe('ACCEPTED')
+  })
+
+  it('rejects a threshold policy below the threshold', () => {
+    expect(decideProposalOutcome(threshold, 1, 3)).toBe('REJECTED')
+    expect(decideProposalOutcome(threshold, 0, 3)).toBe('REJECTED')
+  })
+
+  it('evaluates a percentage policy against total group weight', () => {
+    expect(decideProposalOutcome(percentage, 2, 4)).toBe('ACCEPTED')
+    expect(decideProposalOutcome(percentage, 3, 4)).toBe('ACCEPTED')
+    expect(decideProposalOutcome(percentage, 1, 4)).toBe('REJECTED')
+  })
+
+  it('returns null rather than guessing when the policy cannot be evaluated', () => {
+    expect(decideProposalOutcome(null, 5, 5)).toBeNull()
+    expect(decideProposalOutcome({}, 5, 5)).toBeNull()
+    expect(decideProposalOutcome({ '@type': '/cosmos.group.v1.SomeFuturePolicy' }, 5, 5)).toBeNull()
+    expect(decideProposalOutcome({ ...threshold, threshold: 'abc' }, 5, 5)).toBeNull()
+    // percentage is undecidable without a positive total weight
+    expect(decideProposalOutcome(percentage, 1, 0)).toBeNull()
+  })
+
+  it('reads the policy shape even when @type is absent', () => {
+    expect(decideProposalOutcome({ threshold: '2' }, 2, 3)).toBe('ACCEPTED')
+    expect(decideProposalOutcome({ percentage: '0.5' }, 1, 4)).toBe('REJECTED')
+  })
+})
+
+describe('group_helpers Any handling', () => {
+  it('reads the type url in any of its encodings', () => {
+    expect(anyTypeUrl({ '@type': '/a.b.MsgX' })).toBe('/a.b.MsgX')
+    expect(anyTypeUrl({ type_url: '/a.b.MsgX' })).toBe('/a.b.MsgX')
+    expect(anyTypeUrl({ typeUrl: '/a.b.MsgX' })).toBe('/a.b.MsgX')
+    expect(anyTypeUrl({})).toBeNull()
+  })
+
+  it('detects undecoded base64 payloads', () => {
+    expect(isUndecodedAny({ type_url: '/a.b.MsgX', value: 'CgFh' })).toBe(true)
+    expect(isUndecodedAny({ '@type': '/a.b.MsgX', voter: 'verana1x', value: 'CgFh' })).toBe(false)
+    expect(isUndecodedAny({ '@type': '/a.b.MsgX', voter: 'verana1x' })).toBe(false)
+  })
+})

--- a/test/unit/services/crawl-group/group_helpers.spec.ts
+++ b/test/unit/services/crawl-group/group_helpers.spec.ts
@@ -2,6 +2,8 @@ import {
   anyTypeUrl,
   decideProposalOutcome,
   durationToSeconds,
+  GROUP_MSG_TYPES,
+  GROUP_ROUTED_MESSAGE_TYPES,
   isUndecodedAny,
   normalizeTallyResult,
   parseEventAttrJson,
@@ -13,6 +15,15 @@ import {
   tallyFromVotes,
   votingPeriodSecondsFromDecisionPolicy,
 } from '../../../../src/services/crawl-group/group_helpers'
+
+describe('group_helpers.GROUP_ROUTED_MESSAGE_TYPES', () => {
+  it('routes every x/group message and excludes the verana create message', () => {
+    expect(GROUP_ROUTED_MESSAGE_TYPES).toHaveLength(Object.keys(GROUP_MSG_TYPES).length - 1)
+    expect(GROUP_ROUTED_MESSAGE_TYPES).not.toContain(GROUP_MSG_TYPES.CreateCorporation)
+    expect(GROUP_ROUTED_MESSAGE_TYPES).toContain(GROUP_MSG_TYPES.LeaveGroup)
+    expect(GROUP_ROUTED_MESSAGE_TYPES.every((type) => type.startsWith('/cosmos.group.v1.'))).toBe(true)
+  })
+})
 
 describe('group_helpers enum mapping', () => {
   it('maps proposal statuses from names and numbers to spec short forms', () => {

--- a/test/unit/services/crawl-group/group_processor_decode.spec.ts
+++ b/test/unit/services/crawl-group/group_processor_decode.spec.ts
@@ -1,0 +1,61 @@
+jest.mock('../../../../src/common/utils/db_connection', () => ({ __esModule: true, default: () => ({}) }))
+jest.mock('../../../../src/common/utils/checkpoint_manager', () => ({
+  CheckpointManager: class {
+    async ensureCheckpoint() {}
+    async updateCheckpoint() {}
+  },
+}))
+jest.mock('../../../../src/common/utils/start_mode_detector', () => ({
+  detectStartMode: jest.fn(async () => 'normal'),
+}))
+jest.mock('../../../../src/services/manager/indexer_status.manager', () => ({
+  indexerStatusManager: { isCrawlingActive: () => false },
+}))
+
+import { toBase64 } from '@cosmjs/encoding'
+import { Registry } from '@cosmjs/proto-signing'
+import { defaultRegistryTypes } from '@cosmjs/stargate'
+import { ServiceBroker } from 'moleculer'
+import GroupProcessorService from '../../../../src/services/crawl-group/group_processor.service'
+
+// decodeProposalMessages is the whole implementation of the spec's "messages[] JSON-decoded with their @type"
+// contract; stored MsgSubmitProposal content carries Anys as { type_url, value: base64 }.
+describe('GroupProcessorService.decodeProposalMessages', () => {
+  const service = new GroupProcessorService(new ServiceBroker({ logger: false })) as any
+  const decode = (messages: unknown) => service.decodeProposalMessages(messages)
+
+  it('returns an empty array for non-array input', () => {
+    expect(decode(undefined)).toEqual([])
+    expect(decode(null)).toEqual([])
+    expect(decode({})).toEqual([])
+  })
+
+  it('decodes a base64 Any into JSON fields under @type', () => {
+    const registry = new Registry([...defaultRegistryTypes] as ConstructorParameters<typeof Registry>[0])
+    const encoded = registry.encode({
+      typeUrl: '/cosmos.group.v1.MsgVote',
+      value: { proposalId: 7, voter: 'verana1voter', option: 1, metadata: '', exec: 0 },
+    })
+    const value = toBase64(encoded)
+
+    const [decoded] = decode([{ type_url: '/cosmos.group.v1.MsgVote', value }])
+    expect(decoded['@type']).toBe('/cosmos.group.v1.MsgVote')
+    expect(decoded.voter).toBe('verana1voter')
+    expect(String(decoded.proposalId ?? decoded.proposal_id)).toBe('7')
+  })
+
+  it('normalizes an already-decoded message to the @type key', () => {
+    const [decoded] = decode([{ type_url: '/verana.ec.v1.MsgCreateEcosystem', did: 'did:example:ec' }])
+    expect(decoded).toEqual({ '@type': '/verana.ec.v1.MsgCreateEcosystem', did: 'did:example:ec' })
+    expect('type_url' in decoded).toBe(false)
+  })
+
+  it('keeps the raw value when the type is not in the registry', () => {
+    const [decoded] = decode([{ type_url: '/unknown.v1.MsgMystery', value: 'CgFh' }])
+    expect(decoded).toEqual({ '@type': '/unknown.v1.MsgMystery', value: 'CgFh' })
+  })
+
+  it('passes through entries with no type url', () => {
+    expect(decode([{ foo: 'bar' }])).toEqual([{ foo: 'bar' }])
+  })
+})

--- a/test/unit/services/crawl-group/group_processor_exec.spec.ts
+++ b/test/unit/services/crawl-group/group_processor_exec.spec.ts
@@ -1,0 +1,182 @@
+const tables: Record<string, unknown[]> = {}
+const updates: Array<{ table: string; patch: Record<string, unknown> }> = []
+
+function chainable(table: string, rows: unknown[]) {
+  let current = [...rows]
+  const qb: any = {}
+  const apply =
+    (method: string) =>
+    (...args: unknown[]) => {
+      if (method === 'where' && args.length === 2 && typeof args[0] === 'string') {
+        const column = String(args[0]).split('.').pop() as string
+        current = current.filter((row: any) => String(row?.[column]) === String(args[1]))
+      }
+      return qb
+    }
+  for (const method of ['select', 'where', 'whereIn', 'whereRaw', 'orderBy', 'limit', 'innerJoin']) {
+    qb[method] = apply(method)
+  }
+  qb.update = jest.fn(async (patch: Record<string, unknown>) => {
+    updates.push({ table, patch })
+    for (const row of current) Object.assign(row as object, patch)
+    return current.length
+  })
+  qb.insert = jest.fn(() => qb)
+  qb.onConflict = jest.fn(() => qb)
+  qb.merge = jest.fn(async () => [])
+  qb.ignore = jest.fn(async () => [])
+  qb.first = jest.fn(async () => current[0])
+  qb.then = (resolve: (v: unknown) => void, reject?: (e: unknown) => void) =>
+    Promise.resolve(current).then(resolve, reject)
+  return qb
+}
+
+jest.mock('../../../../src/common/utils/db_connection', () => ({
+  __esModule: true,
+  default: (table: string) => chainable(table.split(' ')[0], tables[table.split(' ')[0]] ?? []),
+}))
+jest.mock('../../../../src/common/utils/checkpoint_manager', () => ({
+  CheckpointManager: class {
+    async ensureCheckpoint() {}
+    async updateCheckpoint() {}
+  },
+}))
+jest.mock('../../../../src/common/utils/start_mode_detector', () => ({
+  detectStartMode: jest.fn(async () => 'normal'),
+}))
+jest.mock('../../../../src/services/manager/indexer_status.manager', () => ({
+  indexerStatusManager: { isCrawlingActive: () => false },
+}))
+jest.mock('../../../../src/common/utils/account_balance_utils', () => ({ getLcdBaseUrl: () => 'http://lcd.test' }))
+
+import { ServiceBroker } from 'moleculer'
+import GroupProcessorService from '../../../../src/services/crawl-group/group_processor.service'
+
+const NOW = '2026-08-12T00:00:00.000Z'
+const OPEN_WINDOW = '2026-08-12T01:00:00.000Z'
+const CLOSED_WINDOW = '2026-08-11T23:00:00.000Z'
+
+function execEvent(result: string) {
+  return {
+    event_id: 1,
+    type: 'cosmos.group.v1.EventExec',
+    tx_id: 1,
+    tx_msg_index: 0,
+    block_height: 100,
+    attrs: { proposal_id: '"7"', result: `"PROPOSAL_EXECUTOR_RESULT_${result}"` },
+  }
+}
+
+function proposalRow(over: Record<string, unknown> = {}) {
+  return {
+    id: 7,
+    corporation_id: 1,
+    status: 'SUBMITTED',
+    executor_result: 'NOT_RUN',
+    voting_period_end: OPEN_WINDOW,
+    ...over,
+  }
+}
+
+let fetchCalls: Array<{ url: string; height?: string }> = []
+function stubFetch(handler: (call: { url: string; height?: string }) => { ok: boolean; body?: unknown }) {
+  fetchCalls = []
+  global.fetch = jest.fn(async (url: unknown, init?: unknown) => {
+    const headers = ((init as { headers?: Record<string, string> })?.headers ?? {}) as Record<string, string>
+    const call = { url: String(url), height: headers['x-cosmos-block-height'] }
+    fetchCalls.push(call)
+    const result = handler(call)
+    return { ok: result.ok, json: async () => result.body ?? {} } as unknown as Response
+  }) as unknown as typeof fetch
+}
+
+describe('GroupProcessorService.handleExecEvent', () => {
+  const service = new GroupProcessorService(new ServiceBroker({ logger: false })) as any
+
+  beforeEach(() => {
+    for (const key of Object.keys(tables)) delete tables[key]
+    updates.length = 0
+    tables.group_vote = []
+    tables.corporation_member = []
+    tables.corporation_group = [{ corporation_id: 1, total_weight: '3', decision_policy: { threshold: '2' } }]
+    stubFetch(() => ({ ok: false }))
+  })
+
+  afterEach(() => jest.restoreAllMocks())
+
+  it('SUCCESS marks the proposal ACCEPTED and does not re-read chain state', async () => {
+    tables.group_proposal = [proposalRow()]
+    await service.handleExecEvent(execEvent('SUCCESS'), 100, NOW)
+
+    expect(updates[0].patch).toMatchObject({ status: 'ACCEPTED', executor_result: 'SUCCESS' })
+    expect(fetchCalls).toHaveLength(0)
+  })
+
+  it('FAILURE also implies ACCEPTED, because x/group only executes an accepted proposal', async () => {
+    tables.group_proposal = [proposalRow()]
+    await service.handleExecEvent(execEvent('FAILURE'), 100, NOW)
+
+    expect(updates[0].patch).toMatchObject({ status: 'ACCEPTED', executor_result: 'FAILURE' })
+  })
+
+  it('NOT_RUN leaves the status alone and settles from chain state', async () => {
+    tables.group_proposal = [proposalRow()]
+    stubFetch(() => ({
+      ok: true,
+      body: { proposal: { status: 'PROPOSAL_STATUS_SUBMITTED', executor_result: 'PROPOSAL_EXECUTOR_RESULT_NOT_RUN' } },
+    }))
+
+    await service.handleExecEvent(execEvent('NOT_RUN'), 100, NOW)
+
+    expect(updates[0].patch.status).toBeUndefined()
+    expect(fetchCalls[0].height).toBe('100')
+  })
+
+  // The regression the audit caught: an unreachable LCD must never invent a terminal status.
+  it('does not fabricate a terminal status when the chain read fails on an open proposal', async () => {
+    tables.group_proposal = [proposalRow({ voting_period_end: OPEN_WINDOW })]
+    stubFetch(() => ({ ok: false }))
+
+    await service.handleExecEvent(execEvent('NOT_RUN'), 100, NOW)
+
+    const statusWrites = updates.filter((u) => u.patch.status !== undefined)
+    expect(statusWrites).toEqual([])
+  })
+
+  it('does not overwrite an already-terminal status when the chain read fails', async () => {
+    tables.group_proposal = [proposalRow({ status: 'ACCEPTED', voting_period_end: CLOSED_WINDOW })]
+    stubFetch(() => ({ ok: false }))
+
+    await service.handleExecEvent(execEvent('FAILURE'), 100, NOW)
+
+    expect(tables.group_proposal[0]).toMatchObject({ status: 'ACCEPTED', executor_result: 'FAILURE' })
+  })
+
+  it('settles a pruned proposal only once its voting window has closed', async () => {
+    tables.group_proposal = [proposalRow({ voting_period_end: CLOSED_WINDOW })]
+    tables.group_vote = [{ proposal_id: 7, voter: 'verana1a', option: 'YES' }]
+    tables.corporation_member = [
+      { corporation_id: 1, address: 'verana1a', weight: '2' },
+      { corporation_id: 1, address: 'verana1b', weight: '1' },
+    ]
+    stubFetch(() => ({ ok: false }))
+
+    await service.handleExecEvent(execEvent('NOT_RUN'), 100, NOW)
+
+    const settled = updates.find((u) => u.patch.status !== undefined)
+    expect(settled?.patch).toMatchObject({ status: 'ACCEPTED' })
+  })
+
+  it('retries the chain read without the height before giving up', async () => {
+    tables.group_proposal = [proposalRow()]
+    stubFetch((call) =>
+      call.height
+        ? { ok: false }
+        : { ok: true, body: { proposal: { status: 'PROPOSAL_STATUS_SUBMITTED', voting_period_end: OPEN_WINDOW } } }
+    )
+
+    await service.handleExecEvent(execEvent('NOT_RUN'), 100, NOW)
+
+    expect(fetchCalls.map((c) => c.height)).toEqual(['100', undefined])
+  })
+})

--- a/test/unit/services/crawl-group/group_processor_lcd.spec.ts
+++ b/test/unit/services/crawl-group/group_processor_lcd.spec.ts
@@ -1,0 +1,84 @@
+jest.mock('../../../../src/common/utils/db_connection', () => ({ __esModule: true, default: () => ({}) }))
+jest.mock('../../../../src/common/utils/checkpoint_manager', () => ({
+  CheckpointManager: class {
+    async ensureCheckpoint() {}
+    async updateCheckpoint() {}
+  },
+}))
+jest.mock('../../../../src/common/utils/start_mode_detector', () => ({
+  detectStartMode: jest.fn(async () => 'normal'),
+}))
+jest.mock('../../../../src/services/manager/indexer_status.manager', () => ({
+  indexerStatusManager: { isCrawlingActive: () => false },
+}))
+jest.mock('../../../../src/common/utils/account_balance_utils', () => ({
+  getLcdBaseUrl: () => 'http://lcd.test',
+}))
+
+import { ServiceBroker } from 'moleculer'
+import GroupProcessorService from '../../../../src/services/crawl-group/group_processor.service'
+
+type FetchCall = { url: string; height?: string }
+
+function stubFetch(handler: (call: FetchCall) => { ok: boolean; body?: unknown }) {
+  const calls: FetchCall[] = []
+  global.fetch = jest.fn(async (url: unknown, init?: unknown) => {
+    const headers = ((init as { headers?: Record<string, string> })?.headers ?? {}) as Record<string, string>
+    const call = { url: String(url), height: headers['x-cosmos-block-height'] }
+    calls.push(call)
+    const result = handler(call)
+    return {
+      ok: result.ok,
+      json: async () => result.body ?? {},
+    } as unknown as Response
+  }) as unknown as typeof fetch
+  return calls
+}
+
+// A pruning node answers current-state queries but 501s historical ones. Membership refresh must
+// still land instead of silently leaving stale members.
+describe('GroupProcessorService LCD height fallback', () => {
+  const service = new GroupProcessorService(new ServiceBroker({ logger: false })) as any
+  const membersBody = {
+    members: [{ member: { address: 'verana1a', weight: '2', metadata: 'm', added_at: '2026-08-10T00:00:00Z' } }],
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('falls back to current state when the historical query fails', async () => {
+    const calls = stubFetch((call) => (call.height ? { ok: false } : { ok: true, body: membersBody }))
+
+    const members = await service.fetchGroupMembers(9, 30)
+
+    expect(members).toEqual([{ address: 'verana1a', weight: '2', metadata: 'm', added_at: '2026-08-10T00:00:00Z' }])
+    expect(calls).toHaveLength(2)
+    expect(calls[0].height).toBe('30')
+    expect(calls[1].height).toBeUndefined()
+  })
+
+  it('uses the historical answer when the node serves it, without a second call', async () => {
+    const calls = stubFetch(() => ({ ok: true, body: membersBody }))
+
+    const members = await service.fetchGroupMembers(9, 30)
+
+    expect(members).toHaveLength(1)
+    expect(calls).toHaveLength(1)
+    expect(calls[0].height).toBe('30')
+  })
+
+  it('returns an empty list when both attempts fail', async () => {
+    const calls = stubFetch(() => ({ ok: false }))
+
+    expect(await service.fetchGroupMembers(9, 30)).toEqual([])
+    expect(calls).toHaveLength(2)
+  })
+
+  it('does not issue a duplicate call when no height was requested', async () => {
+    const calls = stubFetch(() => ({ ok: false }))
+
+    expect(await service.fetchGroupMembers(9)).toEqual([])
+    expect(calls).toHaveLength(1)
+  })
+})

--- a/test/unit/services/crawl-group/group_processor_lcd.spec.ts
+++ b/test/unit/services/crawl-group/group_processor_lcd.spec.ts
@@ -1,4 +1,50 @@
-jest.mock('../../../../src/common/utils/db_connection', () => ({ __esModule: true, default: () => ({}) }))
+const tables: Record<string, unknown[]> = {}
+const deleted: string[] = []
+const inserted: Array<{ table: string; rows: unknown }> = []
+
+function chainable(table: string, rows: unknown[]) {
+  let current = [...rows]
+  const qb: any = {}
+  const apply =
+    (method: string) =>
+    (...args: unknown[]) => {
+      if (method === 'where' && args.length === 2 && typeof args[0] === 'string') {
+        const column = String(args[0]).split('.').pop() as string
+        current = current.filter((row: any) => String(row?.[column]) === String(args[1]))
+      }
+      return qb
+    }
+  for (const method of ['select', 'where', 'whereIn', 'whereRaw', 'orderBy', 'limit']) qb[method] = apply(method)
+  qb.first = jest.fn(async () => current[0])
+  qb.update = jest.fn(async (patch: Record<string, unknown>) => {
+    for (const row of current) Object.assign(row as object, patch)
+    return current.length
+  })
+  qb.delete = jest.fn(async () => {
+    deleted.push(table)
+    return current.length
+  })
+  qb.insert = jest.fn((rows: unknown) => {
+    inserted.push({ table, rows })
+    return qb
+  })
+  qb.onConflict = jest.fn(() => qb)
+  qb.merge = jest.fn(async () => [])
+  qb.ignore = jest.fn(async () => [])
+  qb.then = (resolve: (v: unknown) => void, reject?: (e: unknown) => void) =>
+    Promise.resolve(current).then(resolve, reject)
+  return qb
+}
+
+jest.mock('../../../../src/common/utils/db_connection', () => {
+  const factory = (table: string) => chainable(table.split(' ')[0], tables[table.split(' ')[0]] ?? [])
+  return {
+    __esModule: true,
+    default: Object.assign(factory, {
+      transaction: async (fn: (trx: unknown) => Promise<unknown>) => fn(factory),
+    }),
+  }
+})
 jest.mock('../../../../src/common/utils/checkpoint_manager', () => ({
   CheckpointManager: class {
     async ensureCheckpoint() {}
@@ -68,17 +114,80 @@ describe('GroupProcessorService LCD height fallback', () => {
     expect(calls[0].height).toBe('30')
   })
 
-  it('returns an empty list when both attempts fail', async () => {
+  it('returns null (not an empty list) when both attempts fail', async () => {
     const calls = stubFetch(() => ({ ok: false }))
 
-    expect(await service.fetchGroupMembers(9, 30)).toEqual([])
+    expect(await service.fetchGroupMembers(9, 30)).toBeNull()
     expect(calls).toHaveLength(2)
   })
 
   it('does not issue a duplicate call when no height was requested', async () => {
     const calls = stubFetch(() => ({ ok: false }))
 
-    expect(await service.fetchGroupMembers(9)).toEqual([])
+    expect(await service.fetchGroupMembers(9)).toBeNull()
     expect(calls).toHaveLength(1)
+  })
+
+  it('distinguishes a genuinely empty group from a failed lookup', async () => {
+    stubFetch(() => ({ ok: true, body: { members: [] } }))
+    expect(await service.fetchGroupMembers(9, 30)).toEqual([])
+  })
+})
+
+// The consumer half: a leave must rewrite membership, including down to zero members.
+describe('GroupProcessorService.handleGroupUpdated membership rewrite', () => {
+  const service = new GroupProcessorService(new ServiceBroker({ logger: false })) as any
+
+  beforeEach(() => {
+    for (const key of Object.keys(tables)) delete tables[key]
+    tables.corporation_group = [{ corporation_id: 1, group_id: 9, group_version: 3, total_weight: '3' }]
+    deleted.length = 0
+    inserted.length = 0
+  })
+
+  afterEach(() => jest.restoreAllMocks())
+
+  const leaveEvent = {
+    event_id: 1,
+    type: 'cosmos.group.v1.EventLeaveGroup',
+    tx_id: 1,
+    tx_msg_index: 0,
+    block_height: 100,
+    attrs: { group_id: '"9"' },
+  }
+
+  it('replaces membership with the post-leave list', async () => {
+    stubFetch((call) =>
+      call.url.includes('group_members')
+        ? { ok: true, body: { members: [{ member: { address: 'verana1a', weight: '1', metadata: '' } }] } }
+        : { ok: true, body: { info: { version: '4', total_weight: '1' } } }
+    )
+
+    await service.handleGroupUpdated(leaveEvent, 100, '2026-08-12T00:00:00.000Z')
+
+    expect(deleted).toContain('corporation_member')
+    const members = inserted.filter((i) => i.table === 'corporation_member').flatMap((i) => i.rows as any[])
+    expect(members.map((m) => m.address)).toEqual(['verana1a'])
+  })
+
+  it('clears membership when the last member leaves', async () => {
+    stubFetch((call) =>
+      call.url.includes('group_members')
+        ? { ok: true, body: { members: [] } }
+        : { ok: true, body: { info: { version: '5', total_weight: '0' } } }
+    )
+
+    await service.handleGroupUpdated(leaveEvent, 100, '2026-08-12T00:00:00.000Z')
+
+    expect(deleted).toContain('corporation_member')
+    expect(inserted.filter((i) => i.table === 'corporation_member')).toEqual([])
+  })
+
+  it('leaves membership untouched when the lookup fails', async () => {
+    stubFetch(() => ({ ok: false }))
+
+    await service.handleGroupUpdated(leaveEvent, 100, '2026-08-12T00:00:00.000Z')
+
+    expect(deleted).not.toContain('corporation_member')
   })
 })


### PR DESCRIPTION
Closes #392. Implements verana-spec#49 (merged).

Adds a Group module exposing the x/group state behind each Corporation, plus
event routing for group activity.

Endpoints under `/v4/group`:

- `get/{corporation_id}` (IDX-GR-QRY-1): group, policy with its decision policy,
  and the full member list
- `corporations-by-member` (IDX-GR-QRY-2): membership discovery for an account
- `proposals` (IDX-GR-QRY-3): filters for corporation_id, status, proposer,
  pending_voter and modified_after
- `proposal/{id}` (IDX-GR-QRY-4)
- `votes` (IDX-GR-QRY-5): requires proposal_id or voter

Details:

- new crawler on the `handle:group` checkpoint, tracking group creation,
  proposals, votes, withdrawals, execution and membership changes
- x/group deletes proposals and votes from state once they execute or expire,
  so state is kept in the indexer and reconciled from LCD when needed
- proposal messages are decoded to their `@type`, tallies are member-weight sums
- x/group activity is routed as events of its Corporation with
  `payload.module = "group"`; groups anchoring no Corporation stay unscoped
- five tables with history tables backing At-Block-Height
- openapi.json updated