### PR TITLE
feat: acknowledge subscribe with the next deliverable block

### DIFF
--- a/src/services/api/subscribe_protocol.ts
+++ b/src/services/api/subscribe_protocol.ts
@@ -72,6 +72,15 @@ export function buildReadyMessage(lastProcessedBlock: number, lastBlockTime: str
   }
 }
 
+export interface SubscribedMessage {
+  type: 'subscribed'
+  block: number
+}
+
+export function buildSubscribedMessage(lastProcessedBlock: number): SubscribedMessage {
+  return { type: 'subscribed', block: lastProcessedBlock + 1 }
+}
+
 export function buildBlockEnvelope(
   block: number,
   blockTime: string,

--- a/src/services/api/subscribe_ws_server.ts
+++ b/src/services/api/subscribe_ws_server.ts
@@ -4,7 +4,7 @@ import type { Duplex } from 'stream'
 import { WebSocket, WebSocketServer } from 'ws'
 import { indexerStatusManager } from '../manager/indexer_status.manager'
 import { createLogger, type LoggerLike, toIsoSeconds } from './api_shared'
-import { buildReadyMessage } from './subscribe_protocol'
+import { buildReadyMessage, buildSubscribedMessage } from './subscribe_protocol'
 
 export type ControlParseResult<TMessage> = { ok: true; message: TMessage } | { ok: false; error: string }
 
@@ -120,6 +120,12 @@ export abstract class BaseSubscribeServer<TControl, TState> {
     this.sendJson(ws, ready as unknown as Record<string, unknown>)
   }
 
+  private async sendSubscribed(ws: WebSocket): Promise<void> {
+    const status = await indexerStatusManager.getDetailedStatus()
+    const message = buildSubscribedMessage(status.lastProcessedBlock ?? 0)
+    this.sendJson(ws, message as unknown as Record<string, unknown>)
+  }
+
   private handleControlMessage(ws: WebSocket, raw: string): void {
     const result = this.parseControl(raw)
     if (!result.ok) {
@@ -135,6 +141,12 @@ export abstract class BaseSubscribeServer<TControl, TState> {
     if (!state) return
 
     this.clients.set(ws, this.applyControl(state, result.message))
+
+    // an unsubscribe is not acknowledged
+    if ((result.message as { action?: string }).action === 'unsubscribe') return
+    this.sendSubscribed(ws).catch((error) => {
+      this.logger.error(`[${this.constructor.name}] Error sending subscribed message:`, error)
+    })
   }
 
   protected sendJson(ws: WebSocket, payload: Record<string, unknown>, closeCodeOnFailure = 0): boolean {


### PR DESCRIPTION
Implements the server half of https://github.com/verana-labs/vs-agent/issues/574, specified in https://github.com/verana-labs/verana-spec/pull/52.

handleControlMessage now answers a processed subscribe with { "type": "subscribed", "block": latestProcessedBlock + 1 }, so a client knows when its subscription is actually active and can order its REST catch-up against it. Today it can only wait on its own socket write, which does not mean the server has flipped the filter, and a block landing in between is delivered by neither path.

The change is in BaseSubscribeServer, so both the indexer-events and verifiable-trust channels get it. An unsubscribe is not acknowledged, as per the spec.

Once this is out, vs-agent can wait on the acknowledgement instead of the send callback.