### PR TITLE
fix: stop overwriting ledger op_state and derive ACTIVE without effective_from

### DIFF
--- a/src/modules/pp-height-sync/pp_height_sync_service.ts
+++ b/src/modules/pp-height-sync/pp_height_sync_service.ts
@@ -10,6 +10,12 @@ import {
 const PARTICIPANT_INGEST_SERVICE = 'participantIngest'
 const PARTICIPANT_MULTI_HEIGHT_WINDOW = 3
 
+export type ParticipantHeightSyncResult = {
+  attempted: number
+  synced: number
+  syncedIds: number[]
+}
+
 type ParticipantHeightSyncLogger = {
   info?: (message: string) => void
   warn?: (message: string) => void
@@ -28,10 +34,12 @@ function getParticipantHeightSyncLogger(broker: ServiceBroker): ParticipantHeigh
 export async function runHeightSyncParticipant(
   broker: ServiceBroker,
   messages: ParticipantMessagePayload[]
-): Promise<void> {
-  if (!Array.isArray(messages) || messages.length === 0) return
+): Promise<ParticipantHeightSyncResult> {
+  const result: ParticipantHeightSyncResult = { attempted: 0, synced: 0, syncedIds: [] }
+  if (!Array.isArray(messages) || messages.length === 0) return result
 
   const logger = getParticipantHeightSyncLogger(broker)
+  const syncedIds = new Set<number>()
 
   for (const msg of messages) {
     const blockHeight = Number(msg.height || 0)
@@ -41,6 +49,7 @@ export async function runHeightSyncParticipant(
 
     const participantIds = extractImpactedParticipantIds(msg)
     const sessionIds = extractImpactedSessionIds(msg)
+    result.attempted += participantIds.length
     if (participantIds.length === 0 && sessionIds.length === 0) {
       logger.warn?.(
         `[PP Height Sync] No impacted participant/session IDs resolved from message/events; skipping txHash=${msg.txHash || 'unknown'} at block=${blockHeight}`
@@ -62,6 +71,10 @@ export async function runHeightSyncParticipant(
         txHash: msg.txHash,
         msgType: msg.type,
       })) as any
+
+      if (syncResult?.success === true) {
+        syncedIds.add(participantId)
+      }
 
       const immediateCompare = (await broker.call(`${PARTICIPANT_INGEST_SERVICE}.compareParticipantWithLedger`, {
         participantId,
@@ -137,4 +150,8 @@ export async function runHeightSyncParticipant(
       }
     }
   }
+
+  result.syncedIds = [...syncedIds]
+  result.synced = result.syncedIds.length
+  return result
 }

--- a/src/services/crawl-pp/pp_apis.service.ts
+++ b/src/services/crawl-pp/pp_apis.service.ts
@@ -21,10 +21,12 @@ import { compareById, paginateActivityItems, parseCorporationListPagination } fr
 import { resolveCorporationIdByAddress } from '../crawl-co/corporation_resolve'
 import { enrichTrustDataDeep, parseTrustDataMode, type TrustDataMode } from '../resolver/trust-data-enrichment'
 import {
+  applyActiveEffectiveFromFilter,
   calculateCorporationAvailableActions,
   calculateParticipantState,
   calculateValidatorAvailableActions,
   mapParticipantActionsToVprMessages,
+  ONBOARDING_PENDING_OP_STATES,
   type ParticipantState,
   PENDING_FLAT_VALIDATOR_PARENT_TYPES,
   pendingFlatMatchesOpPendingWithEligibleParticipantState,
@@ -521,6 +523,9 @@ export default class ParticipantAPIService extends BullableService {
     const notRevokedAsOfNow = (qb: any) => {
       qb.whereNull(col('revoked')).orWhere(col('revoked'), '>=', nowIso)
     }
+    const onboardingPending = (qb: any) => {
+      qb.whereIn(col('op_state'), ONBOARDING_PENDING_OP_STATES)
+    }
 
     if (participantState === 'REPAID') {
       query.whereNotNull(col('repaid'))
@@ -554,7 +559,7 @@ export default class ParticipantAPIService extends BullableService {
         baseNotRepaidSlashed(qb)
         qb.where(notRevokedAsOfNow)
         qb.where((q: any) => q.whereNull(col('effective_until')).orWhere(col('effective_until'), '>=', nowIso))
-        qb.whereNotNull(col('effective_from')).andWhere(col('effective_from'), '<=', nowIso)
+        applyActiveEffectiveFromFilter(qb, nowIso, col)
       })
       return { pushedDown: true }
     }
@@ -574,7 +579,7 @@ export default class ParticipantAPIService extends BullableService {
         baseNotRepaidSlashed(qb)
         qb.where(notRevokedAsOfNow)
         qb.where((q: any) => q.whereNull(col('effective_until')).orWhere(col('effective_until'), '>=', nowIso))
-        qb.whereNull(col('effective_from'))
+        qb.whereNull(col('effective_from')).andWhere(onboardingPending)
       })
       return { pushedDown: true }
     }

--- a/src/services/crawl-pp/pp_database.service.ts
+++ b/src/services/crawl-pp/pp_database.service.ts
@@ -1770,7 +1770,6 @@ export default class ParticipantIngestService extends Service {
       // Calculate expire_soon for the new participant
       const newParticipantData = {
         role: participantType,
-        op_state: 'VALIDATION_STATE_UNSPECIFIED',
         effective_from: effectiveFrom,
         effective_until: effectiveUntil,
         revoked: null,
@@ -1791,7 +1790,6 @@ export default class ParticipantIngestService extends Service {
       const insertData: any = {
         schema_id: schemaId,
         role: participantType,
-        op_state: 'VALIDATION_STATE_UNSPECIFIED',
         did: msg.did,
         corporation_id: corporationId,
         effective_from: effectiveFrom,
@@ -1931,7 +1929,6 @@ export default class ParticipantIngestService extends Service {
       // Calculate expire_soon for the new participant
       const newParticipantData = {
         role,
-        op_state: 'VALIDATION_STATE_UNSPECIFIED',
         effective_from: effectiveFrom,
         effective_until: effectiveUntil,
         revoked: null,
@@ -1951,7 +1948,6 @@ export default class ParticipantIngestService extends Service {
       const insertData: any = {
         schema_id: schemaId,
         role,
-        op_state: 'VALIDATION_STATE_UNSPECIFIED',
         did: msg.did,
         corporation_id: corporationId,
         effective_from: effectiveFrom,

--- a/src/services/crawl-pp/pp_processor.service.ts
+++ b/src/services/crawl-pp/pp_processor.service.ts
@@ -85,15 +85,14 @@ export default class ParticipantProcessorService extends BullableService {
         )
         const useHeightSyncParticipant = process.env.USE_HEIGHT_SYNC_PARTICIPANT !== 'false'
         if (useHeightSyncParticipant) {
-          const res = await runHeightSyncParticipant(this.broker, [msg])
-          const synced = (res as any)?.synced
-          const attempted = (res as any)?.attempted
+          const { synced, attempted, syncedIds } = await runHeightSyncParticipant(this.broker, [msg])
+          const targetParticipantId = extractStartParticipantOpNewParticipantId(msg as ParticipantMessagePayload)
 
-          if (typeof synced === 'number' && synced > 0) {
+          if (targetParticipantId != null && syncedIds.includes(targetParticipantId)) {
             continue
           }
           this.logger.warn(
-            `[participant] Height-sync enabled but synced 0/${typeof attempted === 'number' ? attempted : '?'}. Falling back to direct message handlers for type=${msg.type} height=${msg.height} txHash=${msg.txHash ?? 'unknown'}`
+            `[participant] Height-sync synced ${synced}/${attempted} but did not cover target participant ${targetParticipantId ?? 'unknown'}. Falling back to direct message handlers for type=${msg.type} height=${msg.height} txHash=${msg.txHash ?? 'unknown'}`
           )
         }
 

--- a/src/services/crawl-pp/pp_state_utils.ts
+++ b/src/services/crawl-pp/pp_state_utils.ts
@@ -112,8 +112,9 @@ export function calculateParticipantState(participant: ParticipantData, now: Dat
 
 export const ONBOARDING_PENDING_OP_STATES: readonly string[] = ['PENDING', 'TERMINATED']
 
-export function isOnboardingPending(opState?: ValidationState | string | null): boolean {
-  return ONBOARDING_PENDING_OP_STATES.includes(String(opState ?? '').toUpperCase())
+export function isOnboardingPending(opState?: ValidationState | string | number | null): boolean {
+  const normalized = normalizeOpState(opState)
+  return normalized !== null && ONBOARDING_PENDING_OP_STATES.includes(normalized)
 }
 
 export function applyActiveEffectiveFromFilter(

--- a/src/services/crawl-pp/pp_state_utils.ts
+++ b/src/services/crawl-pp/pp_state_utils.ts
@@ -107,7 +107,33 @@ export function calculateParticipantState(participant: ParticipantData, now: Dat
     }
   }
 
-  return 'INACTIVE'
+  return isOnboardingPending(participant.op_state) ? 'INACTIVE' : 'ACTIVE'
+}
+
+export const ONBOARDING_PENDING_OP_STATES: readonly string[] = ['PENDING', 'TERMINATED']
+
+export function isOnboardingPending(opState?: ValidationState | string | null): boolean {
+  return ONBOARDING_PENDING_OP_STATES.includes(String(opState ?? '').toUpperCase())
+}
+
+export function applyActiveEffectiveFromFilter(
+  query: any,
+  nowIso: string,
+  col: (name: string) => string = (name) => name
+): void {
+  query.where((qb: any) =>
+    qb
+      .where((started: any) =>
+        started.whereNotNull(col('effective_from')).andWhere(col('effective_from'), '<=', nowIso)
+      )
+      .orWhere((neverScheduled: any) =>
+        neverScheduled
+          .whereNull(col('effective_from'))
+          .andWhere((onboarded: any) =>
+            onboarded.whereNull(col('op_state')).orWhereNotIn(col('op_state'), ONBOARDING_PENDING_OP_STATES)
+          )
+      )
+  )
 }
 
 function normalizeSchemaMode(mode?: string): SchemaMode {

--- a/src/services/metrics/metrics_api.service.ts
+++ b/src/services/metrics/metrics_api.service.ts
@@ -6,6 +6,7 @@ import ApiResponder from '../../common/utils/apiResponse'
 import { getBlockChainTimeAsOf } from '../../common/utils/block_time'
 import { getBlockHeight, hasBlockHeight } from '../../common/utils/blockHeight'
 import knex from '../../common/utils/db_connection'
+import { applyActiveEffectiveFromFilter } from '../crawl-pp/pp_state_utils'
 import { computeGlobalMetrics, computeTotalLockedTrustDepositWeight } from './metrics_helper'
 
 const IS_PG_CLIENT = String((knex as any)?.client?.config?.client || '').includes('pg')
@@ -459,8 +460,7 @@ export default class MetricsApiService extends BaseService {
         .whereNull('repaid')
         .whereNull('slashed')
         .where((qb) => qb.whereNull('revoked').orWhere('revoked', '>=', nowIso))
-        .whereNotNull('effective_from')
-        .where('effective_from', '<=', nowIso)
+        .modify((qb) => applyActiveEffectiveFromFilter(qb, nowIso))
         .where((qb) => qb.whereNull('effective_until').orWhere('effective_until', '>=', nowIso))
 
       let participantsAgg: any = null

--- a/src/services/metrics/metrics_helper.ts
+++ b/src/services/metrics/metrics_helper.ts
@@ -3,7 +3,7 @@ import { getBlockChainTimeAsOf } from '../../common/utils/block_time'
 import knex from '../../common/utils/db_connection'
 import { resolveParticipantsParticipantColumn } from '../../common/utils/installed_table_columns'
 import { calculateCredentialSchemaStats, calculateCredentialSchemaStatsBatch } from '../crawl-cs/cs_stats'
-import { calculateParticipantState } from '../crawl-pp/pp_state_utils'
+import { applyActiveEffectiveFromFilter, calculateParticipantState } from '../crawl-pp/pp_state_utils'
 
 function isMetricsPgClient(db: Knex): boolean {
   return String((db as any)?.client?.config?.client || '').includes('pg')
@@ -367,9 +367,7 @@ export async function computeGlobalMetrics(blockHeight?: number) {
         .andWhere(function () {
           this.whereNull('revoked').orWhere('revoked', '>=', nowIso)
         })
-        .andWhere(function () {
-          this.whereNotNull('effective_from').andWhere('effective_from', '<=', nowIso)
-        })
+        .modify((qb) => applyActiveEffectiveFromFilter(qb, nowIso))
         .andWhere(function () {
           this.whereNull('effective_until').orWhere('effective_until', '>=', nowIso)
         })

--- a/test/unit/services/crawl-pp/pp_active_window_filter.spec.ts
+++ b/test/unit/services/crawl-pp/pp_active_window_filter.spec.ts
@@ -26,5 +26,4 @@ describe('🧪 applyActiveEffectiveFromFilter', () => {
   it('honours the table prefix used by history queries', () => {
     expect(sqlFor((name) => `ph.${name}`)).toContain('"ph"."effective_from"')
   })
-
 })

--- a/test/unit/services/crawl-pp/pp_active_window_filter.spec.ts
+++ b/test/unit/services/crawl-pp/pp_active_window_filter.spec.ts
@@ -1,0 +1,30 @@
+import createKnex from 'knex'
+import { applyActiveEffectiveFromFilter } from '../../../../src/services/crawl-pp/pp_state_utils'
+
+describe('🧪 applyActiveEffectiveFromFilter', () => {
+  const NOW_ISO = '2025-01-10T00:00:00.000Z'
+  const qb = createKnex({ client: 'pg' })
+
+  afterAll(async () => {
+    await qb.destroy()
+  })
+
+  const sqlFor = (col?: (name: string) => string) => {
+    const query = qb('participants').select('id')
+    applyActiveEffectiveFromFilter(query, NOW_ISO, col)
+    return query.toQuery()
+  }
+
+  it('matches rows already started and rows that never scheduled an effective_from', () => {
+    const sql = sqlFor()
+    expect(sql).toContain('"effective_from" is not null')
+    expect(sql).toContain('"effective_from" is null')
+    expect(sql).toContain('"op_state" is null')
+    expect(sql).toContain("not in ('PENDING', 'TERMINATED')")
+  })
+
+  it('honours the table prefix used by history queries', () => {
+    expect(sqlFor((name) => `ph.${name}`)).toContain('"ph"."effective_from"')
+  })
+
+})

--- a/test/unit/services/crawl-pp/pp_processor_service.spec.ts
+++ b/test/unit/services/crawl-pp/pp_processor_service.spec.ts
@@ -203,4 +203,56 @@ describe('🧪 ParticipantProcessorService', () => {
     ;(fetchParticipantSession as jest.Mock).mockReset()
     process.env.USE_HEIGHT_SYNC_PARTICIPANT = 'false'
   })
+
+  it('✅ skips the legacy handler when height-sync covered the target participant', async () => {
+    process.env.USE_HEIGHT_SYNC_PARTICIPANT = 'true'
+    spyCreateParticipant.mockClear()
+    ;(fetchParticipant as jest.Mock).mockResolvedValue({ participant: { id: 101, schema_id: 7, role: 'ISSUER' } })
+    ;(fetchParticipantSession as jest.Mock).mockResolvedValue(null)
+
+    await broker.call(`v1.${SERVICE.V1.ParticipantProcessorService.key}.handleParticipantMessages`, {
+      participantMessages: [
+        {
+          type: ParticipantMessageTypes.SelfCreateParticipant,
+          content: { id: 101 },
+          height: 123,
+          timestamp: '2026-03-01T00:00:00Z',
+          txHash: '0xabc',
+          txEvents: [],
+        },
+      ],
+    })
+
+    expect(syncParticipantFromLedgerSpy).toHaveBeenCalled()
+    expect(spyCreateParticipant).not.toHaveBeenCalled()
+    ;(fetchParticipant as jest.Mock).mockReset()
+    ;(fetchParticipantSession as jest.Mock).mockReset()
+    process.env.USE_HEIGHT_SYNC_PARTICIPANT = 'false'
+  })
+
+  it('✅ falls back to the legacy handler when height-sync only covered the validator', async () => {
+    process.env.USE_HEIGHT_SYNC_PARTICIPANT = 'true'
+    spyCreateParticipant.mockClear()
+    ;(fetchParticipant as jest.Mock).mockResolvedValue({ participant: { id: 5, schema_id: 7, role: 'ECOSYSTEM' } })
+    ;(fetchParticipantSession as jest.Mock).mockResolvedValue(null)
+
+    await broker.call(`v1.${SERVICE.V1.ParticipantProcessorService.key}.handleParticipantMessages`, {
+      participantMessages: [
+        {
+          type: ParticipantMessageTypes.SelfCreateParticipant,
+          content: { validator_participant_id: 5, did: 'did:example:no-id' },
+          height: 123,
+          timestamp: '2026-03-01T00:00:00Z',
+          txHash: '0xabc',
+          txEvents: [],
+        },
+      ],
+    })
+
+    expect(syncParticipantFromLedgerSpy).toHaveBeenCalled()
+    expect(spyCreateParticipant).toHaveBeenCalled()
+    ;(fetchParticipant as jest.Mock).mockReset()
+    ;(fetchParticipantSession as jest.Mock).mockReset()
+    process.env.USE_HEIGHT_SYNC_PARTICIPANT = 'false'
+  })
 })

--- a/test/unit/services/crawl-pp/pp_state_utils.spec.ts
+++ b/test/unit/services/crawl-pp/pp_state_utils.spec.ts
@@ -108,12 +108,18 @@ describe('🧪 pp_state_utils', () => {
       expect(calculateParticipantState(participant, NOW)).toBe('FUTURE')
     })
 
-    it('returns INACTIVE when no timestamps are set', () => {
-      const participant: ParticipantData = {
-        ...baseParticipant,
-      }
+    it('returns ACTIVE when effective_from is null and no onboarding process is pending', () => {
+      expect(calculateParticipantState({ ...baseParticipant }, NOW)).toBe('ACTIVE')
+      expect(calculateParticipantState({ ...baseParticipant, op_state: null }, NOW)).toBe('ACTIVE')
+      expect(calculateParticipantState({ ...baseParticipant, op_state: 'VALIDATED' }, NOW)).toBe('ACTIVE')
+      expect(
+        calculateParticipantState({ ...baseParticipant, op_state: 'VALIDATION_STATE_UNSPECIFIED' }, NOW)
+      ).toBe('ACTIVE')
+    })
 
-      expect(calculateParticipantState(participant, NOW)).toBe('INACTIVE')
+    it('returns INACTIVE when effective_from is null and the onboarding process is PENDING or TERMINATED', () => {
+      expect(calculateParticipantState({ ...baseParticipant, op_state: 'PENDING' }, NOW)).toBe('INACTIVE')
+      expect(calculateParticipantState({ ...baseParticipant, op_state: 'TERMINATED' }, NOW)).toBe('INACTIVE')
     })
   })
 

--- a/test/unit/services/crawl-pp/pp_state_utils.spec.ts
+++ b/test/unit/services/crawl-pp/pp_state_utils.spec.ts
@@ -112,9 +112,9 @@ describe('🧪 pp_state_utils', () => {
       expect(calculateParticipantState({ ...baseParticipant }, NOW)).toBe('ACTIVE')
       expect(calculateParticipantState({ ...baseParticipant, op_state: null }, NOW)).toBe('ACTIVE')
       expect(calculateParticipantState({ ...baseParticipant, op_state: 'VALIDATED' }, NOW)).toBe('ACTIVE')
-      expect(
-        calculateParticipantState({ ...baseParticipant, op_state: 'VALIDATION_STATE_UNSPECIFIED' }, NOW)
-      ).toBe('ACTIVE')
+      expect(calculateParticipantState({ ...baseParticipant, op_state: 'VALIDATION_STATE_UNSPECIFIED' }, NOW)).toBe(
+        'ACTIVE'
+      )
     })
 
     it('returns INACTIVE when effective_from is null and the onboarding process is PENDING or TERMINATED', () => {


### PR DESCRIPTION
## Changes

- `runHeightSyncParticipant` returns `{ attempted, synced, syncedIds }` instead of `void`. The processor
  now skips the legacy handler only when the message's **target** participant was actually synced from the
  ledger; not merely when *something* was synced, which would strand new participants whose id only
  arrives via tx events.
- Drop the hardcoded `op_state: 'VALIDATION_STATE_UNSPECIFIED'` from `handleCreateRootParticipant` and
  `handleCreateParticipant`. The column is nullable with no default, so the API response is unchanged.
- `participant_state`: `effective_from = null` now derives `ACTIVE` unless `op_state` is `PENDING` /
  `TERMINATED`, per rules 6 and 7 of Participant State Semantics.
- Same rule applied to the `participant_state` SQL pushdown and to the two active-participant metrics
  queries, extracted into `applyActiveEffectiveFromFilter` so filter and computed field cannot drift apart.


## Note

The report was right about the symptom and about the hardcoded value reaching the DB, but the cause was
a different one. Those handlers are not the ingestion path — they are a fallback. `runHeightSyncParticipant`
was declared `Promise<void>` while the caller read `res.synced`, so the guard never fired and the legacy
handler always ran **after** the correct ledger sync, overwriting `op_state`. The proposed fix
(hardcoding `'VALIDATED'`) would have kept overwriting the ledger value in every other case, and would not
have changed the reported `INACTIVE` at all: `participant_state` is computed at read time and never looked
at `op_state` — it returned `INACTIVE` purely because `effective_from` was null.