### PR TITLE
fix: anchor participant_state evaluation to block time instead of wall clock

### DIFF
--- a/src/common/utils/block_time.ts
+++ b/src/common/utils/block_time.ts
@@ -39,3 +39,33 @@ export async function getBlockChainTimeAsOf(height: number, options?: GetBlockCh
 
   return fallback
 }
+
+export type GetLatestIndexedBlockTimeOptions = Omit<GetBlockChainTimeAsOfOptions, 'atOrBefore'>
+
+export async function getLatestIndexedBlockTime(options?: GetLatestIndexedBlockTimeOptions): Promise<Date> {
+  const db = (options?.db ?? knexDefault) as Knex
+  const logContext = options?.logContext ?? '[block_time]'
+  const fallback = options?.fallback ?? new Date()
+  const logWarn = options?.logger?.warn ?? (global as any)?.logger?.warn
+
+  try {
+    const blockRow = await db('block').select('time').orderBy('height', 'desc').first()
+    if (blockRow?.time) {
+      const t = new Date(blockRow.time)
+      if (!Number.isNaN(t.getTime())) return t
+      logWarn?.(`${logContext} latest block.time is not a valid date; using fallback time`, { raw: blockRow.time })
+    }
+  } catch (err: any) {
+    logWarn?.(`${logContext} Failed to load the latest block.time; using fallback time`, err?.message ?? err)
+  }
+
+  return fallback
+}
+
+export async function resolveEvaluationTime(
+  height: number | undefined,
+  options?: GetLatestIndexedBlockTimeOptions
+): Promise<Date> {
+  if (height === undefined) return getLatestIndexedBlockTime(options)
+  return getBlockChainTimeAsOf(height, { ...options, atOrBefore: true })
+}

--- a/src/services/crawl-co/co_stats.ts
+++ b/src/services/crawl-co/co_stats.ts
@@ -1,5 +1,5 @@
 import { BULL_JOB_NAME } from '../../common'
-import { getBlockChainTimeAsOf } from '../../common/utils/block_time'
+import { resolveEvaluationTime } from '../../common/utils/block_time'
 import knex from '../../common/utils/db_connection'
 import { Ecosystem } from '../../models/ecosystem'
 import TrustDeposit from '../../models/trust_deposit'
@@ -111,10 +111,9 @@ export async function calculateCorporationParticipantStats(
 ): Promise<CorporationParticipantStats> {
   const stats = emptyParticipantStats()
 
-  let now = new Date()
-  if (typeof blockHeight === 'number') {
-    now = await getBlockChainTimeAsOf(blockHeight, { logContext: '[co_stats]' })
-  }
+  const now = await resolveEvaluationTime(typeof blockHeight === 'number' ? blockHeight : undefined, {
+    logContext: '[co_stats]',
+  })
 
   const rows = await knex('participants').where('corporation_id', corporationId)
   for (const row of rows) {
@@ -134,10 +133,9 @@ export async function calculateCorporationParticipantStatsBatch(
   }
   if (corporationIds.length === 0) return result
 
-  let now = new Date()
-  if (typeof blockHeight === 'number') {
-    now = await getBlockChainTimeAsOf(blockHeight, { logContext: '[co_stats]' })
-  }
+  const now = await resolveEvaluationTime(typeof blockHeight === 'number' ? blockHeight : undefined, {
+    logContext: '[co_stats]',
+  })
 
   const rows = await knex('participants').whereIn('corporation_id', corporationIds)
   for (const row of rows) {

--- a/src/services/crawl-cs/cs_database.service.ts
+++ b/src/services/crawl-cs/cs_database.service.ts
@@ -4,7 +4,7 @@ import BullableService from '../../base/bullable.service'
 import { MODULE_DISPLAY_NAMES, ModulesParamsNamesTypes, SERVICE } from '../../common'
 import { buildActivityTimeline } from '../../common/utils/activity_timeline_helper'
 import ApiResponder from '../../common/utils/apiResponse'
-import { getBlockChainTimeAsOf } from '../../common/utils/block_time'
+import { getBlockChainTimeAsOf, getLatestIndexedBlockTime } from '../../common/utils/block_time'
 import { isValidISO8601UTC } from '../../common/utils/date_utils'
 import knex from '../../common/utils/db_connection'
 import {
@@ -2373,9 +2373,10 @@ export default class CredentialSchemaDatabaseService extends BullableService {
           )
 
     const participantPart = await resolveParticipantsParticipantColumn(knex)
+    const asOf = await getLatestIndexedBlockTime({ logContext: '[cs_database:participant_corporation_id]' })
     const corpRows = await knex('participants')
       .where(participantPart, corporationId)
-      .modify((qb) => applyActiveParticipantFilter(qb, new Date().toISOString()))
+      .modify((qb) => applyActiveParticipantFilter(qb, asOf.toISOString()))
       .distinct('schema_id')
     const schemaIdsFromCorp = corpRows
       .map((r: { schema_id: string }) => (r.schema_id != null ? parseFloat(r.schema_id) : null))

--- a/src/services/crawl-cs/cs_stats.ts
+++ b/src/services/crawl-cs/cs_stats.ts
@@ -1,4 +1,4 @@
-import { getBlockChainTimeAsOf } from '../../common/utils/block_time'
+import { resolveEvaluationTime } from '../../common/utils/block_time'
 import knex from '../../common/utils/db_connection'
 import { parseExactInteger } from '../../common/utils/exact_numeric_range'
 import { calculateParticipantState } from '../crawl-pp/pp_state_utils'
@@ -331,10 +331,10 @@ export async function calculateCredentialSchemaStatsBatch(
   const result = new Map<number, CredentialSchemaStats>()
   if (schemaIds.length === 0) return result
 
-  let now = new Date()
-  if (typeof blockHeight === 'number' && Number.isFinite(blockHeight) && blockHeight >= 0) {
-    now = await getBlockChainTimeAsOf(blockHeight, { logContext: '[cs_stats]' })
-  }
+  const now = await resolveEvaluationTime(
+    typeof blockHeight === 'number' && Number.isFinite(blockHeight) && blockHeight >= 0 ? blockHeight : undefined,
+    { logContext: '[cs_stats]' }
+  )
 
   let participants: any[] = []
   if (typeof blockHeight === 'number') {

--- a/src/services/crawl-ec/ec_database.service.ts
+++ b/src/services/crawl-ec/ec_database.service.ts
@@ -6,7 +6,7 @@ import BaseService from '../../base/base.service'
 import { MODULE_DISPLAY_NAMES, ModulesParamsNamesTypes, SERVICE } from '../../common'
 import { validateParticipantParam } from '../../common/utils/accountValidation'
 import ApiResponder from '../../common/utils/apiResponse'
-import { getBlockChainTimeAsOf } from '../../common/utils/block_time'
+import { getBlockChainTimeAsOf, getLatestIndexedBlockTime } from '../../common/utils/block_time'
 import knex from '../../common/utils/db_connection'
 import {
   applyExactRangeToQuery,
@@ -2222,9 +2222,10 @@ export default class EcosystemDatabaseService extends BaseService {
     const controllerIds = controllerRows.map((r: { id: number }) => r.id)
 
     const participantPart = await resolveParticipantsParticipantColumn(knex)
+    const asOf = await getLatestIndexedBlockTime({ logContext: '[ec_database:participant_corporation_id]' })
     const corpSchemaIds = await knex('participants')
       .where(participantPart, corporationId)
-      .modify((qb) => applyActiveParticipantFilter(qb, new Date().toISOString()))
+      .modify((qb) => applyActiveParticipantFilter(qb, asOf.toISOString()))
       .distinct('schema_id')
     const schemaIds = corpSchemaIds
       .map((r: { schema_id: string }) => {

--- a/src/services/crawl-pp/pp_apis.service.ts
+++ b/src/services/crawl-pp/pp_apis.service.ts
@@ -5,7 +5,7 @@ import { MODULE_DISPLAY_NAMES, ModulesParamsNamesTypes, SERVICE } from '../../co
 import { validateParticipantParam } from '../../common/utils/accountValidation'
 import { buildActivityTimeline } from '../../common/utils/activity_timeline_helper'
 import ApiResponder from '../../common/utils/apiResponse'
-import { getBlockChainTimeAsOf } from '../../common/utils/block_time'
+import { resolveEvaluationTime } from '../../common/utils/block_time'
 import { getBlockHeight, hasBlockHeight } from '../../common/utils/blockHeight'
 import { isValidISO8601UTC } from '../../common/utils/date_utils'
 import knex from '../../common/utils/db_connection'
@@ -1494,7 +1494,12 @@ export default class ParticipantAPIService extends BullableService {
 
       const blockHeight = getBlockHeight(ctx)
       const useHistoryQuery = this.shouldUseHistoryQuery(ctx, blockHeight)
-      const now = new Date().toISOString()
+      const now = (
+        await resolveEvaluationTime(useHistoryQuery ? blockHeight : undefined, {
+          logContext: '[pp_apis:listParticipants]',
+          logger: this.logger,
+        })
+      ).toISOString()
 
       const pageParsed = parseCorporationListPagination(normalizedParams)
       if (!pageParsed.ok) {
@@ -2045,6 +2050,10 @@ export default class ParticipantAPIService extends BullableService {
       }
       const trustDataMode = trustDataModeParsed.mode
       const useHistoryQuery = this.shouldUseHistoryQuery(ctx, blockHeight)
+      const evaluatedAt = await resolveEvaluationTime(useHistoryQuery ? blockHeight : undefined, {
+        logContext: '[pp_apis:getParticipant]',
+        logger: this.logger,
+      })
 
       // If AtBlockHeight is provided, query historical state
       if (useHistoryQuery && blockHeight !== undefined) {
@@ -2205,7 +2214,7 @@ export default class ParticipantAPIService extends BullableService {
         const enrichedParticipant = await this.enrichParticipantWithStateAndActions(
           historicalParticipant,
           blockHeight,
-          new Date(),
+          evaluatedAt,
           { lightweightDerivedStats: historyHasAllDerivedColumns }
         )
         const [participantWithTrustData] = await this.enrichDidItemsWithTrustData(
@@ -2231,7 +2240,7 @@ export default class ParticipantAPIService extends BullableService {
       const enrichedParticipant = await this.enrichParticipantWithStateAndActions(
         normalizedParticipant,
         blockHeight,
-        new Date(),
+        evaluatedAt,
         { lightweightDerivedStats: liveHasAllDerivedColumns }
       )
 
@@ -2344,10 +2353,10 @@ export default class ParticipantAPIService extends BullableService {
         return ApiResponder.error(ctx, `Participant not found for id(s): ${missingRootIds.join(', ')}`, 404)
       }
 
-      const evaluatedAt =
-        useHistoryQuery && blockHeight !== undefined
-          ? await getBlockChainTimeAsOf(blockHeight, { atOrBefore: true, logContext: '[pp_apis:beneficiaries]' })
-          : new Date()
+      const evaluatedAt = await resolveEvaluationTime(useHistoryQuery ? blockHeight : undefined, {
+        logContext: '[pp_apis:beneficiaries]',
+        logger: this.logger,
+      })
       const inactiveRootIds = rootIds.filter((rootId) => {
         const participant = initialMap.get(rootId)
         return (
@@ -2423,7 +2432,7 @@ export default class ParticipantAPIService extends BullableService {
       const enrichedParticipants = await this.batchEnrichParticipants(
         Array.from(foundParticipantMap.values()),
         useHistoryQuery ? blockHeight : undefined,
-        new Date(),
+        evaluatedAt,
         100
       )
 
@@ -2574,10 +2583,13 @@ export default class ParticipantAPIService extends BullableService {
       }
 
       const limit = Math.min(Math.max(p.limit || 64, 1), 1024)
-      const now = new Date()
 
       const blockHeight = getBlockHeight(ctx)
       const useHistory = this.shouldUseHistoryQuery(ctx, blockHeight)
+      const now = await resolveEvaluationTime(useHistory ? blockHeight : undefined, {
+        logContext: '[pp_apis:pendingFlat]',
+        logger: this.logger,
+      })
 
       const parentIdSet = new Set<number>()
 

--- a/src/services/metrics/metrics_helper.ts
+++ b/src/services/metrics/metrics_helper.ts
@@ -1,5 +1,5 @@
 import type { Knex } from 'knex'
-import { getBlockChainTimeAsOf } from '../../common/utils/block_time'
+import { getBlockChainTimeAsOf, getLatestIndexedBlockTime } from '../../common/utils/block_time'
 import knex from '../../common/utils/db_connection'
 import { resolveParticipantsParticipantColumn } from '../../common/utils/installed_table_columns'
 import { calculateCredentialSchemaStats, calculateCredentialSchemaStatsBatch } from '../crawl-cs/cs_stats'
@@ -357,7 +357,7 @@ export async function computeGlobalMetrics(blockHeight?: number) {
       networkSlashedAmountRepaidSum += Number(s.network_slashed_amount_repaid || 0)
     }
 
-    const nowIso = new Date().toISOString()
+    const nowIso = (await getLatestIndexedBlockTime({ logContext: '[metrics_helper]' })).toISOString()
     const participantParticipantCol = await resolveParticipantsParticipantColumn(knex)
     const activeParticipantsBase = () =>
       knex('participants')

--- a/test/unit/common/block_time.spec.ts
+++ b/test/unit/common/block_time.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from '@jest/globals'
+import type { Knex } from 'knex'
+import { getLatestIndexedBlockTime, resolveEvaluationTime } from '../../../src/common/utils/block_time'
+
+const LATEST_BLOCK_TIME = '2026-08-12T18:04:45.268Z'
+const HEIGHT_50_TIME = '2026-08-12T12:00:00.000Z'
+
+type Recorded = { orderedBy: Array<[string, string]>; wheres: Array<[string, unknown, unknown]> }
+
+function fakeDb(rowFor: (recorded: Recorded) => { time: string } | undefined): { db: Knex; recorded: Recorded } {
+  const recorded: Recorded = { orderedBy: [], wheres: [] }
+  const builder: any = {
+    select: () => builder,
+    orderBy: (column: string, direction: string) => {
+      recorded.orderedBy.push([column, direction])
+      return builder
+    },
+    where: (column: unknown, operator?: unknown, value?: unknown) => {
+      recorded.wheres.push([String(column), operator, value])
+      return builder
+    },
+    first: async () => rowFor(recorded),
+  }
+  return { db: (() => builder) as unknown as Knex, recorded }
+}
+
+describe('🧪 getLatestIndexedBlockTime', () => {
+  test('returns the time of the highest indexed block', async () => {
+    const { db, recorded } = fakeDb(() => ({ time: LATEST_BLOCK_TIME }))
+    const result = await getLatestIndexedBlockTime({ db })
+    expect(result.toISOString()).toBe(LATEST_BLOCK_TIME)
+    expect(recorded.orderedBy).toEqual([['height', 'desc']])
+    expect(recorded.wheres).toEqual([])
+  })
+
+  test('falls back when no block has been indexed yet', async () => {
+    const fallback = new Date('2020-01-01T00:00:00.000Z')
+    const { db } = fakeDb(() => undefined)
+    expect((await getLatestIndexedBlockTime({ db, fallback })).toISOString()).toBe(fallback.toISOString())
+  })
+
+  test('falls back when the stored time is not a valid date', async () => {
+    const fallback = new Date('2020-01-01T00:00:00.000Z')
+    const { db } = fakeDb(() => ({ time: 'not-a-date' }))
+    expect((await getLatestIndexedBlockTime({ db, fallback })).toISOString()).toBe(fallback.toISOString())
+  })
+})
+
+describe('🧪 resolveEvaluationTime', () => {
+  test('uses the latest indexed block when no height is requested', async () => {
+    const { db, recorded } = fakeDb(() => ({ time: LATEST_BLOCK_TIME }))
+    const result = await resolveEvaluationTime(undefined, { db })
+    expect(result.toISOString()).toBe(LATEST_BLOCK_TIME)
+    expect(recorded.wheres).toEqual([])
+  })
+
+  test('uses the requested block, matching at or before that height', async () => {
+    const { db, recorded } = fakeDb(() => ({ time: HEIGHT_50_TIME }))
+    const result = await resolveEvaluationTime(50, { db })
+    expect(result.toISOString()).toBe(HEIGHT_50_TIME)
+    expect(recorded.wheres).toEqual([['height', '<=', 50]])
+    expect(recorded.orderedBy).toEqual([['height', 'desc']])
+  })
+})


### PR DESCRIPTION
`participant_state` was evaluated against the indexer process clock. Per Participant State Semantics, `now` is "the current block, or the `At-Block-Height` block if set", so every path now resolves it from `block.time`.