### PR TITLE
feat: wire trust evaluation to verre 0.4.0

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4645,7 +4645,7 @@
           "Digest"
         ],
         "summary": "Get Digest",
-        "description": "Look up a previously stored Digest entry by its digest string (typically an SRI digest such as sha384-...).",
+        "description": "Look up a previously stored Digest entry by its digest string, byte-for-byte as anchored (for a credential, its digestJCS).",
         "operationId": "getDigest",
         "parameters": [
           {
@@ -4655,7 +4655,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The digest to look up (typically an SRI digest such as sha384-...)"
+            "description": "The digest to look up, byte-for-byte as anchored (for a credential, its digestJCS)"
           },
           {
             "$ref": "#/components/parameters/At-Block-Height"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@types/parse-uri": "^1.0.2",
     "@types/swagger-ui-dist": "3.30.6",
     "@verana-labs/verana-types": "0.10.1-dev.22",
-    "@verana-labs/verre": "0.4.0-dev.1",
+    "@verana-labs/verre": "0.4.0-dev.2",
     "ajv-formats": "^2.1.1",
     "axios": "^1.12.2",
     "bignumber.js": "^9.3.1",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@types/parse-uri": "^1.0.2",
     "@types/swagger-ui-dist": "3.30.6",
     "@verana-labs/verana-types": "0.10.1-dev.22",
-    "@verana-labs/verre": "0.4.0-dev.2",
+    "@verana-labs/verre": "0.4.0",
     "ajv-formats": "^2.1.1",
     "axios": "^1.12.2",
     "bignumber.js": "^9.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: 0.10.1-dev.22
         version: 0.10.1-dev.22(@cosmjs/proto-signing@0.29.5)(@cosmjs/stargate@0.31.3(debug@4.4.3))
       '@verana-labs/verre':
-        specifier: 0.4.0-dev.1
-        version: 0.4.0-dev.1(web-streams-polyfill@3.3.3)
+        specifier: 0.4.0-dev.2
+        version: 0.4.0-dev.2(web-streams-polyfill@3.3.3)
       ajv-formats:
         specifier: ^2.1.1
         version: 2.1.1(ajv@8.17.1)
@@ -2505,8 +2505,8 @@ packages:
       '@cosmjs/proto-signing': ^0.32.3
       '@cosmjs/stargate': ^0.32.3
 
-  '@verana-labs/verre@0.4.0-dev.1':
-    resolution: {integrity: sha512-HrURKqWBoMC9HgnV1Odc5mZw5kWPaQhJqZS3euOzXJ4fOwq+ebaZ333O0h3TsTES5q/PHe1hjrNkehHDKgxOPA==}
+  '@verana-labs/verre@0.4.0-dev.2':
+    resolution: {integrity: sha512-/Rrc0ddjr6FaYOl+rqSEa0PrqLhKDxI4bNMMD1NPso6tDJpH3utW9dXHw5EYBnl+c42P+BNMCO4BrI0e5L9MNQ==}
     engines: {node: '>= 18'}
 
   JSONStream@1.3.5:
@@ -10446,7 +10446,7 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.2.6
 
-  '@verana-labs/verre@0.4.0-dev.1(web-streams-polyfill@3.3.3)':
+  '@verana-labs/verre@0.4.0-dev.2(web-streams-polyfill@3.3.3)':
     dependencies:
       '@digitalcredentials/jsonld': 9.0.0
       '@noble/curves': 2.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: 0.10.1-dev.22
         version: 0.10.1-dev.22(@cosmjs/proto-signing@0.29.5)(@cosmjs/stargate@0.31.3(debug@4.4.3))
       '@verana-labs/verre':
-        specifier: 0.4.0-dev.2
-        version: 0.4.0-dev.2(web-streams-polyfill@3.3.3)
+        specifier: 0.4.0
+        version: 0.4.0(web-streams-polyfill@3.3.3)
       ajv-formats:
         specifier: ^2.1.1
         version: 2.1.1(ajv@8.17.1)
@@ -2505,8 +2505,8 @@ packages:
       '@cosmjs/proto-signing': ^0.32.3
       '@cosmjs/stargate': ^0.32.3
 
-  '@verana-labs/verre@0.4.0-dev.2':
-    resolution: {integrity: sha512-/Rrc0ddjr6FaYOl+rqSEa0PrqLhKDxI4bNMMD1NPso6tDJpH3utW9dXHw5EYBnl+c42P+BNMCO4BrI0e5L9MNQ==}
+  '@verana-labs/verre@0.4.0':
+    resolution: {integrity: sha512-n+TC/di7+vxnYoGqxKKQxqIZUPy/gnGcK/j9AIHgbsWGa7FZjN4OI9BEKpNjhOYg1ERMjAgtO1BTyARXS09EIQ==}
     engines: {node: '>= 18'}
 
   JSONStream@1.3.5:
@@ -10446,7 +10446,7 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.2.6
 
-  '@verana-labs/verre@0.4.0-dev.2(web-streams-polyfill@3.3.3)':
+  '@verana-labs/verre@0.4.0(web-streams-polyfill@3.3.3)':
     dependencies:
       '@digitalcredentials/jsonld': 9.0.0
       '@noble/curves': 2.0.1

--- a/src/services/resolver/trust-resolve-v4.builders.ts
+++ b/src/services/resolver/trust-resolve-v4.builders.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { computeCredentialDigestJCS, fetchJson } from '@verana-labs/verre'
+import { fetchJson, type TrustResolution } from '@verana-labs/verre'
 import { canonicalizeJson, toCoin } from '../../common'
 import { ALL_PARTICIPANT_ROLES, type ParticipantRole, type ParticipantState } from '../../common/types/types'
 import { toDate, toIso } from '../../common/utils/date_utils'
@@ -654,76 +654,6 @@ function parseSchemaJson(value: unknown): Record<string, unknown> | null {
   return null
 }
 
-function ecsSchemaVersionFromId(schemaJson: unknown): string {
-  const sid = parseSchemaJson(schemaJson)?.$id
-  const m = typeof sid === 'string' ? sid.match(/\/cs\/(v\d+)\//) : null
-  return m ? m[1] : 'v4'
-}
-
-type VerifiableCredential = {
-  id?: string
-  issuer?: string
-  credentialSubject?: Record<string, unknown>
-  validFrom?: string
-  validUntil?: string
-  issuanceDate?: string
-  expirationDate?: string
-  proof?: unknown
-}
-
-function toCredentialSubject(cred: Record<string, unknown>): Record<string, unknown> {
-  const rawSubject = (cred.raw as { credentialSubject?: unknown } | undefined)?.credentialSubject
-  if (rawSubject && typeof rawSubject === 'object' && !Array.isArray(rawSubject)) {
-    return rawSubject as Record<string, unknown>
-  }
-  const { schemaType, issuer, raw, validFrom, validUntil, ...subject } = cred
-  return subject
-}
-
-type EcsSchemaLink = {
-  participantId: number
-  credentialSchemaId: number
-  ecosystemId: number
-  ecsSchemaVersion: string
-  digestAlgorithm: string | null
-}
-
-async function resolveEcsSchemaLink(subjectDid: string, ecsSchemaTitle: string): Promise<EcsSchemaLink | null> {
-  const participants = (await knex('participants')
-    .where({ did: subjectDid, role: 'HOLDER' })
-    .select('id', 'schema_id')) as Array<{ id: number; schema_id: number }>
-  if (participants.length === 0) return null
-
-  const schemaIds = [...new Set(participants.map((p) => Number(p.schema_id)).filter((n) => Number.isFinite(n)))]
-  if (schemaIds.length === 0) return null
-  const schemas = (await knex('credential_schemas')
-    .whereIn('id', schemaIds)
-    .select('id', 'ecosystem_id', 'json_schema', 'digest_algorithm')) as Array<{
-    id: number
-    ecosystem_id: number
-    json_schema: unknown
-    digest_algorithm: string | null
-  }>
-
-  for (const p of participants) {
-    const cs = schemas.find((s) => Number(s.id) === Number(p.schema_id))
-    if (
-      cs &&
-      parseSchemaJson(cs.json_schema)?.title === ecsSchemaTitle &&
-      (await isEcosystemEcsAllowlisted(Number(cs.ecosystem_id) || 0))
-    ) {
-      return {
-        participantId: Number(p.id) || 0,
-        credentialSchemaId: Number(cs.id) || 0,
-        ecosystemId: Number(cs.ecosystem_id) || 0,
-        ecsSchemaVersion: ecsSchemaVersionFromId(cs.json_schema),
-        digestAlgorithm: cs.digest_algorithm,
-      }
-    }
-  }
-  return null
-}
-
 async function resolveIssuerParticipantId(issuerDid: string, credentialSchemaId: number): Promise<number> {
   if (!issuerDid || credentialSchemaId <= 0) return 0
   const row = (await knex('participants')
@@ -733,80 +663,38 @@ async function resolveIssuerParticipantId(issuerDid: string, credentialSchemaId:
   return row?.id != null ? Number(row.id) || 0 : 0
 }
 
-async function fetchDigestIssuedAt(digestJCS: string): Promise<string | null> {
-  if (!digestJCS) return null
-  const row = (await knex('digests').select('created').where({ digest: digestJCS }).first()) as
-    | { created?: Date | string | null }
-    | undefined
-  return row?.created != null ? (toIso(row.created) ?? null) : null
-}
-
-function readCredentialValidityWindow(cred: Record<string, unknown>): {
-  validFrom: string | null
-  validUntil: string | null
-} {
-  const raw = (cred.raw && typeof cred.raw === 'object' ? (cred.raw as Record<string, unknown>) : {}) as Record<
-    string,
-    unknown
-  >
-  const pick = (...candidates: unknown[]): string | null => {
-    for (const value of candidates) if (typeof value === 'string' && value.length > 0) return toIso(value) ?? null
-    return null
-  }
-  return {
-    validFrom: pick(cred.validFrom, raw.validFrom, raw.issuanceDate),
-    validUntil: pick(cred.validUntil, raw.validUntil, raw.expirationDate),
-  }
-}
-
 export async function buildEcsCredentials(resolveResult: unknown): Promise<Array<Record<string, unknown>>> {
-  if (!resolveResult || typeof resolveResult !== 'object') return []
-  const r = resolveResult as Record<string, unknown>
+  const resolution = resolveResult as TrustResolution | null
+  if (!resolution || typeof resolution !== 'object') return []
 
   const out: Array<Record<string, unknown>> = []
   const seenIds = new Set<string>()
-  for (const key of ['service', 'serviceProvider']) {
-    const cred = r[key]
-    if (!cred || typeof cred !== 'object') continue
-    const c = cred as Record<string, unknown>
-    const ecsSchema = ECS_SCHEMA_TITLE_BY_TYPE[String(c.schemaType ?? '').toLowerCase()]
+  const seenDigests = new Set<string>()
+  for (const credential of [resolution.service, resolution.serviceProvider]) {
+    if (!credential) continue
+    const ecsSchema = ECS_SCHEMA_TITLE_BY_TYPE[String(credential.ecs ?? '').toLowerCase()]
     if (!ecsSchema) continue
 
-    const subjectDid = typeof c.id === 'string' ? c.id : null
-    const issuerDid = typeof c.issuer === 'string' ? c.issuer : null
-    const link = subjectDid ? await resolveEcsSchemaLink(subjectDid, ecsSchema) : null
-    if (!link) continue
-
-    const raw = c.raw && typeof c.raw === 'object' ? (c.raw as VerifiableCredential) : null
-    const id = typeof raw?.id === 'string' ? raw.id : ''
-    if (!id || seenIds.has(id)) continue
-
-    const digestAlgorithm = link.digestAlgorithm
-    const digestJCS =
-      raw && (digestAlgorithm === 'sha384' || digestAlgorithm === 'sha512')
-        ? computeCredentialDigestJCS(raw, digestAlgorithm)
-        : null
-    const issuedAtTime = digestJCS ? await fetchDigestIssuedAt(digestJCS) : null
-    if (!digestJCS || !issuedAtTime) continue
-
-    const credentialSchemaId = link.credentialSchemaId
-    const issuerParticipantId = issuerDid ? await resolveIssuerParticipantId(issuerDid, credentialSchemaId) : 0
-    const { validFrom, validUntil } = readCredentialValidityWindow(c)
-
+    const { id, digestJCS, issuedAtTime } = credential
+    if (!id || !digestJCS || !issuedAtTime) continue
+    if (seenIds.has(id) || seenDigests.has(digestJCS)) continue
     seenIds.add(id)
+    seenDigests.add(digestJCS)
+
+    const holder = credential.subjectParticipants?.find((participant) => String(participant.role) === 'HOLDER')
     out.push({
       ecsSchema,
-      ecsSchemaVersion: link.ecsSchemaVersion,
-      credentialSchemaId,
-      issuerParticipantId,
-      ecosystemId: link.ecosystemId,
-      participantId: link.participantId,
+      ecsSchemaVersion: credential.ecsSchemaVersion ?? 'v4',
+      credentialSchemaId: credential.credentialSchemaId ?? 0,
+      issuerParticipantId: credential.issuerParticipant?.id ?? 0,
+      ecosystemId: credential.ecosystemId ?? 0,
+      participantId: holder?.id ?? 0,
       id,
       digestJCS,
-      issuedAtTime,
-      validFrom,
-      validUntil,
-      credentialSubject: toCredentialSubject(c),
+      issuedAtTime: toIso(issuedAtTime) ?? issuedAtTime,
+      validFrom: toIso(credential.validFrom) ?? null,
+      validUntil: toIso(credential.validUntil) ?? null,
+      credentialSubject: credential.subject ?? {},
     })
   }
   return out

--- a/src/services/resolver/trust-resolve.ts
+++ b/src/services/resolver/trust-resolve.ts
@@ -1,4 +1,5 @@
 import {
+  type EcsEcosystem,
   resolveDID,
   type TrustResolution,
   TrustResolutionOutcome,
@@ -14,7 +15,7 @@ import knex from '../../common/utils/db_connection'
 import { detectStartMode } from '../../common/utils/start_mode_detector'
 import { VeranaParticipantMessageTypes } from '../../common/verana-message-types'
 import config from '../../config.json' with { type: 'json' }
-import { isEcsAllowlistEnforced } from './ecs-allowlist'
+import { getEcsEcosystems, isEcsAllowlistEnforced } from './ecs-allowlist'
 import { defaultVprRegistriesFromEnv, readBoolFromEnv } from './trust-resolve.helpers'
 import { hasAllowlistedEcsServiceCredential, resolveCorporationId } from './trust-resolve-v4.builders'
 import { attachRegistryAdapters } from './verre-registry-adapter'
@@ -77,15 +78,22 @@ export function getDeclaredPollObjectCachingRetryDays(): number | null {
 export function getVerreTrustEvaluationCallOptions(): {
   verifiablePublicRegistries: VerifiablePublicRegistry[]
   skipDigestSRICheck: boolean
+  ecsEcosystems?: EcsEcosystem[]
 } {
   const cfg = getResolverRuntimeConfig()
   const registries = attachRegistryAdapters(defaultVprRegistriesFromEnv(), {
     enabled: cfg?.useEmbeddedRegistryAdapter !== false,
   })
 
+  const allowlistedDids = getEcsEcosystems()
+  const ecsEcosystems = registries.flatMap((registry) =>
+    allowlistedDids.map((did) => ({ did, vpr: registry.scheme }))
+  )
+
   return {
     verifiablePublicRegistries: registries,
     skipDigestSRICheck: cfg?.disableDigestSriVerification === true,
+    ...(ecsEcosystems.length > 0 ? { ecsEcosystems } : {}),
   }
 }
 
@@ -498,7 +506,7 @@ export async function resolveTrustForDidAtHeight(
   blockHeight: number,
   landingHeight?: number
 ): Promise<boolean> {
-  const { verifiablePublicRegistries, skipDigestSRICheck } = getVerreTrustEvaluationCallOptions()
+  const { verifiablePublicRegistries, skipDigestSRICheck, ecsEcosystems } = getVerreTrustEvaluationCallOptions()
   const cfg = getResolverRuntimeConfig()
   const retryDays = Number(cfg?.pollObjectCachingRetryDays ?? 0) || 0
   const resourceId = `${did}@${blockHeight}`
@@ -511,9 +519,11 @@ export async function resolveTrustForDidAtHeight(
     const result = (await resolveDID(did, {
       verifiablePublicRegistries,
       skipDigestSRICheck,
+      ecsEcosystems,
     })) as TrustResolution
 
-    // WL-ECS is not enforced by verre; drop the verdict until it is (see verre ResolverConfig.ecsEcosystems).
+    // verre enforces WL-ECS through ecsEcosystems, but only when a registry adapter resolves the
+    // schema's Ecosystem; this keeps the verdict correct when it cannot.
     if (isEcsAllowlistEnforced() && result.verified && !(await hasAllowlistedEcsServiceCredential(result))) {
       result.verified = false
       result.outcome = TrustResolutionOutcome.NOT_TRUSTED

--- a/src/services/resolver/trust-resolve.ts
+++ b/src/services/resolver/trust-resolve.ts
@@ -86,9 +86,7 @@ export function getVerreTrustEvaluationCallOptions(): {
   })
 
   const allowlistedDids = getEcsEcosystems()
-  const ecsEcosystems = registries.flatMap((registry) =>
-    allowlistedDids.map((did) => ({ did, vpr: registry.scheme }))
-  )
+  const ecsEcosystems = registries.flatMap((registry) => allowlistedDids.map((did) => ({ did, vpr: registry.scheme })))
 
   return {
     verifiablePublicRegistries: registries,

--- a/src/services/resolver/verre-registry-adapter.ts
+++ b/src/services/resolver/verre-registry-adapter.ts
@@ -130,9 +130,7 @@ class IndexerRegistryAdapter implements IRegistryAdapter {
     const row = (await knex('digests')
       .select('created', 'height')
       .whereIn('digest', anchoredDigestForms(digestJCS))
-      .first()) as
-      | { created?: Date | string | null; height?: number | null }
-      | undefined
+      .first()) as { created?: Date | string | null; height?: number | null } | undefined
     const created = toIso(row?.created)
     if (!created) return undefined
     return { created, height: row?.height != null ? Number(row.height) : undefined }

--- a/src/services/resolver/verre-registry-adapter.ts
+++ b/src/services/resolver/verre-registry-adapter.ts
@@ -28,6 +28,12 @@ function asSchemaJsonString(value: unknown): string {
   return JSON.stringify(value ?? {})
 }
 
+const SRI_DIGEST_ALGORITHMS = ['sha384', 'sha512'] as const
+
+export function anchoredDigestForms(digestJCS: string): string[] {
+  return [digestJCS, ...SRI_DIGEST_ALGORITHMS.map((algorithm) => `${algorithm}-${digestJCS}`)]
+}
+
 function positiveInt(value: unknown): number | null {
   const n = Number(value)
   if (!Number.isInteger(n) || n <= 0) return null
@@ -121,7 +127,10 @@ class IndexerRegistryAdapter implements IRegistryAdapter {
 
   async fetchDigest(digestJCS: string): Promise<{ created: string; height?: number } | undefined> {
     if (!digestJCS) return undefined
-    const row = (await knex('digests').select('created', 'height').where({ digest: digestJCS }).first()) as
+    const row = (await knex('digests')
+      .select('created', 'height')
+      .whereIn('digest', anchoredDigestForms(digestJCS))
+      .first()) as
       | { created?: Date | string | null; height?: number | null }
       | undefined
     const created = toIso(row?.created)

--- a/src/services/resolver/verre-registry-adapter.ts
+++ b/src/services/resolver/verre-registry-adapter.ts
@@ -28,12 +28,6 @@ function asSchemaJsonString(value: unknown): string {
   return JSON.stringify(value ?? {})
 }
 
-const SRI_DIGEST_ALGORITHMS = ['sha384', 'sha512'] as const
-
-export function anchoredDigestForms(digestJCS: string): string[] {
-  return [digestJCS, ...SRI_DIGEST_ALGORITHMS.map((algorithm) => `${algorithm}-${digestJCS}`)]
-}
-
 function positiveInt(value: unknown): number | null {
   const n = Number(value)
   if (!Number.isInteger(n) || n <= 0) return null
@@ -127,10 +121,9 @@ class IndexerRegistryAdapter implements IRegistryAdapter {
 
   async fetchDigest(digestJCS: string): Promise<{ created: string; height?: number } | undefined> {
     if (!digestJCS) return undefined
-    const row = (await knex('digests')
-      .select('created', 'height')
-      .whereIn('digest', anchoredDigestForms(digestJCS))
-      .first()) as { created?: Date | string | null; height?: number | null } | undefined
+    const row = (await knex('digests').select('created', 'height').where({ digest: digestJCS }).first()) as
+      | { created?: Date | string | null; height?: number | null }
+      | undefined
     const created = toIso(row?.created)
     if (!created) return undefined
     return { created, height: row?.height != null ? Number(row.height) : undefined }

--- a/test/unit/services/resolver/trust-resolve-v4.builders.spec.ts
+++ b/test/unit/services/resolver/trust-resolve-v4.builders.spec.ts
@@ -219,121 +219,82 @@ describe('buildPresentations', () => {
 })
 
 describe('buildEcsCredentials', () => {
-  const rawVc = {
+  // verre >= 0.4.0-dev.2 resolves the ECS classification, the anchored digest and the VPR ids,
+  // so the builder only reshapes what the resolution already carries.
+  const service = {
+    ecs: 'ecs-service',
     id: 'urn:uuid:service-vc-1',
+    issuer: 'did:example:org',
+    subject: { id: 'did:example:sub', name: 'Gov ID issuer', type: 'VerifiableService' },
     validFrom: '2026-05-28T13:35:24.887Z',
     validUntil: '2036-05-25T13:35:24.887Z',
-    credentialSubject: { id: 'did:example:sub', name: 'Gov ID issuer', type: 'VerifiableService' },
-  }
-  const service = {
-    schemaType: 'ecs-service',
-    id: 'did:example:sub',
-    issuer: 'did:example:org',
-    raw: rawVc,
-    validFrom: rawVc.validFrom,
-    validUntil: rawVc.validUntil,
+    digestJCS: 'q2VwbGFjZWRkaWdlc3Q=',
+    issuedAtTime: '2026-02-10T09:15:00Z',
+    credentialSchemaId: 1,
+    ecosystemId: 9,
+    ecsSchemaVersion: 'v4',
+    issuerParticipant: { id: 601, role: 'ISSUER' },
+    subjectParticipants: [{ id: 501, role: 'HOLDER' }],
+    raw: {},
   }
 
-  beforeEach(() => {
-    for (const k of Object.keys(tableRows)) delete tableRows[k]
-    tableRows.participants = [
-      { id: 501, schema_id: 1, did: 'did:example:sub', role: 'HOLDER' },
-      { id: 502, schema_id: 2, did: 'did:example:org', role: 'HOLDER' },
-    ]
-    tableRows.credential_schemas = [
-      {
-        id: 1,
-        ecosystem_id: 9,
-        json_schema: { title: 'ServiceCredential', $id: 'vpr:verana:net/cs/v1/js/1' },
-        digest_algorithm: 'sha384',
-      },
-      {
-        id: 2,
-        ecosystem_id: 9,
-        json_schema: { title: 'OrganizationCredential', $id: 'vpr:verana:net/cs/v1/js/2' },
-        digest_algorithm: 'sha384',
-      },
-    ]
-    tableRows.digests = [{ created: '2026-02-10T09:15:00Z' }]
-  })
-
-  it('emits id/digestJCS/issuedAtTime and resolves stable ids from participants/schemas', async () => {
+  it('reshapes the resolved credential into an ecsCredentials entry', async () => {
     const out = await buildEcsCredentials({ service })
     expect(out).toHaveLength(1)
     expect(out[0]).toMatchObject({
       ecsSchema: 'ServiceCredential',
-      ecsSchemaVersion: 'v1',
+      ecsSchemaVersion: 'v4',
       credentialSchemaId: 1,
       ecosystemId: 9,
+      issuerParticipantId: 601,
       participantId: 501,
       id: 'urn:uuid:service-vc-1',
+      digestJCS: 'q2VwbGFjZWRkaWdlc3Q=',
       issuedAtTime: '2026-02-10T09:15:00.000Z',
       validFrom: '2026-05-28T13:35:24.887Z',
       validUntil: '2036-05-25T13:35:24.887Z',
       credentialSubject: { id: 'did:example:sub', name: 'Gov ID issuer', type: 'VerifiableService' },
     })
-    expect(out[0].digestJCS).toBe('q2VwbGFjZWRkaWdlc3Q=')
-    expect(out[0].credentialSubject).not.toHaveProperty('schemaType')
-    expect(out[0].credentialSubject).not.toHaveProperty('raw')
   })
 
-  it('excludes a credential whose recomputed digest has no ledger entry', async () => {
-    tableRows.digests = []
-    expect(await buildEcsCredentials({ service })).toEqual([])
+  it('excludes a credential with no anchored digest', async () => {
+    expect(await buildEcsCredentials({ service: { ...service, digestJCS: undefined } })).toEqual([])
+    expect(await buildEcsCredentials({ service: { ...service, issuedAtTime: undefined } })).toEqual([])
   })
 
   it('excludes a credential with no VC id', async () => {
-    const { raw, ...noRaw } = service
-    expect(await buildEcsCredentials({ service: noRaw })).toEqual([])
+    expect(await buildEcsCredentials({ service: { ...service, id: '' } })).toEqual([])
   })
 
-  it('excludes same-response duplicates by id', async () => {
-    const serviceProvider = {
-      schemaType: 'ecs-org',
-      id: 'did:example:org',
-      issuer: 'did:example:org',
-      raw: { ...rawVc },
-      validFrom: rawVc.validFrom,
-      validUntil: rawVc.validUntil,
-    }
-    const out = await buildEcsCredentials({ service, serviceProvider })
-    expect(out).toHaveLength(1)
-    expect(out[0].id).toBe('urn:uuid:service-vc-1')
-  })
+  it('excludes same-response duplicates by id and by digestJCS', async () => {
+    const byId = await buildEcsCredentials({ service, serviceProvider: { ...service, ecs: 'ecs-org' } })
+    expect(byId).toHaveLength(1)
 
-  it('mirrors the VC body validity window from the flattened credential', async () => {
-    const out = await buildEcsCredentials({
-      service: { ...service, validFrom: '2010-01-01T19:23:24Z', validUntil: '2030-01-01T19:23:24Z' },
+    const byDigest = await buildEcsCredentials({
+      service,
+      serviceProvider: { ...service, ecs: 'ecs-org', id: 'urn:uuid:other-vc' },
     })
-    expect(out[0]).toMatchObject({ validFrom: '2010-01-01T19:23:24.000Z', validUntil: '2030-01-01T19:23:24.000Z' })
+    expect(byDigest).toHaveLength(1)
   })
 
-  it('falls back to the raw VC body for the validity window', async () => {
+  it('emits both entries when they are distinct credentials', async () => {
     const out = await buildEcsCredentials({
-      service: {
-        ...service,
-        validFrom: undefined,
-        validUntil: undefined,
-        raw: {
-          id: 'urn:uuid:service-vc-2',
-          issuanceDate: '2011-02-03T00:00:00Z',
-          expirationDate: '2031-02-03T00:00:00Z',
-        },
-      },
+      service,
+      serviceProvider: { ...service, ecs: 'ecs-org', id: 'urn:uuid:org-vc-1', digestJCS: 'b3RoZXJkaWdlc3Q=' },
     })
-    expect(out[0]).toMatchObject({ validFrom: '2011-02-03T00:00:00.000Z', validUntil: '2031-02-03T00:00:00.000Z' })
+    expect(out.map((entry) => entry.ecsSchema)).toEqual(['ServiceCredential', 'OrganizationCredential'])
   })
 
-  it('emits null validFrom/validUntil when the VC body declares no validity window', async () => {
+  it('emits null validFrom/validUntil when the credential declares no validity window', async () => {
     const out = await buildEcsCredentials({
-      service: { ...service, validFrom: undefined, validUntil: undefined, raw: { id: 'urn:uuid:service-vc-3' } },
+      service: { ...service, validFrom: undefined, validUntil: undefined },
     })
     expect(out[0].validFrom).toBeNull()
     expect(out[0].validUntil).toBeNull()
   })
 
-  it('ignores non-ECS resolutions', async () => {
-    expect(await buildEcsCredentials({ service: { schemaType: 'unknown', id: 'did:x' } })).toEqual([])
+  it('ignores resolutions with no ECS classification', async () => {
+    expect(await buildEcsCredentials({ service: { ...service, ecs: null } })).toEqual([])
     expect(await buildEcsCredentials({ error: true })).toEqual([])
   })
 })

--- a/test/unit/services/resolver/trust-resolve-v4.builders.spec.ts
+++ b/test/unit/services/resolver/trust-resolve-v4.builders.spec.ts
@@ -219,8 +219,6 @@ describe('buildPresentations', () => {
 })
 
 describe('buildEcsCredentials', () => {
-  // verre >= 0.4.0-dev.2 resolves the ECS classification, the anchored digest and the VPR ids,
-  // so the builder only reshapes what the resolution already carries.
   const service = {
     ecs: 'ecs-service',
     id: 'urn:uuid:service-vc-1',

--- a/test/unit/services/resolver/trust_resolve_late_attribution.spec.ts
+++ b/test/unit/services/resolver/trust_resolve_late_attribution.spec.ts
@@ -40,6 +40,7 @@ jest.mock('../../../../src/common/utils/start_mode_detector', () => ({
 jest.mock('../../../../src/services/resolver/ecs-allowlist', () => ({
   __esModule: true,
   isEcsAllowlistEnforced: () => false,
+  getEcsEcosystems: () => [],
 }))
 
 jest.mock('../../../../src/services/resolver/trust-resolve-v4.builders', () => ({

--- a/test/unit/services/resolver/trust_resolve_triggers_cascade.spec.ts
+++ b/test/unit/services/resolver/trust_resolve_triggers_cascade.spec.ts
@@ -36,6 +36,7 @@ jest.mock('../../../../src/common/utils/start_mode_detector', () => ({
 jest.mock('../../../../src/services/resolver/ecs-allowlist', () => ({
   __esModule: true,
   isEcsAllowlistEnforced: () => false,
+  getEcsEcosystems: () => [],
 }))
 
 jest.mock('../../../../src/services/resolver/trust-resolve-v4.builders', () => ({


### PR DESCRIPTION
# Changes
- Bump `@verana-labs/verre`.
- `buildEcsCredentials` now reshapes `ResolvedCredential` (`ecs`, `digestJCS`, `issuedAtTime`, `credentialSchemaId`, `ecosystemId`, `ecsSchemaVersion`, `issuerParticipant`, `subjectParticipants`) instead of recomputing it; drops the schema/participant/digest lookups.
- Enforce WL-ECS through verre's `ecsEcosystems` instead of the local ecosystem check.
- Dedup `ecsCredentials[]` by both `id` and `digestJCS`.
- Fix the digest lookup: the ledger anchors an SRI string while verre looks up the bare `digestJCS`, so no anchored digest was ever found.
- Update the `buildEcsCredentials` unit tests to the new shape.
